### PR TITLE
fix SIGHASH_SINGLE signing in segwit

### DIFF
--- a/jmbitcoin/jmbitcoin/secp256k1_transaction.py
+++ b/jmbitcoin/jmbitcoin/secp256k1_transaction.py
@@ -2,7 +2,6 @@
 import binascii, re, json, copy, sys
 from jmbitcoin.secp256k1_main import *
 from _functools import reduce
-import os
 
 is_python2 = sys.version_info.major == 2
 
@@ -200,7 +199,7 @@ def segwit_signature_form(txobj, i, script, amount, hashcode=SIGHASH_ALL):
         hashPrevouts = bin_dbl_sha256(pi)
     #create hashSequence
     if not hashcode & SIGHASH_ANYONECANPAY and not (
-        hashcode & 0x1f == SIGHASH_NONE) and not (hashcode & 0x1f == SIGHASH_NONE):
+        hashcode & 0x1f == SIGHASH_SINGLE) and not (hashcode & 0x1f == SIGHASH_NONE):
         pi = ""
         for inp in txobj["ins"]:
             pi += encode(inp["sequence"], 256, 4)[::-1]
@@ -221,12 +220,10 @@ def segwit_signature_form(txobj, i, script, amount, hashcode=SIGHASH_ALL):
             pi += (num_to_var_int(len(binascii.unhexlify(out["script"]))) + \
                    binascii.unhexlify(out["script"]))
         hashOutputs = bin_dbl_sha256(pi)
-    elif hashcode & 0x1f == SIGHASH_SINGLE:
-        pi = ""
-        if i < len(txobj['outs']):
-            pi += encode(txobj["outs"][i]["value"], 256, 8)[::-1]
-            pi += (num_to_var_int(len(binascii.unhexlify(txobj["outs"][i][
-                "script"]))) + binascii.unhexlify(txobj["outs"][i]["script"]))
+    elif hashcode & 0x1f == SIGHASH_SINGLE and i < len(txobj['outs']):
+        pi = encode(txobj["outs"][i]["value"], 256, 8)[::-1]
+        pi += (num_to_var_int(len(binascii.unhexlify(txobj["outs"][i]["script"]))) +
+               binascii.unhexlify(txobj["outs"][i]["script"]))
         hashOutputs = bin_dbl_sha256(pi)
     else:
         hashOutputs = "\x00"*32


### PR DESCRIPTION
Fix signing SIGHASH_SINGLE transaction in segwit mode. Currently created signatures are invalid.

Tests do not cover extensive segwit signing because `jmclient/test/test_tx_creation.py` only tests non-segwit signing code.

Impact to joinmarket as a whole is negligible because SIGHASH_SINGLE is not used.