### PR TITLE
Add caching support for dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,9 @@ addons:
 matrix:
   include:
     - os: osx
+      env: PIP_DOWNLOAD_CACHE=$HOME/Library/Caches/pip
     - os: linux
+      env: PIP_DOWNLOAD_CACHE=$HOME/.cache/pip
     - os: linux
       services: docker
       env: DOCKER_IMG_JM=xenial
@@ -33,9 +35,15 @@ before_install:
   - on_docker(){ if [ -n "$DOCKER_IMG_JM" ]; then $@ ; fi; }
 cache:
   directories:
-    $HOME/downloads
+   - $HOME/downloads
+   - $HOME/.cache/pip
+   - $HOME/Library/Caches/pip
 install:
+  - mkdir -p "$HOME/downloads"
+  - mkdir -p "$TRAVIS_BUILD_DIR/deps/cache/"
+  - find "$HOME/downloads" -type f -exec cp -v {} "$TRAVIS_BUILD_DIR/deps/cache/" \;
   - on_host ./install.sh --develop --no-gpg-validation
+  - on_host find "$TRAVIS_BUILD_DIR/deps/cache/" -type f -exec cp -v {} "$HOME/downloads/" \;
 before_script:
   - on_host source jmvenv/bin/activate
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,19 @@
 sudo: required
 dist: trusty
-addons:
-  apt:
-    sources:
-    - sourceline: 'ppa:bitcoin/bitcoin'
-      key_url: 'http://keyserver.ubuntu.com:11371/pks/lookup?op=get&search=0xD46F45428842CE5E'
-    packages:
-      - bitcoind
-      - python-qt4 python-sip
 matrix:
   include:
     - os: osx
       env: PIP_DOWNLOAD_CACHE=$HOME/Library/Caches/pip
     - os: linux
       env: PIP_DOWNLOAD_CACHE=$HOME/.cache/pip
+      addons:
+        apt:
+           sources:
+           - sourceline: 'ppa:bitcoin/bitcoin'
+             key_url: 'http://keyserver.ubuntu.com:11371/pks/lookup?op=get&search=0xD46F45428842CE5E'
+           packages:
+             - bitcoind
+             - python-qt4 python-sip
     - os: linux
       services: docker
       env: DOCKER_IMG_JM=xenial

--- a/test/Dockerfiles/bionic.Dockerfile
+++ b/test/Dockerfiles/bionic.Dockerfile
@@ -26,8 +26,8 @@ USER chaum
 WORKDIR /home/chaum
 RUN ls -la .
 RUN ls -la ${repo_name}
-RUN ls -la ${repo_name}/deps
-RUN tar xaf ./${repo_name}/deps/${core_dist} -C /home/chaum
+RUN ls -la ${repo_name}/deps/cache
+RUN tar xaf ./${repo_name}/deps/cache/${core_dist} -C /home/chaum
 ENV PATH "/home/chaum/bitcoin-${core_version}/bin:${PATH}"
 RUN bitcoind --version | head -1
 

--- a/test/Dockerfiles/build_docker.sh
+++ b/test/Dockerfiles/build_docker.sh
@@ -18,16 +18,23 @@ build_docker ()
     core_version='0.16.1'
     core_dist="bitcoin-${core_version}-x86_64-linux-gnu.tar.gz"
     core_url="https://bitcoin.org/bin/bitcoin-core-${core_version}/${core_dist}"
+    libffi_lib_tar='v3.2.1.tar.gz'
+    libffi_url="https://github.com/libffi/libffi/archive/${libffi_lib_tar}"
+    sodium_lib_tar='libsodium-1.0.13.tar.gz'
+    sodium_url="https://download.libsodium.org/libsodium/releases/${sodium_lib_tar}"
+    declare -A deps=( [${core_dist}]="${core_url}" [${libffi_lib_tar}]="${libffi_url}" [${sodium_lib_tar}]="${sodium_url}" )
     jm_root="${TRAVIS_BUILD_DIR}"
     owner_name="${TRAVIS_REPO_SLUG%\/*}"
     repo_name="${TRAVIS_REPO_SLUG#*\/}"
 
