### PR TITLE
add the wallets directory to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ nums_basepoints.txt
 schedulefortesting
 scripts/commitmentlist
 tmp/
+wallets/


### PR DESCRIPTION
Might be worth to add this in so e.g. `git clean -fdx` doesn't remove this directory
edit : Actually `-x` there will still remove `wallets/` , so this change only helps for `git clean -fd` which is good enough :)