### PR TITLE
Implement wallet history flag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ logs/
 miniircd/
 nums_basepoints.txt
 schedulefortesting
+scripts/commitmentlist

--- a/jmclient/jmclient/__init__.py
+++ b/jmclient/jmclient/__init__.py
@@ -19,8 +19,8 @@ from .taker import Taker
 from .wallet import (AbstractWallet, BitcoinCoreInterface, Wallet,
                      BitcoinCoreWallet, estimate_tx_fee, WalletError,
                      create_wallet_file, SegwitWallet, Bip39Wallet)
-from .configure import (load_program_config, jm_single, get_p2pk_vbyte,
-    get_network, jm_single, get_network, validate_address, get_irc_mchannels,
+from .configure import (load_program_config, get_p2pk_vbyte,
+    jm_single, get_network, validate_address, get_irc_mchannels,
     get_blockchain_interface_instance, get_p2sh_vbyte, set_config)
 from .blockchaininterface import (BlockchainInterface, sync_wallet,
                                   RegtestBitcoinCoreInterface, BitcoinCoreInterface)


### PR DESCRIPTION
## Description

https://github.com/JoinMarket-Org/joinmarket-clientserver/issues/68

## Why Change?

`python wallet-tool.py default.json history` is a very useful command and the only way that I know of to examine one's wallet transaction history.

## Implementation

Mostly copy-pasted from the [previous, pre-SegWit JM release](https://github.com/JoinMarket-Org/joinmarket/blob/8c2b6d83dfddb85451d185e64f0fe4df62d5c54e/wallet-tool.py#L390).

## Questions

* Should we add tests for this behavior?
* Should we have a module which contains the wallet utils at e.g. `jmclient/jmclient/wallet_utils` and including files e.g. `jmclient/jmclient/wallet_utils/__init__.py` and `jmclient/jmclient/wallet_utils/history.py` for the `wallet-tool.py default.json history` command?