### PR TITLE
Randomize manually set tx_fee to be within +/- 20% of the given value

### DIFF
--- a/jmclient/jmclient/blockchaininterface.py
+++ b/jmclient/jmclient/blockchaininterface.py
@@ -191,7 +191,7 @@ class ElectrumWalletInterface(BlockchainInterface): #pragma: no cover
 
     def estimate_fee_per_kb(self, N):
         if super(ElectrumWalletInterface, self).fee_per_kb_has_been_manually_set(N):
-            return N
+            return int(random.uniform(N * float(0.8), N * float(1.2)))
         fee = self.wallet.network.synchronous_get(('blockchain.estimatefee', [N]
                                                   ))
         log.debug("Got fee: " + str(fee))
@@ -798,7 +798,7 @@ class BitcoinCoreInterface(BlockchainInterface):
 
     def estimate_fee_per_kb(self, N):
         if super(BitcoinCoreInterface, self).fee_per_kb_has_been_manually_set(N):
-            return N
+            return int(random.uniform(N * float(0.8), N * float(1.2)))
         estimate = int(Decimal(1e8) * Decimal(self.rpc('estimatefee', [N])))
         if (N == 1) and (estimate < 0):
             # Special bitcoin core case: sometimes the highest priority


### PR DESCRIPTION
If a manual tx_fee is supplied, randomize it by 20% to make on-chain analysis harder.
Tested on my setup.

Idea suggested by https://www.reddit.com/r/joinmarket/comments/6x5m41/advice_on_fees/

Some more discussion here (why/why not randomize automatic fees as well, etc.): #73 