### PR TITLE
Use gpg for fetching keys from key servers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ install:
   - mkdir -p "$HOME/downloads"
   - mkdir -p "$TRAVIS_BUILD_DIR/deps/cache/"
   - find "$HOME/downloads" -type f -exec cp -v {} "$TRAVIS_BUILD_DIR/deps/cache/" \;
-  - on_host ./install.sh --develop --no-gpg-validation
+  - on_host ./install.sh --develop
   - on_host find "$TRAVIS_BUILD_DIR/deps/cache/" -type f -exec cp -v {} "$HOME/downloads/" \;
 before_script:
   - on_host source jmvenv/bin/activate


### PR DESCRIPTION
Use `--recv-keys` for fetching a key, and `--list-keys` for testing whether a key is already in our keyring.
Currently two key servers are checked one after the other, and if the first has the key then the second is skipped.
The second commit re-enables pgp signature validation for dependencies on travis, which I'm guessing should be safer now (`curl`ing the key was flaky at times), but I can remove it if it's an unwanted change.