### PR TITLE
Switch over to using labels instead of accounts

### DIFF
--- a/scripts/cli_options.py
+++ b/scripts/cli_options.py
@@ -185,7 +185,7 @@ def get_tumbler_parser():
 def get_sendpayment_parser():
     parser = OptionParser(
         usage=
-        'usage: %prog [options] [wallet file / fromaccount] [amount] [destaddr]',
+        'usage: %prog [options] [wallet file] [amount] [destaddr]',
         description='Sends a single payment from a given mixing depth of your '
         +
         'wallet to an given address using coinjoin and then switches off. Also sends from bitcoinqt. '


### PR DESCRIPTION
Bitcoin Core 0.17 deprecates the accounts feature and replaces it with labels. The RPC functions using accounts still work for use with older version of Core.

See issue #185 

[WIP] because I haven't tested it yet.