### PR TITLE
Yield generator default fee adjustments

### DIFF
--- a/scripts/yg-privacyenhanced.py
+++ b/scripts/yg-privacyenhanced.py
@@ -15,10 +15,10 @@ from jmclient import (YieldGenerator, YieldGeneratorBasic, ygmain, get_log,
 """
 
 ordertype = 'swreloffer'  # [string, 'swreloffer' or 'swabsoffer'] / which fee type to actually use
-cjfee_a = 5000            # [satoshis, any integer] / absolute offer fee you wish to receive for coinjoins (cj)
-cjfee_r = '0.0002'        # [percent, any str between 0-1] / relative offer fee you wish to receive based on a cj's amount
+cjfee_a = 500             # [satoshis, any integer] / absolute offer fee you wish to receive for coinjoins (cj)
+cjfee_r = '0.00002'       # [percent, any str between 0-1] / relative offer fee you wish to receive based on a cj's amount
 cjfee_factor = 0.1        # [percent, 0-1] / variance around the average fee. Ex: 200 fee, 0.2 var = fee is btw 160-240
-txfee = 1000              # [satoshis, any integer] / the average transaction fee you're adding to coinjoin transactions
+txfee = 100               # [satoshis, any integer] / the average transaction fee you're adding to coinjoin transactions
 txfee_factor = 0.3        # [percent, 0-1] / variance around the average fee. Ex: 1000 fee, 0.2 var = fee is btw 800-1200
 minsize = 1000000         # [satoshis, any integer] / minimum size of your cj offer. Lower cj amounts will be disregarded
 size_factor = 0.1         # [percent, 0-1] / variance around all offer sizes. Ex: 500k minsize, 0.1 var = 450k-550k

--- a/scripts/yield-generator-basic.py
+++ b/scripts/yield-generator-basic.py
@@ -10,9 +10,9 @@ from jmclient import (YieldGenerator, YieldGeneratorBasic, ygmain, get_log,
 
 """THESE SETTINGS CAN SIMPLY BE EDITED BY HAND IN THIS FILE:
 """
-txfee = 1000
-cjfee_a = 200
-cjfee_r = '0.0002'
+txfee = 100
+cjfee_a = 500
+cjfee_r = '0.00002'
 ordertype = 'swreloffer' #'swreloffer' or 'swabsoffer'
 nickserv_password = ''
 max_minsize = 100000


### PR DESCRIPTION
This PR reduces the yield generator **default** coinjoin fee by one order of magnitude. It can, of course, still be overridden by the user.

Rationale: the current JM makers nearly all take very low fees ([see web-orderbook for reference](https://joinmarket.me/ob/)). New joinmarket-makers using the defaults see nearly no coinjoins due to their high fees (relatively speaking), which leaves them wondering if their bots work and also accidently reduces the default anonymity set of takers.
Defaults should work "out of the box", so that even without much expertise by new makers, it just works. This should help get closer to the goal.