### PR TITLE
Add support for taker using a non-segwit wallet

### DIFF
--- a/jmclient/jmclient/taker.py
+++ b/jmclient/jmclient/taker.py
@@ -303,8 +303,7 @@ class Taker(object):
             #Construct the Bitcoin address for the auth_pub field
             #Ensure that at least one address from utxos corresponds.
             input_addresses = [d['address'] for d in utxo_data]
-            auth_address = btc.pubkey_to_p2sh_p2wpkh_address(auth_pub,
-                                                             get_p2sh_vbyte())
+            auth_address = self.wallet.pubkey_to_address(auth_pub)
             if not auth_address in input_addresses:
                 jlog.warn("ERROR maker's (" + nick + ")"
                          " authorising pubkey is not included "
@@ -479,7 +478,6 @@ class Taker(object):
             else:
                 jlog.debug("Invalid signature message - more than 3 items")
                 break
-            print("Got sig_deserialized: ", sig_deserialized)
             ver_amt = utxo_data[i]['value'] if wit else None
             sig_good = btc.verify_tx_input(txhex, u[0], utxo_data[i]['script'],
                                                ver_sig, ver_pub, witness=wit,

--- a/jmclient/jmclient/taker.py
+++ b/jmclient/jmclient/taker.py
@@ -175,9 +175,11 @@ class Taker(object):
         if sweep:
             self.orderbook = orderbook #offers choosing deferred to next step
         else:
+            allowed_types = ["reloffer", "absoffer"] if jm_single().config.get(
+                "POLICY", "segwit") == "false" else ["swreloffer", "swabsoffer"]
             self.orderbook, self.total_cj_fee = choose_orders(
                 orderbook, self.cjamount, self.n_counterparties, self.order_chooser,
-                self.ignored_makers)
+                self.ignored_makers, allowed_types=allowed_types)
             if self.orderbook is None:
                 #Failure to get an orderbook means order selection failed
                 #for some reason; no action is taken, we let the stallMonitor
@@ -246,10 +248,12 @@ class Taker(object):
             self.total_txfee = max([estimated_fee,
                                     self.n_counterparties * self.txfee_default])
             total_value = sum([va['value'] for va in self.input_utxos.values()])
+            allowed_types = ["reloffer", "absoffer"] if jm_single().config.get(
+                "POLICY", "segwit") == "false" else ["swreloffer", "swabsoffer"]
             self.orderbook, self.cjamount, self.total_cj_fee = choose_sweep_orders(
                 self.orderbook, total_value, self.total_txfee,
                 self.n_counterparties, self.order_chooser,
-                self.ignored_makers)
+                self.ignored_makers, allowed_types=allowed_types)
             if not self.orderbook:
                 self.taker_info_callback("ABORT",
                                 "Could not find orders to complete transaction")

--- a/jmclient/test/test_taker.py
+++ b/jmclient/test/test_taker.py
@@ -10,8 +10,8 @@ import pytest
 import json
 from base64 import b64encode
 from jmclient import (load_program_config, jm_single, set_commitment_file,
-                      get_commitment_file, AbstractWallet, Taker,
-                      get_p2sh_vbyte)
+                      get_commitment_file, AbstractWallet, Taker, SegwitWallet,
+                      get_p2sh_vbyte, get_p2pk_vbyte)
 from taker_test_data import (t_utxos_by_mixdepth, t_selected_utxos, t_orderbook,
                              t_maker_response, t_chosen_orders, t_dummy_ext)
 
