### PR TITLE
More clear description of sendpayment -P option

### DIFF
--- a/scripts/cli_options.py
+++ b/scripts/cli_options.py
@@ -241,7 +241,7 @@ def get_sendpayment_parser():
         dest='pickorders',
         default=False,
         help=
-        'manually pick which orders to take. doesn\'t work while sweeping.')
+        'interactively pick which orders to take. doesn\'t work while sweeping.')
     parser.add_option('-m',
                       '--mixdepth',
                       action='store',


### PR DESCRIPTION
I think "manually" was disambiguous, as it could mean two things - either you will need to choose orders interactively or you must somehow specify counterparties as command-line options or something. This is more clear.