### PR TITLE
update travis main ubuntu distribution

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 sudo: required
-dist: trusty
+dist: xenial
 matrix:
   include:
     - os: osx


### PR DESCRIPTION
Currently tests are run on Ubuntu trusty, which is going to reach EOL in few months. It's also using a pretty old python version (2.7.6), not supporting features needed by the `cryptography` module. They will remove support for that old version in some future version.

This PR bumps the main testing distribution to Ubuntu xenial.

This, however, adds some duplication because we also have a xenial docker image.

@fivepiece is it still worth keeping the xenial docker image?