### PR TITLE
add flake8 style checks to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,6 +50,7 @@ before_script:
 script:
   - on_host do_on linux bitcoind --help | head -1
   - on_host do_on linux ./test/run_tests.sh
+  - on_host do_on linux flake8 jmbase jmbitcoin jmclient jmdaemon scripts test
   - on_docker ./test/Dockerfiles/build_docker.sh
 after_success:
   - on_docker echo "Success !"

--- a/jmbase/test/test_commands.py
+++ b/jmbase/test/test_commands.py
@@ -1,12 +1,11 @@
 #! /usr/bin/env python
 from __future__ import print_function
-from twisted.internet import protocol, reactor
+from twisted.internet import protocol, reactor, task
 from twisted.internet.error import (ConnectionLost, ConnectionAborted,
                                     ConnectionClosed, ConnectionDone)
 from twisted.protocols.amp import UnknownRemoteError
 from twisted.protocols import amp
 from twisted.trial import unittest
-from twisted.internet import reactor, task
 
 from jmbase.commands import *
 

--- a/jmbitcoin/jmbitcoin/secp256k1_main.py
+++ b/jmbitcoin/jmbitcoin/secp256k1_main.py
@@ -32,10 +32,6 @@ if sys.version_info.major == 2:
         256: ''.join([chr(x) for x in range(256)])
     }
 
-    def bin_dbl_sha256(s):
-        bytes_to_hash = from_string_to_bytes(s)
-        return hashlib.sha256(hashlib.sha256(bytes_to_hash).digest()).digest()
-
     def lpad(msg, symbol, length):
         if len(msg) >= length:
             return msg

--- a/jmbitcoin/test/test_tx_serialize.py
+++ b/jmbitcoin/test/test_tx_serialize.py
@@ -1,4 +1,3 @@
-import sys
 import jmbitcoin as btc
 import pytest
 import json

--- a/jmclient/jmclient/btc.py
+++ b/jmclient/jmclient/btc.py
@@ -7,8 +7,6 @@ BTC_P2SH_VBYTE = {"mainnet": 0x05, "testnet": 0xc4}
 PODLE_COMMIT_FILE = None
 
 from jmbase.support import get_log
-import binascii, sys, re, hashlib, base64
-from pprint import pformat
 log = get_log()
 
 #Required only for PoDLE calculation:
@@ -68,7 +66,7 @@ except ImportError:
     #Electrum specific code starts here
     import electrum.bitcoin as ebt
     import electrum.transaction as etr
-    from ecdsa.ecdsa import curve_secp256k1, generator_secp256k1, point_is_valid
+    from ecdsa.ecdsa import point_is_valid
     from ecdsa.util import string_to_number, sigdecode_der, sigencode_der
     from ecdsa import VerifyingKey, BadSignatureError, BadDigestError
     from ecdsa.curves import SECP256k1
@@ -193,7 +191,7 @@ except ImportError:
         try:
             verified = ecdsa_pub.verify_digest(sig, txforsig,
                                        sigdecode = sigdecode_der)
-        except BadSignatureError, BadDigestError:
+        except (BadSignatureError, BadDigestError):
             return False
         return True
     

--- a/jmclient/jmclient/electruminterface.py
+++ b/jmclient/jmclient/electruminterface.py
@@ -15,8 +15,8 @@ from twisted.internet import reactor, task, defer
 from .blockchaininterface import BlockchainInterface
 from .configure import get_p2sh_vbyte
 from .support import get_log
-from .electrum_data import (get_default_ports, get_default_servers,
-                            set_electrum_testnet, DEFAULT_PROTO)
+from .electrum_data import get_default_servers, set_electrum_testnet,\
+    DEFAULT_PROTO
 
 log = get_log()
 
@@ -290,19 +290,19 @@ class ElectrumInterface(BlockchainInterface):
         tah[i]['synced'] = True
         #Having updated this specific record, check if the entire batch from start_index
         #has been synchronized
