### PR TITLE
Remove --rpcwallet CLI option

### DIFF
--- a/scripts/cli_options.py
+++ b/scripts/cli_options.py
@@ -268,14 +268,6 @@ def get_sendpayment_parser():
                       dest='answeryes',
                       default=False,
                       help='answer yes to everything')
-    parser.add_option(
-        '--rpcwallet',
-        action='store_true',
-        dest='userpcwallet',
-        default=False,
-        help=('Use the Bitcoin Core wallet through json rpc, instead '
-              'of the internal joinmarket wallet. Requires '
-              'blockchain_source=json-rpc'))
     parser.add_option('--fast',
                       action='store_true',
                       dest='fastsync',


### PR DESCRIPTION
It is not working (not implemented) since 995c123eecbbbf84b6676cfec5578fa6ae6dffdd