### PR TITLE
support for mixed addresses coinjoins

### DIFF
--- a/jmclient/jmclient/maker.py
+++ b/jmclient/jmclient/maker.py
@@ -15,6 +15,8 @@ from jmbase.support import get_log
 from jmclient.support import (calc_cj_fee)
 from jmclient.podle import verify_podle, PoDLE, PoDLEError
 from twisted.internet import task
+from .cryptoengine import EngineError
+
 jlog = get_log()
 
 class Maker(object):
@@ -81,10 +83,11 @@ class Maker(object):
             reason = "commitment utxo too small: " + str(res[0]['value'])
             return reject(reason)
 
-        # FIXME: This only works if taker's commitment address is of same type
-        # as our wallet.
-        if res[0]['address'] != \
-                self.wallet.pubkey_to_addr(unhexlify(cr_dict['P'])):
+        try:
+            if not self.wallet.pubkey_has_script(
+                    unhexlify(cr_dict['P']), unhexlify(res[0]['script'])):
+                raise EngineError()
+        except EngineError:
             reason = "Invalid podle pubkey: " + str(cr_dict['P'])
             return reject(reason)
 

--- a/jmclient/jmclient/wallet.py
+++ b/jmclient/jmclient/wallet.py
@@ -20,8 +20,7 @@ from numbers import Integral
 from .configure import jm_single
 from .support import select_gradual, select_greedy, select_greediest, \
     select
-from .cryptoengine import BTC_P2PKH, BTC_P2SH_P2WPKH, TYPE_P2PKH, \
-    TYPE_P2SH_P2WPKH
+from .cryptoengine import TYPE_P2PKH, TYPE_P2SH_P2WPKH, ENGINES
 from .support import get_random_bytes
 from . import mn_encode, mn_decode, btc
 
@@ -204,10 +203,7 @@ class BaseWallet(object):
         'greediest': select_greediest
     }
 
-    _ENGINES = {
-        TYPE_P2PKH: BTC_P2PKH,
-        TYPE_P2SH_P2WPKH: BTC_P2SH_P2WPKH
-    }
+    _ENGINES = ENGINES
 
     _ENGINE = None
 
@@ -383,6 +379,14 @@ class BaseWallet(object):
         path = self.script_to_path(script)
         engine = self._get_priv_from_path(path)[1]
         return engine.script_to_address(script)
+
+    @classmethod
+    def pubkey_has_address(cls, pubkey, addr):
+        return cls._ENGINE.pubkey_has_address(pubkey, addr)
+
+    @classmethod
+    def pubkey_has_script(cls, pubkey, script):
+        return cls._ENGINE.pubkey_has_script(pubkey, script)
 
     @deprecated
     def get_key(self, mixdepth, internal, index):
@@ -1340,7 +1344,7 @@ class BIP32Wallet(BaseWallet):
 
 class LegacyWallet(ImportWalletMixin, BIP32Wallet):
     TYPE = TYPE_P2PKH
-    _ENGINE = BTC_P2PKH
+    _ENGINE = ENGINES[TYPE_P2PKH]
 
     def _create_master_key(self):
         return hexlify(self._entropy)
@@ -1351,7 +1355,7 @@ class LegacyWallet(ImportWalletMixin, BIP32Wallet):
 
 class BIP49Wallet(BIP32Wallet):
     _BIP49_PURPOSE = 2**31 + 49
-    _ENGINE = BTC_P2SH_P2WPKH
+    _ENGINE = ENGINES[TYPE_P2SH_P2WPKH]
 
     def _get_bip32_base_path(self):
         return self._key_ident, self._BIP49_PURPOSE,\

--- a/jmclient/test/commontest.py
+++ b/jmclient/test/commontest.py
@@ -91,13 +91,16 @@ class DummyBlockchainInterface(BlockchainInterface):
                                 'confirms': wallet_outs[to][1]})
             return results
         if txouts[0] in known_outs:
+            addr = btc.pubkey_to_p2sh_p2wpkh_address(
+                        known_outs[txouts[0]], get_p2sh_vbyte())
             return [{'value': 200000000,
-                    'address': btc.pubkey_to_p2sh_p2wpkh_address(
-                        known_outs[txouts[0]], get_p2sh_vbyte()),
-                    'confirms': 20}]
+                     'address': addr,
+                     'script': btc.address_to_script(addr),
+                     'confirms': 20}]
         for t in txouts:
             result_dict = {'value': 10000000000,
-                        'address': "mrcNu71ztWjAQA6ww9kHiW3zBWSQidHXTQ"}
+                           'address': "mrcNu71ztWjAQA6ww9kHiW3zBWSQidHXTQ",
+                           'script': '76a91479b000887626b294a914501a4cd226b58b23598388ac'}
             if includeconf:
                 result_dict['confirms'] = 20
             result.append(result_dict)        

--- a/jmclient/test/test_taker.py
+++ b/jmclient/test/test_taker.py
@@ -197,9 +197,10 @@ def test_auth_pub_not_found(createcmtdata):
              "498faa8b22534f3b443c6b0ce202f31e12f21668b4f0c7a005146808f250d4c3:0",
              "3f3ea820d706e08ad8dc1d2c392c98facb1b067ae4c671043ae9461057bd2a3c:1"]
     fake_query_results = [{'value': 200000000,
-                            'address': "blah",
-                            'utxo': utxos[i],
-                            'confirms': 20} for i in range(3)]
+                           'address': "mrKTGvFfYUEqk52qPKUroumZJcpjHLQ6pn",
+                           'script': '76a914767c956efe6092a775fea39a06d1cac9aae956d788ac',
+                           'utxo': utxos[i],
+                           'confirms': 20} for i in range(3)]
     jm_single().bc_interface.insert_fake_query_results(fake_query_results)
     res = taker.receive_utxos(maker_response)
     assert not res[0]
@@ -418,9 +419,13 @@ def test_on_sig(createcmtdata, dummyaddr, schedule):
     #my inputs are the first 2 utxos
     taker.input_utxos = {utxos[0]:
                         {'address': bitcoin.privkey_to_address(privs[0], False, magicbyte=0x6f),
+                         'script': bitcoin.mk_pubkey_script(
+                            bitcoin.privkey_to_address(privs[0], False, magicbyte=0x6f)),
                          'value': 200000000},
                         utxos[1]:
                         {'address': bitcoin.privkey_to_address(privs[1], False, magicbyte=0x6f),
+                         'script': bitcoin.mk_pubkey_script(
+                            bitcoin.privkey_to_address(privs[1], False, magicbyte=0x6f)),
                          'value': 200000000}}    
     taker.utxos = {None: utxos[:2], "cp1": [utxos[2]], "cp2": [utxos[3]], "cp3":[utxos[4]]}
     for i in range(2):


### PR DESCRIPTION
This PR addresses the FIXME's in
https://github.com/JoinMarket-Org/joinmarket-clientserver/blob/a057b87e4bab3e35c188714e9d6f004f2a166453/jmclient/jmclient/taker.py#L368
and
https://github.com/JoinMarket-Org/joinmarket-clientserver/blob/a057b87e4bab3e35c188714e9d6f004f2a166453/jmclient/jmclient/maker.py#L75

allowing for potentially mixing addresses of differing address/script types (p2pkh/p2sh_p2wpkh/p2wpkh) during a coinjoin.

Note: This does not add high-level ability to do such cjs to joinmarket (which could potentially be hurtful for privacy) because the differing offer types, eg `reloffer` vs `swreloffer`, will still guard against accidental mixing between the two pools. It only adds support for such exotic cases to the "backend".