### PR TITLE
Simple osx build on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,26 @@
 sudo: required
+os:
+  - linux
+  - osx
 dist: trusty
-language: python
-python:
-  - "2.7_with_system_site_packages"
+addons:
+  apt:
+    sources:
+    - sourceline: 'ppa:bitcoin/bitcoin'
+      key_url: 'http://keyserver.ubuntu.com:11371/pks/lookup?op=get&search=0xD46F45428842CE5E'
+    packages:
+      - bitcoind
 before_install:
-  - sudo apt-add-repository ppa:bitcoin/bitcoin -y
-  - sudo apt-get update -q
-  - sudo apt-get install --no-install-recommends --no-upgrade -qq bitcoind
+  - do_on(){ if [ "$TRAVIS_OS_NAME" = "$1" ]; then shift; $@ ; fi; }
 install:
   - ./install.sh --develop --no-gpg-validation
 before_script:
   - source jmvenv/bin/activate
 script:
-  - ./test/run_tests.sh
+  - do_on linux bitcoind --help | head -1
+  - do_on linux ./test/run_tests.sh
 after_success:
-  - coveralls
+  - do_on linux coveralls
 branches:
  only:
   - master


### PR DESCRIPTION
This PR enables travis building of jm-cs on osx.  Tests are not being run yet as there's some issues with those.

* Rearranging `.travis.yml` for cleaner inclusion of more osx specific commands later
* Fixup in `run_tests.sh` to support tar unpacking `miniircd` on osx
* A bit more debug info in travis logs when tests fail
* #116 included (since it's trivial and was useful in testing this)