### PR TITLE
remove unused imports

### DIFF
--- a/jmbase/jmbase/commands.py
+++ b/jmbase/jmbase/commands.py
@@ -4,7 +4,7 @@ Commands defining client-server (daemon)
 messaging protocol (*not* Joinmarket p2p protocol).
 Used for AMP asynchronous messages.
 """
-from twisted.protocols.amp import Integer, String, Unicode, Boolean, Command
+from twisted.protocols.amp import Boolean, Command, Integer, String
 from bigstring import BigString
 
 class DaemonNotReady(Exception):

--- a/jmbase/jmbase/support.py
+++ b/jmbase/jmbase/support.py
@@ -4,7 +4,6 @@ import sys
 
 import logging
 import pprint
-import random
 from getpass import getpass
 
 logFormatter = logging.Formatter(

--- a/jmbase/test/test_base_support.py
+++ b/jmbase/test/test_base_support.py
@@ -1,7 +1,6 @@
 #! /usr/bin/env python
 from __future__ import print_function
-from jmbase.support import debug_dump_object, get_password, get_log, joinmarket_alert
-import pytest
+from jmbase.support import debug_dump_object, joinmarket_alert
 
 def test_debug_dump_object():
     joinmarket_alert[0] = "dummy jm alert"

--- a/jmbase/test/test_commands.py
+++ b/jmbase/test/test_commands.py
@@ -1,12 +1,9 @@
 #! /usr/bin/env python
 from __future__ import print_function
-from twisted.python.log import startLogging, err
-from twisted.python.log import msg as tmsg
 from twisted.internet import protocol, reactor
 from twisted.internet.error import (ConnectionLost, ConnectionAborted,
                                     ConnectionClosed, ConnectionDone)
 from twisted.protocols.amp import UnknownRemoteError
-from twisted.python import failure
 from twisted.protocols import amp
 from twisted.trial import unittest
 from twisted.internet import reactor, task
@@ -14,7 +11,6 @@ from twisted.internet import reactor, task
 from jmbase.commands import *
 
 import json
-import pytest
 
 test_completed = False
 

--- a/jmbitcoin/jmbitcoin/bci.py
+++ b/jmbitcoin/jmbitcoin/bci.py
@@ -1,7 +1,6 @@
 #!/usr/bin/python
 import json, re
 import random
-import sys
 import time
 import platform
 from jmbase.support import get_log

--- a/jmbitcoin/jmbitcoin/secp256k1_deterministic.py
+++ b/jmbitcoin/jmbitcoin/secp256k1_deterministic.py
@@ -1,7 +1,6 @@
 from jmbitcoin.secp256k1_main import *
 import hmac
 import hashlib
-from binascii import hexlify
 
 # Below code ASSUMES binary inputs and compressed pubkeys
 MAINNET_PRIVATE = b'\x04\x88\xAD\xE4'

--- a/jmbitcoin/jmbitcoin/secp256k1_main.py
+++ b/jmbitcoin/jmbitcoin/secp256k1_main.py
@@ -4,11 +4,7 @@ import binascii
 import hashlib
 import re
 import sys
-import os
 import base64
-import time
-import random
-import hmac
 import secp256k1
 
 #Required only for PoDLE calculation:

--- a/jmbitcoin/jmbitcoin/secp256k1_transaction.py
+++ b/jmbitcoin/jmbitcoin/secp256k1_transaction.py
@@ -1,5 +1,8 @@
 #!/usr/bin/python
-import binascii, re, json, copy, sys
+import binascii
+import copy
+import re
+import sys
 from jmbitcoin.secp256k1_main import *
 from jmbitcoin.bech32 import *
 from _functools import reduce

--- a/jmbitcoin/test/test_btc_formatting.py
+++ b/jmbitcoin/test/test_btc_formatting.py
@@ -5,7 +5,6 @@ from __future__ import absolute_import
 import jmbitcoin as btc
 import pytest
 import binascii
-import hashlib
 
 #used in p2sh addresses
 def test_hash160():

--- a/jmbitcoin/test/test_main.py
+++ b/jmbitcoin/test/test_main.py
@@ -5,7 +5,6 @@ from __future__ import absolute_import
 
 import jmbitcoin as btc
 import binascii
-import json
 import pytest
 import os
 testdir = os.path.dirname(os.path.realpath(__file__))

--- a/jmclient/jmclient/blockchaininterface.py
+++ b/jmclient/jmclient/blockchaininterface.py
@@ -164,7 +164,6 @@ class BlockchainInterface(object):
         the wallet. Call the callbacks and update the watcher loop state.
         End the loop when the confirmation has been seen (no spent monitoring here).
         """
