### PR TITLE
fix coveralls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ before_install:
   - sudo apt-get update -q
   - sudo apt-get install --no-install-recommends --no-upgrade -qq bitcoind
 install:
-  - ./install.sh
+  - ./install.sh --develop
 before_script:
   - source jmvenv/bin/activate
 script:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,9 +1,9 @@
 # matplotlib
 # numpy
 pexpect
-coverage==4.2
-pytest==3.0.5
-pytest-cov==2.4.0
+coverage
+pytest
+pytest-cov
 python-coveralls
 mock
 


### PR DESCRIPTION
This fixes the issue with coverage reporting being broken on travis (and thus coveralls not working).

Unrelated to that it also removes version pinning of dev packages.