### PR TITLE
Additional method changemixdepth in wallet-tool

### DIFF
--- a/jmclient/jmclient/wallet.py
+++ b/jmclient/jmclient/wallet.py
@@ -1074,6 +1074,8 @@ class BIP32Wallet(BaseWallet):
 
         for md, data in self._storage.data[self._STORAGE_INDEX_CACHE].items():
             md = int(md)
+            if md > self.max_mixdepth:
+                continue
             md_map = self._index_cache[md]
             for t, k in data.items():
                 md_map[int(t)] = k

--- a/jmclient/jmclient/wallet_utils.py
+++ b/jmclient/jmclient/wallet_utils.py
@@ -31,7 +31,10 @@ def get_wallettool_parser():
         '(importprivkey) Adds privkeys to this wallet, privkeys are spaces or commas separated.\n'
         '(dumpprivkey) Export a single private key, specify an hd wallet path\n'
         '(signmessage) Sign a message with the private key from an address in \n'
-        'the wallet. Use with -H and specify an HD wallet path for the address.')
+        'the wallet. Use with -H and specify an HD wallet path for the address.\n'
+        '(changemixdepth) Use with -m to change the *maximum* number of mixdepths\n'
+        'in the wallet; you are advised to only increase, not decrease this \n'
+        'number from the current value (initially 5).')
     parser = OptionParser(usage='usage: %prog [options] [wallet file] [method]',
                           description=description)
     parser.add_option('-p',
@@ -851,6 +854,11 @@ def get_wallet_cls(wtype=None):
     return cls
 
 
+def change_wallet_mixdepth(wallet, max_mixdepth):
+    wallet.max_mixdepth = max_mixdepth
+    wallet.save()
+    return "Maximum mixdepth successfully updated."
+
 def create_wallet(path, password, max_mixdepth, wallet_cls=None, **kwargs):
     storage = Storage(path, password, create=True)
     wallet_cls = wallet_cls or get_wallet_cls()
@@ -977,7 +985,8 @@ def wallet_tool_main(wallet_root_path):
     methods = ['display', 'displayall', 'summary', 'showseed', 'importprivkey',
                'history', 'showutxos']
     methods.extend(noseed_methods)
-    noscan_methods = ['showseed', 'importprivkey', 'dumpprivkey', 'signmessage']
+    noscan_methods = ['showseed', 'importprivkey', 'dumpprivkey',
+                      'signmessage', 'changemixdepth']
     readonly_methods = ['display', 'displayall', 'summary', 'showseed',
                         'history', 'showutxos', 'dumpprivkey', 'signmessage']
 
@@ -1044,6 +1053,8 @@ def wallet_tool_main(wallet_root_path):
         return "Key import completed."
     elif method == "signmessage":
         return wallet_signmessage(wallet, options.hd_path, args[2])
+    elif method == 'changemixdepth':
+        return change_wallet_mixdepth(wallet, options.mixdepth-1)
 
 
 #Testing (can port to test modules, TODO)

--- a/scripts/tumbler.py
+++ b/scripts/tumbler.py
@@ -34,7 +34,13 @@ def main():
     max_mix_depth = options['mixdepthsrc'] + options['mixdepthcount']
     wallet_path = get_wallet_path(wallet_name, None)
     wallet = open_test_wallet_maybe(wallet_path, wallet_name, max_mix_depth)
-
+    if wallet.max_mixdepth < max_mix_depth:
+        print("Your wallet does not contain the required number of mixdepths: ",
+              max_mix_depth)
+        print("Increase using this command: `python wallet-tool.py -m ",
+              max_mix_depth, " (yourwalletname) changemixdepth")
+        print("Then start the tumbler again with the same settings.")
+        sys.exit(0)
     if jm_single().config.get("BLOCKCHAIN",
                               "blockchain_source") == "electrum-server":
         jm_single().bc_interface.synctype = "with-script"


### PR DESCRIPTION
This commit adds a method 'changemixdepth' to the list
of methods that can be invoked with the wallet-tool.py script.
It is a noscan method, so doesn't require sync, and uses the
value of the -m option as the new *number* of mixdepths, and
updates the wallet's storage for future runs.
Users are advised not to reduce this number, but increasing it
should always be fine.

Thanks to @undeath for figuring this out and supplying the main code for the fix/improvement.

This closes #191  (although I think there may be more that can be done, it should at least address the basic issue of coin access).