@@ -52,8 +52,9 @@ class DummyWallet(AbstractWallet):
         """
         return 'p2sh-p2wpkh'
 
-    def get_vbyte(self):
-        return get_p2sh_vbyte()
+    @classmethod
+    def pubkey_to_address(cls, pubkey):
+        return SegwitWallet.pubkey_to_address(pubkey)
 
     def get_key_from_addr(self, addr):
         """usable addresses: privkey all 1s, 2s, 3s, ... :"""

--- a/jmclient/test/test_wallets.py
+++ b/jmclient/test/test_wallets.py
@@ -14,7 +14,7 @@ from mnemonic import Mnemonic
 from ConfigParser import SafeConfigParser, NoSectionError
 from decimal import Decimal
 from commontest import (interact, make_wallets,
-                        make_sign_and_push, DummyBlockchainInterface)
+                        make_sign_and_push)
 import json
 
 import jmbitcoin as bitcoin

--- a/scripts/joinmarket-qt.py
+++ b/scripts/joinmarket-qt.py
@@ -1577,6 +1577,15 @@ except Exception as e:
              ])
     JMQtMessageBox(None, config_load_error, mbtype='crit', title='failed to load')
     exit(1)
+#refuse to load non-segwit wallet (needs extra work in wallet-utils).
+if not jm_single().config.get("POLICY", "segwit") == "true":
+    wallet_load_error = ''.join(["Joinmarket-Qt only supports segwit based wallets, ",
+                                 "please edit the config file and remove any setting ",
+                                 "of the field `segwit` in the `POLICY` section."])
+    JMQtMessageBox(None, wallet_load_error, mbtype='crit',
+                   title='Incompatible wallet type')
+    exit(1)
+
 update_config_for_gui()
 
 #to allow testing of confirm/unconfirm callback for multiple txs

--- a/scripts/sendtomany.py
+++ b/scripts/sendtomany.py
@@ -103,6 +103,9 @@ def main():
         if not validate_address(d):
             quit(parser, "Address was not valid; wrong network?: " + d)
     txsigned = sign(u, priv, destaddrs, segwit = not options.nonsegwit)
+    if not txsigned:
+        log.info("Transaction signing operation failed, see debug messages for details.")
+        return
     log.debug("Got signed transaction:\n" + txsigned)
     log.debug("Deserialized:")
     log.debug(pformat(btc.deserialize(txsigned)))

--- a/scripts/tumbler.py
+++ b/scripts/tumbler.py
@@ -15,7 +15,7 @@ from twisted.python.log import startLogging
 from jmclient import (Taker, load_program_config, get_schedule,
                       weighted_order_choose, JMClientProtocolFactory,
                       start_reactor, validate_address, jm_single, WalletError,
-                      Wallet, SegwitWallet, sync_wallet, get_tumble_schedule,
+                      get_wallet_cls, sync_wallet, get_tumble_schedule,
                       RegtestBitcoinCoreInterface, estimate_tx_fee,
                       tweak_tumble_schedule, human_readable_schedule_entry,
                       schedule_to_text, restart_waiter, get_tumble_log,
@@ -40,7 +40,7 @@ def main():
     wallet_name = args[0]
     max_mix_depth = options['mixdepthsrc'] + options['mixdepthcount']
     if not os.path.exists(os.path.join('wallets', wallet_name)):
-        wallet = SegwitWallet(wallet_name, None, max_mix_depth)
+        wallet = get_wallet_cls()(wallet_name, None, max_mix_depth)
     else:
         while True:
             try:

--- a/test/common.py
+++ b/test/common.py
@@ -12,7 +12,7 @@ from decimal import Decimal
 data_dir = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
 sys.path.insert(0, os.path.join(data_dir))
 
-from jmclient import SegwitWallet, Wallet, get_log, estimate_tx_fee, jm_single
+from jmclient import get_wallet_cls, get_log, estimate_tx_fee, jm_single
 import jmbitcoin as btc
 from jmbase import chunks
 
@@ -63,7 +63,7 @@ def make_wallets(n,
                  fixed_seeds=None,
                  test_wallet=False,
                  passwords=None,
-                 walletclass=SegwitWallet):
+                 walletclass=None):
     '''n: number of wallets to be created
        wallet_structure: array of n arrays , each subarray
        specifying the number of addresses to be populated with coins
@@ -85,7 +85,11 @@ def make_wallets(n,
         if test_wallet:
             w = TestWallet(seeds[i], max_mix_depth=5, pwd=passwords[i])
         else:
-            w = walletclass(seeds[i], pwd=None, max_mix_depth=5)
+            if walletclass:
+                wc = walletclass
+            else:
+                wc = get_wallet_cls()
+            w = wc(seeds[i], pwd=None, max_mix_depth=5)
         wallets[i + start_index] = {'seed': seeds[i],
                                     'wallet': w}
         for j in range(5):


### PR DESCRIPTION
As for maker, to use this feature set segwit = false
in the POLICY section of the config file.
This commit does *not* include support in the GUI.

Not much more to add apart from the above commit message. Let me know if you see anything while trying this out on regtest with any non-segwit wallet. I've tested sendpayment and tumbler, although not really exhaustively. I will try some other less-used modes before merging it.