### PR TITLE
Allow Takers to restart with honest makers

### DIFF
--- a/jmclient/jmclient/taker_utils.py
+++ b/jmclient/jmclient/taker_utils.py
@@ -159,6 +159,16 @@ def unconf_update(taker, schedulefile, tumble_log, addtolog=False):
     #is sufficient
     taker.wallet.update_cache_index()
 
+    #If honest-only was set, and we are going to continue (e.g. Tumbler),
+    #we switch off the honest-only filter. We also wipe the honest maker
+    #list, because the intention is to isolate the source of liquidity
+    #to exactly those that participated, in 1 transaction (i.e. it's a 1
+    #transaction feature). This code is here because it *must* be called
+    #before any continuation, even if confirm_callback happens before
+    #unconfirm_callback
+    taker.set_honest_only(False)
+    taker.honest_makers = []
+
     #We persist the fact that the transaction is complete to the
     #schedule file. Note that if a tweak to the schedule occurred,
     #it only affects future (non-complete) transactions, so the final
@@ -227,20 +237,53 @@ def tumbler_taker_finished_update(taker, schedulefile, tumble_log, options,
             taker.wallet.remove_old_utxos(txd)
             taker.wallet.add_new_utxos(txd, txid)
         else:
-            #a transaction failed; tumbler is aggressive in trying to
-            #complete; we tweak the schedule from this point in the mixdepth,
-            #then try again:
-            tumble_log.info("Transaction attempt failed, tweaking schedule"
-                            " and trying again.")
-            tumble_log.info("The paramaters of the failed attempt: ")
-            tumble_log.info(str(taker.schedule[taker.schedule_index]))
+            #a transaction failed, either because insufficient makers
+            #(acording to minimum_makers) responded in Stage 1, or not all
+            #makers responded in Stage 2. We'll first try to repeat without the
+            #troublemakers.
+            #Note that Taker.nonrespondants is always set to the full maker
+            #list at the start of Taker.receive_utxos, so it is always updated
+            #to a new list in each tx run.
             log.info("Schedule entry: " + str(
                 taker.schedule[taker.schedule_index]) + \
                      " failed after timeout, trying again")
-            taker.schedule_index -= 1
-            taker.schedule = tweak_tumble_schedule(options, taker.schedule,
-                                                   taker.schedule_index,
-                                                   taker.tdestaddrs)
+            taker.add_ignored_makers(taker.nonrespondants)
+            #Now we have to set the specific group we want to use, and hopefully
+            #they will respond again as they showed honesty last time.
+            taker.add_honest_makers(list(set(
+                taker.maker_utxo_data.keys()).symmetric_difference(
+                    set(taker.nonrespondants))))
+            #If no makers were honest, we can only tweak the schedule.
+            #If some were, we prefer the restart with them only:
+            if len(taker.honest_makers) != 0:
+                tumble_log.info("Transaction attempt failed, attempting to "
+                                "restart with subset.")
+                tumble_log.info("The paramaters of the failed attempt: ")
+                tumble_log.info(str(taker.schedule[taker.schedule_index]))
+                #we must reset the number of counterparties, as well as fix who they
+                #are; this is because the number is used to e.g. calculate fees.
+                #cleanest way is to reset the number in the schedule before restart.
+                taker.schedule[taker.schedule_index][2] = len(taker.honest_makers)
+                retry_str = "Retrying with: " + str(taker.schedule[
+                    taker.schedule_index][2]) + " counterparties."
+                tumble_log.info(retry_str)
+                log.info(retry_str)
+                taker.set_honest_only(True)
+                taker.schedule_index -= 1
+
+            #a tumbler is aggressive in trying to complete; we tweak the schedule
+            #from this point in the mixdepth, then try again. However we only
+            #try this strategy if the previous (select-honest-only) strategy
+            #failed.
+            else:
+                tumble_log.info("Transaction attempt failed, tweaking schedule"
+                                " and trying again.")
+                tumble_log.info("The paramaters of the failed attempt: ")
+                tumble_log.info(str(taker.schedule[taker.schedule_index]))
+                taker.schedule_index -= 1
+                taker.schedule = tweak_tumble_schedule(options, taker.schedule,
+                                                       taker.schedule_index,
+                                                       taker.tdestaddrs)
             tumble_log.info("We tweaked the schedule, the new schedule is:")
             tumble_log.info(pprint.pformat(taker.schedule))
     else:

--- a/scripts/sendpayment.py
+++ b/scripts/sendpayment.py
@@ -188,8 +188,35 @@ def main():
                 reactor.callLater(waittime*60,
                                   clientfactory.getClient().clientStart)
             else:
-                #a transaction failed; just stop
-                reactor.stop()
+                #a transaction failed; we'll try to repeat without the
+                #troublemakers
+                #Note that Taker.nonrespondants is always set to the full maker
+                #list at the start of Taker.receive_utxos, so it is always updated
+                #to a new list in each run.
+                print("We failed to complete the transaction. The following "
+                      "makers didn't respond: ", taker.nonrespondants,
+                      ", so we will retry without them.")
+                taker.add_ignored_makers(taker.nonrespondants)
+                #Now we have to set the specific group we want to use, and hopefully
+                #they will respond again as they showed honesty last time.
+                taker.add_honest_makers(list(set(
+                    taker.maker_utxo_data.keys()).symmetric_difference(
+                        set(taker.nonrespondants))))
+                if len(taker.honest_makers) == 0:
+                    log.info("None of the makers responded honestly; "
+                             "giving up this attempt.")
+                    reactor.stop()
+                    return
+                #we must reset the number of counterparties, as well as fix who they
+                #are; this is because the number is used to e.g. calculate fees.
+                #cleanest way is to reset the number in the schedule before restart.
+                taker.schedule[taker.schedule_index][2] = len(taker.honest_makers)
+                log.info("Retrying with: " + str(taker.schedule[
+                    taker.schedule_index][2]) + " counterparties.")
+                #rewind to try again (index is incremented in Taker.initialize())
+                taker.schedule_index -= 1
+                taker.set_honest_only(True)
+                reactor.callLater(5.0, clientfactory.getClient().clientStart)
         else:
             if not res:
                 log.info("Did not complete successfully, shutting down")


### PR DESCRIPTION
If N makers are chosen and M fail to respond with sig,
this alteration to taker code allows restart of
entire transaction with that specific subset of makers (N-M)
that originally responded honestly.

Still somewhat WIP, although functionality *appears* to be complete. Developers please review, test on regtest (use `test/ygrunner.py`) or you can try on mainnet, as I will this week (worst can happen is a failed tx or two, I believe!).

This should drastically improve completion rates.

I may add one or two commits to tweak things, but it'll be very minor from here.