### PR TITLE
Switch default merge_algorithm in joinmarket.cfg to 'greedy'

### DIFF
--- a/jmclient/jmclient/configure.py
+++ b/jmclient/jmclient/configure.py
@@ -152,7 +152,7 @@ segwit = true
 # for more rapid dust sweeping, try merge_algorithm = greedy
 # for most rapid dust sweeping, try merge_algorithm = greediest
 # but don't forget to bump your miner fees!
-merge_algorithm = default
+merge_algorithm = greedy
 # the fee estimate is based on a projection of how many satoshis
 # per kB are needed to get in one of the next N blocks, N set here
 # as the value of 'tx_fees'. This estimate is high if you set N=1, 


### PR DESCRIPTION
To reduce UTXOs/dust collection/excessive tx fees.

Upsides:
- maker: less dust, not hundreds of little UTXOs after running a yield gen for a while
- taker: predictably less inputs when joining. With this merge algo, it should be very rare that one of the makers has 10+ UTXOs as input, which I saw sometimes happening on bigger amounts (just anecdotes though, not statistically significant)
- whole ecosystem: smaller UTXO set

Downsides:
- Unsure. Easier linkability in blockchain analysis?

This PR is meant as basis for discussion. It was just mentioned that changing this default maybe could be a good idea by @AdamISZ on IRC.