### PR TITLE
Install virtualenv on travis osx via pip

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,7 @@ before_install:
   - do_on(){ if [ "$TRAVIS_OS_NAME" = "$1" ]; then shift; $@ ; fi; }
   - on_host(){ if [ -z "$DOCKER_IMG_JM" ]; then $@ ; fi; }
   - on_docker(){ if [ -n "$DOCKER_IMG_JM" ]; then $@ ; fi; }
+  - do_on osx pip install virtualenv
 cache:
   directories:
    - $HOME/downloads


### PR DESCRIPTION
`virtualenv` seems to be missing from travis `osx` since this build :
https://travis-ci.org/JoinMarket-Org/joinmarket-clientserver/jobs/411886791#L81

Following https://docs.travis-ci.com/user/reference/osx#python-related-tools , added a 
```
pip install virtualenv
```
to `.travis.yml`, before `osx` install starts.