### PR TITLE
Fixes bugs in restart-with-subset including #169; see PR for more

### DIFF
--- a/jmclient/jmclient/client_protocol.py
+++ b/jmclient/jmclient/client_protocol.py
@@ -370,14 +370,20 @@ class JMTakerClientProtocol(JMClientProtocol):
     def on_JM_FILL_RESPONSE(self, success, ioauth_data):
         """Receives the entire set of phase 1 data (principally utxos)
         from the counterparties and passes through to the Taker for
-        tx construction, if successful. Then passes back the phase 2
-        initiating data to the daemon.
+        tx construction. If there were sufficient makers, data is passed
+        over for exactly those makers that responded. If not, the list
+        of non-responsive makers is added to the permanent "ignored_makers"
+        list, but the Taker processing is bypassed and the transaction
+        is abandoned here (so will be picked up as stalled in multi-join
+        schedules).
+        In the first of the above two cases, after the Taker processes
+        the ioauth data and returns the proposed
+        transaction, passes the phase 2 initiating data to the daemon.
         """
         ioauth_data = json.loads(ioauth_data)
         if not success:
-            nonresponders = ioauth_data
-            jlog.info("Makers didnt respond: " + str(nonresponders))
-            self.client.add_ignored_makers(nonresponders)
+            jlog.info("Makers who didnt respond: " + str(ioauth_data))
+            self.client.add_ignored_makers(ioauth_data)
             return {'accepted': True}
         else:
             jlog.info("Makers responded with: " + json.dumps(ioauth_data))

--- a/jmdaemon/jmdaemon/daemon_protocol.py
+++ b/jmdaemon/jmdaemon/daemon_protocol.py
@@ -632,7 +632,8 @@ class JMDaemonServerProtocol(amp.AMP, OrderbookWatch):
         """
         if nick in self.crypto_boxes and self.crypto_boxes[nick] != None:
             return self.crypto_boxes[nick][1]
-        elif nick in self.active_orders and self.active_orders[nick] != None:
+        elif nick in self.active_orders and self.active_orders[nick] != None \
+             and "crypto_box" in self.active_orders[nick]:
             return self.active_orders[nick]["crypto_box"]
         else:
             log.msg('something wrong, no crypto object, nick=' + nick +


### PR DESCRIPTION

Reproducing this list from #169 for convenience:

Start: request is for N counterparties
minimum maker setting = m

Pre-phase 1: set nonrespondants to all N

Phase 1: n responders. Remove them from nonrespondants (now contains N-n makers).
Case 1a: n < m: action: add nonrespondants to ignored_makers
Case 1a1: if sendpayment, stop (sendpayment is manual so they just try again)
Case 1a2: if tumbler, tweak the tumble schedule and try again
Case 1b: m <= n < N : action: add nonrespondants to ignored_makers and continue to phase 2.
Case 1c: m = N: same as 1b except nonrespondants is empty.

Pre-phase 2: set nonrespondants to n responders from Phase 1.

Phase 2: q responders. Remove them from nonrespondants (now contains n-q makers)
Case 2a: m <= q < n: action: add nonrespondants to ignored_makers. Set honest makers to q responders. Restart with honesty toggled on (i.e. request that specific set in restart).
Case 2b: q < m: action: add n-q nonresponders to ignored_makers
Case 2b1: if sendpayment, stop (as 1a1)
Case 2b2: if tumbler, tweak tumble schedule and try again
Case 2c: q = n: action: complete normally.

All of the above scenarios have been tested on regtest. I intend to push this out (since the existing code is simply wrong, and crashes, in a couple of edge cases, at least) today. I will do a few final sanity checks on mainnet.

So, the above "table" is the set of actions that's intended, but there are couple of imperfections that must be mentioned:

* #59 has not been addressed. This is not a disaster, but it means that if a sendpayment or tumble finds that it is able to complete Phase 1 (as above) with m <= n < N then the nonresponding makers are not added to the ignored_makers list, and are thus still selected again in future attempts. It basically slows down the "convergence" during a tumble run, to the honest set of makers.

* Rather more serious: in sendpayment, if q < n in Phase 2 (again using above notation), we actually wait for the stallmonitor to kick in before reviewing the state and deciding to give up. This isn't exactly the most useful behaviour, even if it isn't really wrong. The problem is that the stallMonitor wakes up only after 20*maker_timeout_sec, which by default is 20 minutes! The user will have given up by then, if they're sitting at the screen.