-    if [[ ! -f "${HOME}/downloads/${core_dist}" ]]; then
-        wget "${core_url}" -O "$HOME/downloads/${core_dist}"
-    fi
+    for dep in ${!deps[@]}; do
+        if [[ ! -r "${HOME}/downloads/${dep}" ]]; then
+            curl --retry 5 -L "${deps[${dep}]}" -o "$HOME/downloads/${dep}"
+        fi
+    done
 
-    mkdir -p "${jm_root}/deps"
-    cp "${HOME}/downloads/${core_dist}" "${jm_root}/deps/"
+    mkdir -p "${jm_root}/deps/cache"
+    find "$HOME/downloads" -type f -exec cp -v {} "${jm_root}/deps/cache/" \;
     cd "${jm_root}/../"
 
     docker build \

--- a/test/Dockerfiles/centos7.Dockerfile
+++ b/test/Dockerfiles/centos7.Dockerfile
@@ -22,8 +22,8 @@ USER chaum
 WORKDIR /home/chaum
 RUN ls -la .
 RUN ls -la ${repo_name}
-RUN ls -la ${repo_name}/deps
-RUN tar xaf ./${repo_name}/deps/${core_dist} -C /home/chaum
+RUN ls -la ${repo_name}/deps/cache
+RUN tar xaf ./${repo_name}/deps/cache/${core_dist} -C /home/chaum
 ENV PATH "/home/chaum/bitcoin-${core_version}/bin:${PATH}"
 RUN bitcoind --version | head -1
 

--- a/test/Dockerfiles/fedora27.Dockerfile
+++ b/test/Dockerfiles/fedora27.Dockerfile
@@ -25,8 +25,8 @@ USER chaum
 WORKDIR /home/chaum
 RUN ls -la .
 RUN ls -la ${repo_name}
-RUN ls -la ${repo_name}/deps
-RUN tar xaf ./${repo_name}/deps/${core_dist} -C /home/chaum
+RUN ls -la ${repo_name}/deps/cache
+RUN tar xaf ./${repo_name}/deps/cache/${core_dist} -C /home/chaum
 ENV PATH "/home/chaum/bitcoin-${core_version}/bin:${PATH}"
 RUN bitcoind --version | head -1
 

--- a/test/Dockerfiles/stretch.Dockerfile
+++ b/test/Dockerfiles/stretch.Dockerfile
@@ -26,8 +26,8 @@ USER chaum
 WORKDIR /home/chaum
 RUN ls -la .
 RUN ls -la ${repo_name}
-RUN ls -la ${repo_name}/deps
-RUN tar xaf ./${repo_name}/deps/${core_dist} -C /home/chaum
+RUN ls -la ${repo_name}/deps/cache
+RUN tar xaf ./${repo_name}/deps/cache/${core_dist} -C /home/chaum
 ENV PATH "/home/chaum/bitcoin-${core_version}/bin:${PATH}"
 RUN bitcoind --version | head -1
 

--- a/test/Dockerfiles/xenial.Dockerfile
+++ b/test/Dockerfiles/xenial.Dockerfile
@@ -26,8 +26,8 @@ USER chaum
 WORKDIR /home/chaum
 RUN ls -la .
 RUN ls -la ${repo_name}
-RUN ls -la ${repo_name}/deps
-RUN tar xaf ./${repo_name}/deps/${core_dist} -C /home/chaum
+RUN ls -la ${repo_name}/deps/cache
+RUN tar xaf ./${repo_name}/deps/cache/${core_dist} -C /home/chaum
 ENV PATH "/home/chaum/bitcoin-${core_version}/bin:${PATH}"
 RUN bitcoind --version | head -1
 


### PR DESCRIPTION
This PR adds support for caching dependencies, both local (user install) and on travis.
- Library dependencies such as `libffi-3.2.1` and `libsodium-1.0.13` are now cached in `./deps/cache/` and will only be fetched if they are missing or if their hashes mismatch during the install process
- On travis native builds (Trusty and osx), `pip` dependencies are also cached by travis
- On travis dockers, library dependencies have been added to travis cache and are passed to the containers before building and testing starts
- On travis, downloading Bitcoin Core from Ubuntu PPA is now only done on Trusty