### PR TITLE
Replace deprecated py.test syntax with pytest.

### DIFF
--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -13,7 +13,7 @@ Install the test requirements (still in your virtualenv as mentioned above):
 
 Running the test suite should be done like:
 
-    python -m py.test --cov=jmclient --cov=jmbitcoin --cov=jmbase --cov=jmdaemon --cov-report html --btcpwd=123456abcdef --nirc=2
+    python -m pytest --cov=jmclient --cov=jmbitcoin --cov=jmbase --cov=jmdaemon --cov-report html --btcpwd=123456abcdef --nirc=2
     
 (you'll first want to copy the regtest_joinmarket.cfg file from the test/ directory to the root directory, this file will need minor edits for your btc configuration).
 
@@ -23,7 +23,7 @@ The file `test/ygrunner.py` provides the ability to spin up a set of yieldgenera
 bots against the local IRC instance with the local regtest blockchain. It can be
 started with
 
-    py.test --btcroot=/path/to/bitcoin/bin/ --btcpwd=123456abcdef --nirc=2 test/ygrunner.py -s
+    pytest --btcroot=/path/to/bitcoin/bin/ --btcpwd=123456abcdef --nirc=2 test/ygrunner.py -s
 
 Here the `-s` flag is useful because it prints log output to the console. If you
 keep the logging level at the default `INFO` only a minimum amount will come out, if

--- a/jmbitcoin/test/test_addresses.py
+++ b/jmbitcoin/test/test_addresses.py
@@ -51,7 +51,7 @@ def test_b58_valid_addresses():
                 net = "testnet"
             else:
                 net = "mainnet"
-            #if using py.test -s ; sanity check to see what's actually being tested
+            #if using pytest -s ; sanity check to see what's actually being tested
             print 'testing this address: ' + addr
             res, message = validate_address(addr, net)
             assert res == True, "Incorrectly failed to validate address: " + addr + " with message: " + message

--- a/jmbitcoin/test/test_keys.py
+++ b/jmbitcoin/test/test_keys.py
@@ -46,7 +46,7 @@ def test_wif_privkeys_invalid():
     for k in invalid_key_list:
         bad_key = k[0]
         for netval in ["mainnet", "testnet"]:
-            #if using py.test -s ; sanity check to see what's actually being tested
+            #if using pytest -s ; sanity check to see what's actually being tested
             print 'testing this key: ' + bad_key
             #should throw exception
             with pytest.raises(Exception) as e_info:

--- a/jmclient/test/test_valid_addresses.py
+++ b/jmclient/test/test_valid_addresses.py
@@ -33,7 +33,7 @@ def test_b58_valid_addresses():
                 jm_single().config.set("BLOCKCHAIN", "network", "testnet")
             else:
                 jm_single().config.set("BLOCKCHAIN", "network", "mainnet")
-            #if using py.test -s ; sanity check to see what's actually being tested
+            #if using pytest -s ; sanity check to see what's actually being tested
             print('testing this address: ', addr)
             res, message = validate_address(addr)
             assert res == True, "Incorrectly failed to validate address: " + addr + " with message: " + message

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -45,7 +45,7 @@ run_jm_tests ()
     cp -f ./test/bitcoin.conf "${jm_test_datadir}/bitcoin.conf"
     ${orig_umask}
     echo "datadir=${jm_test_datadir}" >> "${jm_test_datadir}/bitcoin.conf"
-    python -m py.test ${HAS_JOSH_K_SEAL_OF_APPROVAL+--cov=jmclient --cov=jmbitcoin --cov=jmbase --cov=jmdaemon --cov-report html} --btcpwd=123456abcdef --btcconf=${jm_test_datadir}/bitcoin.conf --btcuser=bitcoinrpc --nirc=2 -p no:warnings -k "not configure"
+    python -m pytest ${HAS_JOSH_K_SEAL_OF_APPROVAL+--cov=jmclient --cov=jmbitcoin --cov=jmbase --cov=jmdaemon --cov-report html} --btcpwd=123456abcdef --btcconf=${jm_test_datadir}/bitcoin.conf --btcuser=bitcoinrpc --nirc=2 -p no:warnings -k "not configure"
     local success="$?"
     unlink ./joinmarket.cfg
     if read bitcoind_pid <"${jm_test_datadir}/bitcoind.pid"; then

--- a/test/ygrunner.py
+++ b/test/ygrunner.py
@@ -7,7 +7,7 @@ from __future__ import absolute_import, print_function
    makes it much easier to handle start up and
    shut down of the environment.
    Run it like:
-   PYTHONPATH=.:$PYTHONPATH py.test \
+   PYTHONPATH=.:$PYTHONPATH pytest \
    --btcroot=/path/to/bitcoin/bin/ \
    --btcpwd=123456abcdef --btcconf=/blah/bitcoin.conf \
    --nirc=2 -s test/ygrunner.py


### PR DESCRIPTION
The `py.test` syntax is deprecated and should not be used.