-        if all([tah[i]['synced'] for i in range(start_index, start_index + self.BATCH_SIZE)]):
+        if all([tah[j]['synced'] for j in range(start_index, start_index + self.BATCH_SIZE)]):
             #check if unused goes back as much as gaplimit *and* we are ahead of any
             #existing index_cache from the wallet file; if both true, end, else, continue
             #to next batch
-            if all([tah[i]['used'] is False for i in range(
+            if all([tah[j]['used'] is False for j in range(
                 start_index + self.BATCH_SIZE - wallet.gap_limit,
                 start_index + self.BATCH_SIZE)]):
                 last_used_addr = None
                 #to find last used, note that it may be in the *previous* batch;
                 #may as well just search from the start, since it takes no time.
-                for i in range(start_index + self.BATCH_SIZE):
-                    if tah[i]['used']:
-                        last_used_addr = tah[i]['addr']
+                for j in range(start_index + self.BATCH_SIZE):
+                    if tah[j]['used']:
+                        last_used_addr = tah[j]['addr']
                 if last_used_addr:
                     wallet.set_next_index(
                         mixdepth, forchange,

--- a/jmclient/jmclient/maker.py
+++ b/jmclient/jmclient/maker.py
@@ -214,8 +214,8 @@ class Maker(object):
             self.offerlist.remove(order[0])
         if len(to_announce) > 0:
             for ann in to_announce:
-                oldorder_s = [order for order in self.offerlist
-                              if order['oid'] == ann['oid']]
+                oldorder_s = [o for o in self.offerlist
+                              if o['oid'] == ann['oid']]
                 if len(oldorder_s) > 0:
                     self.offerlist.remove(oldorder_s[0])
             self.offerlist += to_announce

--- a/jmclient/jmclient/podle.py
+++ b/jmclient/jmclient/podle.py
@@ -3,13 +3,15 @@ from __future__ import print_function
 #Proof Of Discrete Logarithm Equivalence
 #For algorithm steps, see https://gist.github.com/AdamISZ/9cbba5e9408d23813ca8
 import os
+import sys
 import hashlib
 import json
 import binascii
+from btc import multiply, add_pubkeys, getG, podle_PublicKey,\
+    podle_PrivateKey, encode, decode, N, podle_PublicKey_class
+
+
 PODLE_COMMIT_FILE = None
-from btc import (multiply, add_pubkeys, getG, podle_PublicKey, podle_PrivateKey,
-                 encode, decode, N,
-                 podle_PublicKey_class, podle_PrivateKey_class)
 
 
 def set_commitment_file(file_loc):

--- a/jmclient/jmclient/taker_utils.py
+++ b/jmclient/jmclient/taker_utils.py
@@ -1,5 +1,4 @@
 from __future__ import absolute_import, print_function
-from jmclient import schedule_to_text, human_readable_schedule_entry
 import logging
 import pprint
 import os
@@ -7,7 +6,8 @@ import time
 import numbers
 from binascii import hexlify, unhexlify
 from .configure import get_log, jm_single, validate_address
-from .schedule import human_readable_schedule_entry, tweak_tumble_schedule
+from .schedule import human_readable_schedule_entry, tweak_tumble_schedule,\
+    schedule_to_text
 from .wallet import BaseWallet, estimate_tx_fee
 from .btc import deserialize, mktx, serialize, txhash
 log = get_log()

--- a/jmclient/jmclient/yieldgenerator.py
+++ b/jmclient/jmclient/yieldgenerator.py
@@ -7,9 +7,8 @@ import time
 import abc
 from twisted.python.log import startLogging
 from optparse import OptionParser
-from jmclient import (Maker, jm_single, get_network, load_program_config, get_log,
-                      sync_wallet, JMClientProtocolFactory,
-                      start_reactor, calc_cj_fee, WalletError)
+from jmclient import Maker, jm_single, load_program_config, get_log,\
+    sync_wallet, JMClientProtocolFactory, start_reactor, calc_cj_fee
 from .wallet_utils import open_test_wallet_maybe, get_wallet_path
 
 jlog = get_log()

--- a/jmclient/test/test_client_protocol.py
+++ b/jmclient/test/test_client_protocol.py
@@ -2,8 +2,8 @@
 from __future__ import absolute_import
 '''test client-protocol interfacae.'''
 
-from jmclient import (get_schedule, load_program_config, start_reactor,
-                      Taker, get_log, JMClientProtocolFactory, jm_single)
+from jmclient import load_program_config, Taker, get_log,\
+    JMClientProtocolFactory, jm_single
 from jmclient.client_protocol import JMTakerClientProtocol
 from twisted.python.log import msg as tmsg
 from twisted.internet import protocol, reactor, task

--- a/jmclient/test/test_commitment_utils.py
+++ b/jmclient/test/test_commitment_utils.py
@@ -5,8 +5,7 @@ import pytest
 
 from jmclient import (load_program_config, jm_single)
 from jmclient.commitment_utils import get_utxo_info, validate_utxo_data
-from taker_test_data import (t_utxos_by_mixdepth, t_selected_utxos, t_orderbook,
-                             t_maker_response, t_chosen_orders, t_dummy_ext)
+
 
 def test_get_utxo_info():
     load_program_config()
@@ -55,4 +54,3 @@ def test_get_utxo_info():
     retval = validate_utxo_data(utxodatas, False)
     assert not retval
     dbci.setQUSFail(False)
-    

--- a/jmclient/test/test_configure.py
+++ b/jmclient/test/test_configure.py
@@ -3,9 +3,7 @@ from __future__ import absolute_import
 '''test configure module.'''
 
 import pytest
-from jmclient import (load_program_config, jm_single, get_irc_mchannels,
-                      BTC_P2PK_VBYTE, BTC_P2SH_VBYTE, validate_address,
-                      JsonRpcConnectionError)
+from jmclient import load_program_config, jm_single, get_irc_mchannels
 from jmclient.configure import (get_config_irc_channel, get_p2sh_vbyte,
                                 get_p2pk_vbyte, get_blockchain_interface_instance)
 import os

--- a/jmclient/test/test_maker.py
+++ b/jmclient/test/test_maker.py
@@ -77,10 +77,9 @@ def get_address_generator(script_pre, script_post, vbyte):
         counter += 1
 
 
-def create_tx_and_offerlist(cj_addr, changeaddr, other_output_scripts,
+def create_tx_and_offerlist(cj_addr, cj_change_addr, other_output_scripts,
                             cj_script=None, cj_change_script=None, offertype='swreloffer'):
     assert len(other_output_scripts) % 2 == 0, "bug in test"
-    other_participant_count = len(other_output_scripts) // 2
 
     cj_value = 100000000
     maker_total_value = cj_value*3
@@ -88,7 +87,7 @@ def create_tx_and_offerlist(cj_addr, changeaddr, other_output_scripts,
     if cj_script is None:
         cj_script = btc.address_to_script(cj_addr)
     if cj_change_script is None:
-        changeaddr = btc.address_to_script(cj_change_addr)
+        cj_change_script = btc.address_to_script(cj_change_addr)
 
     inputs = create_tx_inputs(3)
     outputs = create_tx_outputs(
@@ -101,7 +100,7 @@ def create_tx_and_offerlist(cj_addr, changeaddr, other_output_scripts,
     maker_utxos = [inputs[0]]
 
     tx = btc.deserialize(btc.mktx(inputs, outputs))
-    offerlist = construct_tx_offerlist(cj_addr, changeaddr, maker_utxos,
+    offerlist = construct_tx_offerlist(cj_addr, cj_change_addr, maker_utxos,
                                        maker_total_value, cj_value, offertype)
 
     return tx, offerlist

--- a/jmclient/test/test_podle.py
+++ b/jmclient/test/test_podle.py
@@ -7,10 +7,9 @@ import binascii
 import json
 import pytest
 import copy
-from jmclient import (load_program_config, get_log, jm_single, generate_podle,
-                      generate_podle_error_string, set_commitment_file,
-                      get_commitment_file, PoDLE, get_podle_commitments,
-                      add_external_commitments, update_commitments)
+from jmclient import load_program_config, get_log, jm_single, generate_podle,\
+    generate_podle_error_string, get_commitment_file, PoDLE,\
+    get_podle_commitments, add_external_commitments, update_commitments
 from jmclient.podle import verify_all_NUMS, verify_podle, PoDLEError
 from commontest import make_wallets
 log = get_log()

--- a/jmclient/test/test_taker.py
+++ b/jmclient/test/test_taker.py
@@ -9,11 +9,11 @@ import shutil
 import pytest
 import json
 from base64 import b64encode
-from jmclient import (
-    load_program_config, jm_single, set_commitment_file, get_commitment_file,
-    SegwitLegacyWallet, Taker, VolatileStorage, get_p2sh_vbyte, get_network)
-from taker_test_data import (t_utxos_by_mixdepth, t_selected_utxos, t_orderbook,
-                             t_maker_response, t_chosen_orders, t_dummy_ext)
+from jmclient import load_program_config, jm_single, set_commitment_file,\
+    get_commitment_file, SegwitLegacyWallet, Taker, VolatileStorage,\
+    get_network
+from taker_test_data import t_utxos_by_mixdepth, t_orderbook,\
+    t_maker_response, t_chosen_orders, t_dummy_ext
 
 
 class DummyWallet(SegwitLegacyWallet):

--- a/jmclient/test/test_tx_creation.py
+++ b/jmclient/test/test_tx_creation.py
@@ -9,9 +9,8 @@ from commontest import make_wallets, make_sign_and_push
 
 import jmbitcoin as bitcoin
 import pytest
-from jmclient import (
-    load_program_config, jm_single, sync_wallet, get_p2pk_vbyte, get_log,
-    select_gradual, select, select_greedy, select_greediest, estimate_tx_fee)
+from jmclient import load_program_config, jm_single, sync_wallet,\
+    get_p2pk_vbyte, get_log
 
 log = get_log()
 #just a random selection of pubkeys for receiving multisigs;

--- a/jmdaemon/jmdaemon/daemon_protocol.py
+++ b/jmdaemon/jmdaemon/daemon_protocol.py
@@ -17,7 +17,7 @@ from twisted.internet import reactor, ssl
 from twisted.internet.protocol import ServerFactory
 from twisted.internet.error import (ConnectionLost, ConnectionAborted,
                                     ConnectionClosed, ConnectionDone)
-from twisted.python import failure, log
+from twisted.python import log
 import json
 import threading
 import os

--- a/jmdaemon/jmdaemon/irc.py
+++ b/jmdaemon/jmdaemon/irc.py
@@ -6,8 +6,6 @@ from twisted.internet.endpoints import TCP4ClientEndpoint
 from twisted.application.internet import ClientService
 from twisted.internet.ssl import ClientContextFactory
 from twisted.words.protocols import irc
-from twisted.internet.error import (ConnectionLost, ConnectionAborted,
-                                    ConnectionClosed, ConnectionDone)
 from jmdaemon.message_channel import MessageChannel
 from jmbase.support import get_log, chunks
 from txsocksx.client import SOCKS5ClientEndpoint

--- a/jmdaemon/jmdaemon/message_channel.py
+++ b/jmdaemon/jmdaemon/message_channel.py
@@ -3,11 +3,9 @@ from __future__ import print_function
 import abc
 import base64
 import threading
-from jmdaemon import (
-    encrypt_encode, decode_decrypt, COMMAND_PREFIX, ORDER_KEYS,
-    NICK_HASH_LENGTH, NICK_MAX_ENCODED, JM_VERSION, JOINMARKET_NICK_HEADER,
-    nickname, plaintext_commands, encrypted_commands, commitment_broadcast_list,
-    offername_list, public_commands, private_commands)
+from jmdaemon import encrypt_encode, decode_decrypt, COMMAND_PREFIX,\
+    NICK_HASH_LENGTH, NICK_MAX_ENCODED, plaintext_commands,\
+    encrypted_commands, commitment_broadcast_list, offername_list
 from jmbase.support import get_log
 from functools import wraps
 
@@ -156,8 +154,8 @@ class MessageChannelCollection(object):
         may be some issues with intialization.
         """
         if mchannel not in self.mchannels:
-            self.mc_status[mc] = 0
-            self.nicks_seen[mc] = set()
+            self.mc_status[mchannel] = 0
+            self.nicks_seen[mchannel] = set()
         self.mchannels += mchannel
         self.mchannels = list(set(self.mchannels))
 

--- a/jmdaemon/jmdaemon/orderbookwatch.py
+++ b/jmdaemon/jmdaemon/orderbookwatch.py
@@ -1,14 +1,9 @@
 #! /usr/bin/env python
 from __future__ import absolute_import, print_function
 
-import base64
-import pprint
-import random
 import sqlite3
 import sys
-import time
 import threading
-import json
 from decimal import InvalidOperation, Decimal
 
 from jmdaemon.protocol import JM_VERSION

--- a/jmdaemon/jmdaemon/socks.py
+++ b/jmdaemon/jmdaemon/socks.py
@@ -217,7 +217,7 @@ class socksocket(socket.socket):
             if authstat[1] != "\x00":
                 # Authentication failed
                 self.close()
-                raise Socks5AuthError, (3, _socks5autherrors[3])
+                raise Socks5AuthError((3, _socks5autherrors[3]))
                 # Authentication succeeded
         else:
             # Reaching here is always bad

--- a/jmdaemon/test/test_daemon_protocol.py
+++ b/jmdaemon/test/test_daemon_protocol.py
@@ -2,11 +2,11 @@
 from __future__ import absolute_import
 '''test daemon-protocol interfacae.'''
 
-from jmdaemon import (JMDaemonServerProtocolFactory, MessageChannelCollection)
+from jmdaemon import MessageChannelCollection
 from jmdaemon.orderbookwatch import OrderbookWatch
 from jmdaemon.daemon_protocol import JMDaemonServerProtocol
-from jmdaemon.protocol import (COMMAND_PREFIX, ORDER_KEYS, NICK_HASH_LENGTH,
-                       NICK_MAX_ENCODED, JM_VERSION, JOINMARKET_NICK_HEADER)
+from jmdaemon.protocol import NICK_HASH_LENGTH, NICK_MAX_ENCODED, JM_VERSION,\
+    JOINMARKET_NICK_HEADER
 from jmclient import (load_program_config, get_log, jm_single, get_irc_mchannels)
 from twisted.python.log import msg as tmsg
 from twisted.internet import protocol, reactor, task

--- a/jmdaemon/test/test_irc_messaging.py
+++ b/jmdaemon/test/test_irc_messaging.py
@@ -2,21 +2,10 @@
 from __future__ import absolute_import
 '''Tests of joinmarket bots end-to-end (including IRC and bitcoin) '''
 
-import subprocess
-import signal
-import os
-import pytest
 import time
-import threading
-import hashlib
 from twisted.trial import unittest
-from twisted.internet import reactor, task, defer
-import jmbitcoin as btc
-from jmdaemon import (JOINMARKET_NICK_HEADER, NICK_HASH_LENGTH,
-                      NICK_MAX_ENCODED, IRCMessageChannel,
-                      MessageChannelCollection)
-from jmdaemon.message_channel import CJPeerError
-import jmdaemon
+from twisted.internet import reactor, task
+from jmdaemon import IRCMessageChannel, MessageChannelCollection
 #needed for test framework
 from jmclient import (load_program_config, get_irc_mchannels, jm_single)
 

--- a/jmdaemon/test/test_message_channel.py
+++ b/jmdaemon/test/test_message_channel.py
@@ -3,17 +3,13 @@ from __future__ import absolute_import
 '''test messagechannel management code.'''
 
 import pytest
-from jmdaemon import (JMDaemonServerProtocolFactory, MessageChannelCollection)
+from jmdaemon import MessageChannelCollection
 from jmdaemon.message_channel import MChannelThread
 from jmdaemon.orderbookwatch import OrderbookWatch
-from jmdaemon.daemon_protocol import JMDaemonServerProtocol
-from jmdaemon.protocol import (COMMAND_PREFIX, ORDER_KEYS, NICK_HASH_LENGTH,
-                       NICK_MAX_ENCODED, JM_VERSION, JOINMARKET_NICK_HEADER)
+from jmdaemon.protocol import COMMAND_PREFIX, NICK_HASH_LENGTH,\
+    NICK_MAX_ENCODED, JM_VERSION, JOINMARKET_NICK_HEADER
 from jmclient import get_log
-import os
-from jmbase.commands import *
 from msgdata import *
-import json
 import time
 import hashlib
 import base64
@@ -21,7 +17,8 @@ import traceback
 import threading
 import jmbitcoin as bitcoin
 from dummy_mc import DummyMessageChannel
-from twisted.internet import reactor
+
+
 jlog = get_log()
 
 def make_valid_nick(i=0):

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,4 +6,4 @@ pytest
 pytest-cov
 python-coveralls
 mock
-
+flake8

--- a/scripts/add-utxo.py
+++ b/scripts/add-utxo.py
@@ -14,11 +14,10 @@ from pprint import pformat
 
 from optparse import OptionParser
 import jmclient.btc as btc
-from jmclient import (
-    load_program_config, jm_single, get_p2pk_vbyte, open_wallet, WalletError,
-    sync_wallet, add_external_commitments, generate_podle, update_commitments,
-    PoDLE, set_commitment_file, get_podle_commitments, get_utxo_info,
-    validate_utxo_data, quit, get_wallet_path)
+from jmclient import load_program_config, jm_single, get_p2pk_vbyte,\
+    open_wallet, sync_wallet, add_external_commitments, update_commitments,\
+    PoDLE, get_podle_commitments, get_utxo_info, validate_utxo_data, quit,\
+    get_wallet_path
 
 
 def add_ext_commitments(utxo_datas):

--- a/scripts/joinmarket-qt.py
+++ b/scripts/joinmarket-qt.py
@@ -20,12 +20,11 @@ Some widgets copied and modified from https://github.com/spesmilo/electrum
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 '''
 
-import sys, base64, textwrap, datetime, os, logging
+import sys, datetime, os, logging
 import platform, csv, threading, time
 
 
 from decimal import Decimal
-from functools import partial
 
 from PyQt4 import QtCore
 from PyQt4.QtGui import *
@@ -52,24 +51,19 @@ JM_CORE_VERSION = '0.3.5'
 #Version of this Qt script specifically
 JM_GUI_VERSION = '7'
 
-from jmclient import (
-    load_program_config, get_network, open_test_wallet_maybe, get_wallet_path,
-    get_p2sh_vbyte, get_p2pk_vbyte, jm_single, validate_address, get_log,
-    weighted_order_choose, Taker, JMClientProtocolFactory, WalletError,
-    start_reactor, get_schedule, get_tumble_schedule, schedule_to_text,
-    get_blockchain_interface_instance, sync_wallet,
-    direct_send, RegtestBitcoinCoreInterface, tweak_tumble_schedule,
-    human_readable_schedule_entry, tumbler_taker_finished_update,
-    get_tumble_log, restart_wait, tumbler_filter_orders_callback,
-    wallet_generate_recover_bip39, wallet_display)
+from jmclient import load_program_config, get_network,\
+    open_test_wallet_maybe, get_wallet_path, get_p2sh_vbyte, get_p2pk_vbyte,\
+    jm_single, validate_address, get_log, weighted_order_choose, Taker,\
+    JMClientProtocolFactory, start_reactor, get_schedule, schedule_to_text,\
+    get_blockchain_interface_instance, direct_send,\
+    RegtestBitcoinCoreInterface, tumbler_taker_finished_update,\
+    get_tumble_log, restart_wait, tumbler_filter_orders_callback,\
+    wallet_generate_recover_bip39, wallet_display
+from qtsupport import ScheduleWizard, TumbleRestartWizard, config_tips,\
+    config_types, QtHandler, XStream, Buttons, OkButton, CancelButton,\
+    PasswordDialog, MyTreeWidget, JMQtMessageBox, BLUE_FG,\
+    donation_more_message
 
-from qtsupport import (ScheduleWizard, TumbleRestartWizard, warnings, config_tips,
-                       config_types, TaskThread, QtHandler, XStream, Buttons,
-                       CloseButton, CopyButton, CopyCloseButton, OkButton,
-                       CancelButton, check_password_strength,
-                       update_password_strength, make_password_dialog,
-                       PasswordDialog, MyTreeWidget, JMQtMessageBox, BLUE_FG,
-                       donation_more_message)
 
 from twisted.internet import task
 def satoshis_to_amt_str(x):

--- a/scripts/obwatch/ob-watcher.py
+++ b/scripts/obwatch/ob-watcher.py
@@ -411,7 +411,6 @@ def get_dummy_nick():
     an orderbook request, so no such need, but for better
     privacy, a conformant nick is created based on a random
     pseudo-pubkey."""
-    import binascii
     nick_pkh_raw = hashlib.sha256(os.urandom(10)).digest()[:NICK_HASH_LENGTH]
     nick_pkh = btc.changebase(nick_pkh_raw, 256, 58)
     #right pad to maximum possible; b58 is not fixed length.

--- a/scripts/sendpayment.py
+++ b/scripts/sendpayment.py
@@ -12,12 +12,11 @@ import sys
 from twisted.internet import reactor
 import pprint
 
-from jmclient import (
-    Taker, load_program_config, get_schedule, JMClientProtocolFactory,
-    start_reactor, validate_address, jm_single, WalletError, choose_orders,
-    choose_sweep_orders, cheapest_order_choose, weighted_order_choose,
-    sync_wallet, RegtestBitcoinCoreInterface, estimate_tx_fee, direct_send,
-    open_test_wallet_maybe, get_wallet_path)
+from jmclient import Taker, load_program_config, get_schedule,\
+    JMClientProtocolFactory, start_reactor, validate_address, jm_single,\
+    cheapest_order_choose, weighted_order_choose, sync_wallet,\
+    RegtestBitcoinCoreInterface, estimate_tx_fee, direct_send,\
+    open_test_wallet_maybe, get_wallet_path
 from twisted.python.log import startLogging
 from jmbase.support import get_log
 from cli_options import get_sendpayment_parser

--- a/scripts/sendtomany.py
+++ b/scripts/sendtomany.py
@@ -9,9 +9,11 @@ for other reasons).
 from pprint import pformat
 from optparse import OptionParser
 import jmclient.btc as btc
-from jmclient import (load_program_config, estimate_tx_fee, jm_single,
-                      get_p2sh_vbyte, get_p2pk_vbyte, validate_address, get_log,
-                      get_utxo_info, validate_utxo_data, quit)
+from jmclient import load_program_config, estimate_tx_fee, jm_single,\
+    get_p2pk_vbyte, validate_address, get_log, get_utxo_info,\
+    validate_utxo_data, quit
+
+
 log = get_log()
 
 def sign(utxo, priv, destaddrs, segwit=True):

--- a/scripts/tumbler.py
+++ b/scripts/tumbler.py
@@ -6,14 +6,12 @@ from twisted.internet import reactor
 import os
 import pprint
 from twisted.python.log import startLogging
-from jmclient import (
-    Taker, load_program_config, get_schedule,  weighted_order_choose,
-    JMClientProtocolFactory, start_reactor, validate_address, jm_single,
-    get_wallet_path, open_test_wallet_maybe, WalletError, sync_wallet,
-    get_tumble_schedule, RegtestBitcoinCoreInterface, estimate_tx_fee,
-    tweak_tumble_schedule, human_readable_schedule_entry, schedule_to_text,
-    restart_waiter, get_tumble_log, tumbler_taker_finished_update,
-    tumbler_filter_orders_callback)
+from jmclient import Taker, load_program_config, get_schedule,\
+    weighted_order_choose, JMClientProtocolFactory, start_reactor, jm_single,\
+    get_wallet_path, open_test_wallet_maybe, sync_wallet,\
+    get_tumble_schedule, RegtestBitcoinCoreInterface, schedule_to_text,\
+    restart_waiter, get_tumble_log, tumbler_taker_finished_update,\
+    tumbler_filter_orders_callback
 from jmbase.support import get_log
 from cli_options import get_tumbler_parser
 log = get_log()
@@ -26,7 +24,7 @@ def main():
     (options, args) = get_tumbler_parser().parse_args()
     options = vars(options)
     if len(args) < 1:
-        parser.error('Needs a wallet file')
+        print('Error: Needs a wallet file')
         sys.exit(0)
     load_program_config()
     #Load the wallet

--- a/scripts/yg-privacyenhanced.py
+++ b/scripts/yg-privacyenhanced.py
@@ -3,8 +3,8 @@ from __future__ import absolute_import, print_function
 
 import random
 
-from jmclient import (YieldGenerator, YieldGeneratorBasic, ygmain, get_log,
-                      jm_single, calc_cj_fee)
+from jmclient import YieldGeneratorBasic, ygmain, get_log, jm_single
+
 
 # This is a maker for the purposes of generating a yield from held bitcoins
 # while maximising the difficulty of spying on blockchain activity.

--- a/scripts/yield-generator-basic.py
+++ b/scripts/yield-generator-basic.py
@@ -2,8 +2,7 @@
 from __future__ import absolute_import, print_function
 
 
-from jmclient import (YieldGenerator, YieldGeneratorBasic, ygmain, get_log,
-                      jm_single, calc_cj_fee)
+from jmclient import YieldGeneratorBasic, ygmain, get_log
 
 """THESE SETTINGS CAN SIMPLY BE EDITED BY HAND IN THIS FILE:
 """

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,24 @@
 # content of pytest.ini
 [tool:pytest]
 testpaths = jmbitcoin jmclient jmbase jmdaemon test
+
+[flake8]
+exclude =
+    # defaults
+    .svn,CVS,.bzr,.hg,.git,__pycache__,.tox,
+    # lots of "unused imports"
+    __init__.py,
+    # unmaintained
+    jmclient/jmclient/slowaes.py
+
+# default value, keep?
+max-line-length = 79
+
+statistics = True
+max-complexity = 15
+
+# should be extended once existing issues are fixed
+select = F,E9,W6
+
+# those cause many errors, need to be fixed eventually
+ignore = F403,F405,F841

--- a/test/ygrunner.py
+++ b/test/ygrunner.py
@@ -13,14 +13,11 @@ from __future__ import absolute_import, print_function
    --nirc=2 -s test/ygrunner.py
    '''
 from common import make_wallets
-import os
 import pytest
-import sys
-import time
 import random
-from jmclient import (YieldGeneratorBasic, ygmain, load_program_config,
-                      jm_single, sync_wallet, JMClientProtocolFactory,
-                      start_reactor)
+from jmclient import YieldGeneratorBasic, load_program_config, jm_single,\
+    sync_wallet, JMClientProtocolFactory, start_reactor
+
 
 class MaliciousYieldGenerator(YieldGeneratorBasic):
     """Overrides, randomly, some maker functions


### PR DESCRIPTION
Add flake8 to the travis test runner. Right now only `F401` (unused imports) is checked. The travis build will fail if violations are detected.

Fixed all identified cases of unused imports.

Further tuning of `setup.cfg` may be desirable.