-        pass
 
     @abc.abstractmethod
     def tx_watcher(self, txd, unconfirmfun, confirmfun, spentfun, c, n):
@@ -174,7 +173,6 @@ class BlockchainInterface(object):
         of confs = c.
         TODO: Deal with conflicts correctly. Here just abandons monitoring.
         """
-        pass
 
     @abc.abstractmethod
     def pushtx(self, txhex):
@@ -924,7 +922,6 @@ class RegtestBitcoinCoreInterface(BitcoinCoreInterface): #pragma: no cover
             log.debug(
                 "Failed to generate blocks, looks like the bitcoin daemon \
 	    has been shut down. Ignoring.")
-            pass
 
     def grab_coins(self, receiving_addr, amt=50):
         """

--- a/jmclient/jmclient/client_protocol.py
+++ b/jmclient/jmclient/client_protocol.py
@@ -6,7 +6,6 @@ from twisted.internet.error import (ConnectionLost, ConnectionAborted,
 from twisted.protocols import amp
 try:
     from twisted.internet.ssl import ClientContextFactory
-    from twisted.internet import ssl
 except ImportError:
     pass
 from jmbase import commands

--- a/jmclient/jmclient/commitment_utils.py
+++ b/jmclient/jmclient/commitment_utils.py
@@ -1,6 +1,6 @@
 from __future__ import print_function
 
-import sys, os
+import sys
 import jmclient.btc as btc
 from jmclient import jm_single, get_p2pk_vbyte, get_p2sh_vbyte
 

--- a/jmclient/jmclient/configure.py
+++ b/jmclient/jmclient/configure.py
@@ -5,7 +5,6 @@ import logging
 import threading
 import os
 import binascii
-import sys
 
 from ConfigParser import SafeConfigParser, NoOptionError
 

--- a/jmclient/jmclient/jsonrpc.py
+++ b/jmclient/jmclient/jsonrpc.py
@@ -46,7 +46,6 @@ class JsonRpcConnectionError(Exception):
   are wrong.
   """
 
-    pass
 
 
 class JsonRpc(object):

--- a/jmclient/jmclient/schedule.py
+++ b/jmclient/jmclient/schedule.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 from __future__ import print_function
 import copy
-from pprint import pformat
 from jmclient import (validate_address, rand_exp_array,
                       rand_norm_array, rand_pow_array, jm_single)
 """Utility functions for dealing with Taker schedules.

--- a/jmclient/jmclient/taker.py
+++ b/jmclient/jmclient/taker.py
@@ -7,7 +7,7 @@ import random
 from binascii import hexlify, unhexlify
 
 import btc
-from jmclient.configure import jm_single, get_p2pk_vbyte, get_p2sh_vbyte
+from jmclient.configure import get_p2sh_vbyte, jm_single
 from jmbase.support import get_log
 from jmclient.support import (calc_cj_fee, weighted_order_choose, choose_orders,
                               choose_sweep_orders)

--- a/jmclient/jmclient/taker_utils.py
+++ b/jmclient/jmclient/taker_utils.py
@@ -9,7 +9,7 @@ from binascii import hexlify, unhexlify
 from .configure import get_log, jm_single, validate_address
 from .schedule import human_readable_schedule_entry, tweak_tumble_schedule
 from .wallet import BaseWallet, estimate_tx_fee
-from .btc import mktx, serialize, deserialize, sign, txhash
+from .btc import deserialize, mktx, serialize, txhash
 log = get_log()
 
 """

--- a/jmclient/test/test_argon2.py
+++ b/jmclient/test/test_argon2.py
@@ -1,7 +1,6 @@
 from __future__ import print_function, absolute_import, division, unicode_literals
 
 from jmclient import Argon2Hash, get_random_bytes
-import pytest
 
 
 def test_argon2_sanity():

--- a/jmclient/test/test_blockchaininterface.py
+++ b/jmclient/test/test_blockchaininterface.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import, print_function
 """Blockchaininterface functionality tests."""
 
 import binascii
-from commontest import create_wallet_for_sync, make_sign_and_push
+from commontest import create_wallet_for_sync
 
 import pytest
 from jmclient import load_program_config, jm_single, sync_wallet, get_log

--- a/jmclient/test/test_client_protocol.py
+++ b/jmclient/test/test_client_protocol.py
@@ -2,24 +2,19 @@
 from __future__ import absolute_import
 '''test client-protocol interfacae.'''
 
-import pytest
 from jmclient import (get_schedule, load_program_config, start_reactor,
                       Taker, get_log, JMClientProtocolFactory, jm_single)
-from jmclient.client_protocol import JMProtocolError, JMTakerClientProtocol
-import os
-from twisted.python.log import startLogging, err
+from jmclient.client_protocol import JMTakerClientProtocol
 from twisted.python.log import msg as tmsg
 from twisted.internet import protocol, reactor, task
 from twisted.internet.error import (ConnectionLost, ConnectionAborted,
                                     ConnectionClosed, ConnectionDone)
 from twisted.protocols.amp import UnknownRemoteError
-from twisted.python import failure
 from twisted.protocols import amp
 from twisted.trial import unittest
 from jmbase.commands import *
 from taker_test_data import t_raw_signed_tx
 import json
-import time
 import jmbitcoin as bitcoin
 
 import twisted

--- a/jmclient/test/test_configure.py
+++ b/jmclient/test/test_configure.py
@@ -8,8 +8,6 @@ from jmclient import (load_program_config, jm_single, get_irc_mchannels,
                       JsonRpcConnectionError)
 from jmclient.configure import (get_config_irc_channel, get_p2sh_vbyte,
                                 get_p2pk_vbyte, get_blockchain_interface_instance)
-import jmbitcoin as bitcoin
-import copy
 import os
 
 def test_attribute_dict():

--- a/jmdaemon/jmdaemon/enc_wrapper.py
+++ b/jmdaemon/jmdaemon/enc_wrapper.py
@@ -8,8 +8,6 @@ from __future__ import absolute_import, print_function
 
 import binascii
 import base64
-import string
-import random
 
 
 from libnacl import public

--- a/jmdaemon/jmdaemon/irc.py
+++ b/jmdaemon/jmdaemon/irc.py
@@ -1,17 +1,10 @@
 from __future__ import absolute_import, print_function
 
-import base64
-import random
-import socket
-import ssl
 #TODO: SSL support (can it be done without back-end openssl?)
-import threading
-import time
 from twisted.internet import reactor, protocol
 from twisted.internet.endpoints import TCP4ClientEndpoint
 from twisted.application.internet import ClientService
 from twisted.internet.ssl import ClientContextFactory
-from twisted.logger import Logger
 from twisted.words.protocols import irc
 from twisted.internet.error import (ConnectionLost, ConnectionAborted,
                                     ConnectionClosed, ConnectionDone)

--- a/jmdaemon/jmdaemon/message_channel.py
+++ b/jmdaemon/jmdaemon/message_channel.py
@@ -1,6 +1,8 @@
 #! /usr/bin/env python
 from __future__ import print_function
-import base64, abc, threading, time
+import abc
+import base64
+import threading
 from jmdaemon import (
     encrypt_encode, decode_decrypt, COMMAND_PREFIX, ORDER_KEYS,
     NICK_HASH_LENGTH, NICK_MAX_ENCODED, JM_VERSION, JOINMARKET_NICK_HEADER,

--- a/jmdaemon/test/dummy_mc.py
+++ b/jmdaemon/test/dummy_mc.py
@@ -1,10 +1,5 @@
 from __future__ import absolute_import, print_function
 
-import base64
-import random
-import socket
-import ssl
-import threading
 import time
 
 
@@ -61,7 +56,6 @@ class DummyMessageChannel(MessageChannel):
     def _privmsg(self, nick, cmd, message):
         """As for pubmsg
         """
-        pass
     def _announce_orders(self, orderlist):
         pass
     def change_nick(self, new_nick):

--- a/jmdaemon/test/test_daemon_protocol.py
+++ b/jmdaemon/test/test_daemon_protocol.py
@@ -2,31 +2,25 @@
 from __future__ import absolute_import
 '''test daemon-protocol interfacae.'''
 
-import pytest
 from jmdaemon import (JMDaemonServerProtocolFactory, MessageChannelCollection)
 from jmdaemon.orderbookwatch import OrderbookWatch
 from jmdaemon.daemon_protocol import JMDaemonServerProtocol
 from jmdaemon.protocol import (COMMAND_PREFIX, ORDER_KEYS, NICK_HASH_LENGTH,
                        NICK_MAX_ENCODED, JM_VERSION, JOINMARKET_NICK_HEADER)
 from jmclient import (load_program_config, get_log, jm_single, get_irc_mchannels)
-import os
-from twisted.python.log import startLogging, err
 from twisted.python.log import msg as tmsg
 from twisted.internet import protocol, reactor, task
-from twisted.internet.protocol import ServerFactory, ClientCreator
+from twisted.internet.protocol import ServerFactory
 from twisted.internet.error import (ConnectionLost, ConnectionAborted,
                                     ConnectionClosed, ConnectionDone)
 from twisted.protocols.amp import UnknownRemoteError
-from twisted.python import failure
 from twisted.protocols import amp
 from twisted.trial import unittest
 from jmbase.commands import *
 from msgdata import *
 import json
-import time
 import base64
 from dummy_mc import DummyMessageChannel
-from test_message_channel import make_valid_nick
 test_completed = False
 end_early = False
 jlog = get_log()

--- a/scripts/joinmarketd.py
+++ b/scripts/joinmarketd.py
@@ -1,6 +1,6 @@
 import sys
-from twisted.internet import reactor, ssl
-from twisted.python.log import startLogging, err
+from twisted.internet import reactor
+from twisted.python.log import startLogging
 import jmdaemon
 
 def startup_joinmarketd(host, port, usessl, finalizer=None, finalizer_args=None):

--- a/scripts/qtsupport.py
+++ b/scripts/qtsupport.py
@@ -20,7 +20,6 @@ Qt files for the wizard for initiating a tumbler run.
 '''
 import sys, math, re, logging, Queue
 from collections import namedtuple
-from decimal import Decimal
 
 from PyQt4 import QtCore
 from PyQt4.QtGui import *

--- a/scripts/sendpayment.py
+++ b/scripts/sendpayment.py
@@ -8,13 +8,8 @@ For notes, see scripts/README.md; in particular, note the use
 of "schedules" with the -S flag.
 """
 
-import random
 import sys
-import threading
-from optparse import OptionParser
 from twisted.internet import reactor
-import time
-import os
 import pprint
 
 from jmclient import (
@@ -24,7 +19,7 @@ from jmclient import (
     sync_wallet, RegtestBitcoinCoreInterface, estimate_tx_fee, direct_send,
     open_test_wallet_maybe, get_wallet_path)
 from twisted.python.log import startLogging
-from jmbase.support import get_log, debug_dump_object, get_password
+from jmbase.support import get_log
 from cli_options import get_sendpayment_parser
 
 log = get_log()

--- a/scripts/sendtomany.py
+++ b/scripts/sendtomany.py
@@ -6,8 +6,6 @@ for a Joinmarket user, although of course it may be useful
 for other reasons).
 """
 
-import binascii
-import sys, os
 from pprint import pformat
 from optparse import OptionParser
 import jmclient.btc as btc

--- a/scripts/tumbler.py
+++ b/scripts/tumbler.py
@@ -14,7 +14,7 @@ from jmclient import (
     tweak_tumble_schedule, human_readable_schedule_entry, schedule_to_text,
     restart_waiter, get_tumble_log, tumbler_taker_finished_update,
     tumbler_filter_orders_callback)
-from jmbase.support import get_log, debug_dump_object, get_password
+from jmbase.support import get_log
 from cli_options import get_tumbler_parser
 log = get_log()
 logsdir = os.path.join(os.path.dirname(

--- a/scripts/yield-generator-basic.py
+++ b/scripts/yield-generator-basic.py
@@ -1,9 +1,6 @@
 #! /usr/bin/env python
 from __future__ import absolute_import, print_function
 
-import datetime
-import os
-import time
 
 from jmclient import (YieldGenerator, YieldGeneratorBasic, ygmain, get_log,
                       jm_single, calc_cj_fee)


### PR DESCRIPTION
remove all unused imports

those files were cleaned up using

    autoflake --in-place --remove-all-unused-imports {jmbase,jmdaemon,jmclient,jmbitcoin}/*/[^_]*.py scripts/*.py

it may be worth exploring adding pylint/pyflakes to the test runner in order to spot newly occurring unused imports (and in the long run possibly more code style checks)