### PR TITLE
Do not include 0/0 our_inputs/our_outputs transactions in wallet history

### DIFF
--- a/jmclient/jmclient/wallet_utils.py
+++ b/jmclient/jmclient/wallet_utils.py
@@ -635,8 +635,7 @@ def wallet_fetch_history(wallet, options):
             mixdepth_dst = wallet_addr_cache[cj_addr][0]
         else:
             tx_type = 'unknown type'
-            # Uncomment the following line to print the inputs/outputs count when debugging
-            # print('our-inputs = ' + str(len(our_input_addrs)) + ' our-outputs = ' + str(len(our_output_addrs)))
+            print('our-inputs = ' + str(len(our_input_addrs)) + ' our-outputs = ' + str(len(our_output_addrs)))
         balance += delta_balance
         utxo_count += (len(our_output_addrs) - utxos_consumed)
         index = '% 4d'%(i)

--- a/jmclient/jmclient/wallet_utils.py
+++ b/jmclient/jmclient/wallet_utils.py
@@ -594,20 +594,21 @@ def wallet_fetch_history(wallet, options):
                     our_output_addrs)
             if len(mixdepth_dst) == 1:
                 mixdepth_dst = mixdepth_dst[0]
+        elif len(our_input_addrs) == 0 and len(our_output_addrs) == 0: continue
         elif len(our_input_addrs) > 0 and len(our_output_addrs) == 0:
-            #we swept coins elsewhere
+            # we swept coins elsewhere
             if is_coinjoin:
                 tx_type = 'cj sweepout'
                 amount = cj_amount
                 fees = our_input_value - cj_amount
             else:
-                tx_type = 'sweep out  '
+                tx_type = 'sweepout'
                 amount = sum([v for v in output_addr_values.values()])
                 fees = our_input_value - amount
             delta_balance = -our_input_value
             mixdepth_src = wallet_addr_cache[list(our_input_addrs)[0]][0]
         elif len(our_input_addrs) > 0 and len(our_output_addrs) == 1:
-            #payment out somewhere with our change address getting the remaining
+            # payment out somewhere with our change address getting the remaining
             change_value = output_addr_values[list(our_output_addrs)[0]]
             if is_coinjoin:
                 tx_type = 'cj withdraw'
@@ -621,7 +622,7 @@ def wallet_fetch_history(wallet, options):
             fees = our_input_value - change_value - cj_amount
             mixdepth_src = wallet_addr_cache[list(our_input_addrs)[0]][0]
         elif len(our_input_addrs) > 0 and len(our_output_addrs) == 2:
-            #payment to self
+            # payment to self
             out_value = sum([output_addr_values[a] for a in our_output_addrs])
             if not is_coinjoin:
                 print('this is wrong TODO handle non-coinjoin internal')
@@ -634,7 +635,8 @@ def wallet_fetch_history(wallet, options):
             mixdepth_dst = wallet_addr_cache[cj_addr][0]
         else:
             tx_type = 'unknown type'
-            print('our-inputs = ' + str(len(our_input_addrs)) + ' our-outputs = ' + str(len(our_output_addrs)))
+            # Uncomment the following line to print the inputs/outputs count when debugging
+            # print('our-inputs = ' + str(len(our_input_addrs)) + ' our-outputs = ' + str(len(our_output_addrs)))
         balance += delta_balance
         utxo_count += (len(our_output_addrs) - utxos_consumed)
         index = '% 4d'%(i)

--- a/jmclient/jmclient/wallet_utils.py
+++ b/jmclient/jmclient/wallet_utils.py
@@ -569,6 +569,7 @@ def wallet_fetch_history(wallet, options):
         rpc_input_addrs = set((btc.script_to_address(ind['script'],
             get_p2sh_vbyte()) for ind in rpc_inputs))
         our_input_addrs = wallet_addr_set.intersection(rpc_input_addrs)
+        print('our-inputs = ' + str(len(our_input_addrs)) + ' our-outputs = ' + str(len(our_output_addrs)))
         our_input_values = [ind['value'] for ind in rpc_inputs if btc.
                 script_to_address(ind['script'], get_p2sh_vbyte()) in
                 our_input_addrs]

--- a/jmclient/jmclient/wallet_utils.py
+++ b/jmclient/jmclient/wallet_utils.py
@@ -217,7 +217,7 @@ class WalletViewBranch(WalletViewBase):
         if self.forchange == -1:
             start = "Imported keys"
         return self.serclass(self.separator.join([start, bippath, self.xpub]))
-        
+
 class WalletViewAccount(WalletViewBase):
     def __init__(self, bip32path, account, branches=None, account_name="mixdepth",
                  serclass=str, custom_separator=None, xpub=None):
@@ -495,9 +495,10 @@ def wallet_fetch_history(wallet, options):
     tx_db = con.cursor()
     tx_db.execute("CREATE TABLE transactions(txid TEXT, "
             "blockhash TEXT, blocktime INTEGER);")
-    jm_single().debug_silence[0] = True
+    jm_single().debug_silence[0] = False
     wallet_name = jm_single().bc_interface.get_wallet_name(wallet)
     for wn in [wallet_name, ""]:
+        print(wn)
         buf = range(1000)
         t = 0
         while len(buf) == 1000:
@@ -826,6 +827,8 @@ def wallet_tool_main(wallet_root_path):
                     'blockchain interface')
             sys.exit(0)
         else:
+            print(wallet)
+            print(options)
             return wallet_fetch_history(wallet, options)
     elif method == "generate":
         retval = wallet_generate_recover("generate", wallet_root_path)

--- a/jmclient/jmclient/wallet_utils.py
+++ b/jmclient/jmclient/wallet_utils.py
@@ -570,7 +570,6 @@ def wallet_fetch_history(wallet, options):
         rpc_input_addrs = set((btc.script_to_address(ind['script'],
             get_p2sh_vbyte()) for ind in rpc_inputs))
         our_input_addrs = wallet_addr_set.intersection(rpc_input_addrs)
-        print('our-inputs = ' + str(len(our_input_addrs)) + ' our-outputs = ' + str(len(our_output_addrs)))
         our_input_values = [ind['value'] for ind in rpc_inputs if btc.
                 script_to_address(ind['script'], get_p2sh_vbyte()) in
                 our_input_addrs]
@@ -635,6 +634,7 @@ def wallet_fetch_history(wallet, options):
             mixdepth_dst = wallet_addr_cache[cj_addr][0]
         else:
             tx_type = 'unknown type'
+            print('our-inputs = ' + str(len(our_input_addrs)) + ' our-outputs = ' + str(len(our_output_addrs)))
         balance += delta_balance
         utxo_count += (len(our_output_addrs) - utxos_consumed)
         index = '% 4d'%(i)


### PR DESCRIPTION
## Description

See https://github.com/JoinMarket-Org/joinmarket-clientserver/issues/83.

## Implementation

When iterating over the list of a wallet's historical transactions (as returned by [this blockchain query](https://github.com/mecampbellsoup/joinmarket-clientserver/blob/cfb1a31bad3a1153eecb2bf2fa0d750786f2eb18/jmclient/jmclient/wallet_utils.py#L505-L506) which may pull in more transactions than it should), we add this conditional to skip 0/0 inputs/outputs transactions:

```python
elif len(our-inputs) == 0 and len(our-outputs) == 0: continue
```