### PR TITLE
Replace unmaintained txsocksx with txtorcon.

### DIFF
--- a/jmdaemon/jmdaemon/irc.py
+++ b/jmdaemon/jmdaemon/irc.py
@@ -128,9 +128,10 @@ class IRCMessageChannel(MessageChannel):
         wlog('building irc')
         if self.tx_irc_client:
             raise Exception('irc already built')
+        if self.usessl.lower() == 'true':
+            ctx = ClientContextFactory()
         if self.usessl.lower() == 'true' and not self.socks5.lower() == 'true':
             factory = TxIRCFactory(self)
-            ctx = ClientContextFactory()
             reactor.connectSSL(self.serverport[0], self.serverport[1],
                                factory, ctx)
         elif self.socks5.lower() == 'true':
@@ -139,7 +140,7 @@ class IRCMessageChannel(MessageChannel):
             torEndpoint = TCP4ClientEndpoint(reactor, str(self.socks5_host),
                                              self.socks5_port)
             if self.usessl.lower() == 'true':
-                use_tls = True
+                use_tls = ctx
             else:
                 use_tls = False
             ircEndpoint = TorSocksEndpoint(torEndpoint, self.serverport[0],

--- a/jmdaemon/setup.py
+++ b/jmdaemon/setup.py
@@ -9,5 +9,5 @@ setup(name='joinmarketdaemon',
       author_email='',
       license='GPL',
       packages=['jmdaemon'],
-      install_requires=['txsocksx', 'pyopenssl', 'libnacl', 'joinmarketbase==0.4.1'],
+      install_requires=['txtorcon', 'pyopenssl', 'libnacl', 'joinmarketbase==0.4.1'],
       zip_safe=False)


### PR DESCRIPTION
The `txsocksx` package is unmaintained and broken on python3, `txtorcon` seems to work fine as a replacement.