### PR TITLE
Use 'kill' instead of 'pkill' in run_tests.sh

### DIFF
--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -49,7 +49,7 @@ run_jm_tests ()
     local success="$?"
     unlink ./joinmarket.cfg
     if read bitcoind_pid <"${jm_test_datadir}/bitcoind.pid"; then
-        pkill -15 ${bitcoind_pid} || pkill -9 ${bitcoind_pid}
+        kill -15 ${bitcoind_pid} || kill -9 ${bitcoind_pid}
     fi
     rm -rf "${jm_test_datadir}"
     return ${success:-1}


### PR DESCRIPTION
In `run_tests.sh` there is a line that's supposed to catch any leftover running `bitcoind` processes and terminate them.  It seems that I've made a typo (twice!) and used `pkill` instead of `kill`.
`kill` is correct because we are reading the PID from the `bitcoind.pid` file.  `pkill` will (hopefully :) ) always fail to kill a process which the same **name** as bitcoind's PID.

This PR fixes the mistake.