### PR TITLE
Fixes the sweep maker selection issue (#171) by moving to approximate cjamount estimation

### DIFF
--- a/jmclient/jmclient/support.py
+++ b/jmclient/jmclient/support.py
@@ -233,6 +233,7 @@ def choose_orders(offers, cj_amount, n, chooseOrdersBy, ignored_makers=None,
     """
     feekey = lambda x: x[1]
     if not pick:
+        # filter to only the cheapest suitable offer for each maker
         orders_fees = sorted(
             dict((v[0]['counterparty'], v)
                  for v in sorted(orders_fees,
@@ -248,6 +249,7 @@ def choose_orders(offers, cj_amount, n, chooseOrdersBy, ignored_makers=None,
     for i in range(n):
         chosen_order, chosen_fee = chooseOrdersBy(orders_fees, n)
         # remove all orders from that same counterparty
+        # only needed if offers are manually picked
         orders_fees = [o
                        for o in orders_fees
                        if o[0]['counterparty'] != chosen_order['counterparty']]
@@ -305,6 +307,8 @@ def choose_sweep_orders(offers,
     #Filter ignored makers and inappropriate amounts
     offers = [o for o in offers if o['counterparty'] not in ignored_makers]
     offers = [o for o in offers if o['minsize'] < total_input_value]
+    # while we do not know the exact cj value yet, we can approximate a ceiling:
+    offers = [o for o in offers if o['maxsize'] > (total_input_value - total_txfee)]
 
     log.debug('orderlist = \n' + '\n'.join([str(o) for o in offers]))
     orders_fees = [(o, calc_cj_fee(o['ordertype'], o['cjfee'],
@@ -312,7 +316,13 @@ def choose_sweep_orders(offers,
 
     feekey = lambda x: x[1]
     # sort from smallest to biggest cj fee
-    orders_fees = sorted(orders_fees, key=feekey)
+    # filter to only the cheapest suitable offer for each maker
+    orders_fees = sorted(
+        dict((v[0]['counterparty'], v)
+             for v in sorted(orders_fees,
+                             key=feekey,
+                             reverse=True)).values(),
+        key=feekey)
     chosen_orders = []
     while len(chosen_orders) < n:
         for i in range(n - len(chosen_orders)):


### PR DESCRIPTION
This PR intends to fix #171, in which a maker can gain an unfair selection advantage by having multiple overlapping offers. This problem so far has been minor, since the weighting selection has made sure that the effects of this sweeping issue do not cause much trouble. Buf if #166 is merged, this would be a huge problem.

Changes:
- adds a max cjamount estimation to filter more offers first
- then sorts by fee and only allows one offer per maker **before** the actual selection algorithm chooses the offers to use

Upside:
- remove the unfair advantage of bad makers with multiple, overlapping offers
- ensures that the cheapest offer per maker is used for sweeps as well

Downside:
- as descriped also in [#356](https://github.com/JoinMarket-Org/joinmarket/issues/356), the exact cj amount is unknown at this point. So an offer might be selected, but when at a later time it turns out that the cjamount is a lot lower and the selected offer not suitable any more (e.g. due to very large cjfees or higher than estimated txfees).

Rationale:
I want to argue though that the Downside is not a big deal: most makers just have **one** offer nowadays --> so if one of these offers is chosen, it will be a big range anyways (offer-min-cjamount, offer-max-maxcjamount) and still extremely likely to be suitable to complete the sweep join. If not, the maker would not have been suitable to start with. Also txfees and cjfees are negligible within the last months, so the cjamount approximation should be very close the the true value.
So these edge cases are, imho, very very unlikely to occur. And if they do, the code just selects another maker instead.

In my opinion, this change as a whole is better than the status quo, as the downside is unlikely to occur and if it does, it will not make the join fail.