### PR TITLE
fix test_configure for new jsonrpc

### DIFF
--- a/jmclient/test/test_configure.py
+++ b/jmclient/test/test_configure.py
@@ -27,9 +27,9 @@ def test_load_config():
     jm_single().config_location = "joinmarket.cfg"
     #TODO hack: load from default implies a connection error unless
     #actually mainnet, but tests cannot; for now catch the connection error
-    with pytest.raises(JsonRpcConnectionError) as e_info:
+    with pytest.raises(Exception) as e_info:
         load_program_config(config_path=ncp, bs="regtest")
-    assert str(e_info.value) in ["authentication for JSON-RPC failed",
+    assert str(e_info.value) in ["[Errno 111] Connection refused", "authentication for JSON-RPC failed",
                                  "JSON-RPC connection failed. Err:error(111, 'Connection refused')"]
     os.remove("dummydirforconfig/joinmarket.cfg")
     os.removedirs("dummydirforconfig")


### PR DESCRIPTION
Fixes #147 

The change in #140 meant a different Exception type was being thrown.

Code is still very hacky, but it's not super important (just a test of a harmless feature of the code).