### PR TITLE
fix yieldgenerator daemon always listening on all interfaces

### DIFF
--- a/jmclient/jmclient/client_protocol.py
+++ b/jmclient/jmclient/client_protocol.py
@@ -487,9 +487,10 @@ def start_reactor(host, port, factory, ish=True, daemon=False, rs=True, gui=Fals
                 if usessl:
                     reactor.listenSSL(port, dfactory,
                                   ssl.DefaultOpenSSLContextFactory(
-                                      "./ssl/key.pem", "./ssl/cert.pem"))
+                                      "./ssl/key.pem", "./ssl/cert.pem"),
+                                     interface=host)
                 else:
-                    reactor.listenTCP(port, dfactory)
+                    reactor.listenTCP(port, dfactory, interface=host)
                 jlog.info("Listening on port " + str(port))
                 break
             except Exception:


### PR DESCRIPTION
joinmarketd started by yieldgenerator (and possibly other methods, too?) will always listen on all interfaces. This fix makes joinmarketd listen only on the specified interface, which seems the intended and security-wise most sane handling.