### PR TITLE
Add miniircd.tar.gz to gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ deps/
 jmvenv/
 logs/
 miniircd/
+miniircd.tar.gz
 nums_basepoints.txt
 schedulefortesting
 scripts/commitmentlist


### PR DESCRIPTION
Seems this sometimes gets left around when running tests.