### PR TITLE
Remove utxos from proposed transaction if spent or invalid

### DIFF
--- a/jmclient/jmclient/taker.py
+++ b/jmclient/jmclient/taker.py
@@ -359,8 +359,8 @@ class Taker(object):
             if None in utxo_data:
                 jlog.warn(('ERROR outputs unconfirmed or already spent. '
                            'utxo_data={}').format(pprint.pformat(utxo_data)))
-                # when internal reviewing of makers is created, add it here to
-                # immediately quit; currently, the timeout thread suffices.
+                jlog.warn('Disregarding this counterparty.')
+                del self.utxos[nick]
                 continue
 
             #Complete maker authorization:


### PR DESCRIPTION
Previous to this patch, if an already-spent utxo was proposed
by a counterparty, the counterparty would be removed from the
proposed transaction but the input (utxo) would not, meaning
that the transaction would contain inputs for which signatures
were never going to be provided; these transactions simply time
out. This was not, of course, intended behaviour, it was intended
that the transaction would complete with the valid utxos from the
other counterparties. That's what this patch does.