### PR TITLE
Replace secp256k1-py with coincurve

### DIFF
--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -24,7 +24,7 @@ is actually newer in version number, than what was there already.
 
 To install everything (client and server), install these packages:
 
-    sudo apt-get install python-dev python-pip git build-essential automake pkg-config libtool libffi-dev libssl-dev
+    sudo apt-get install python-dev python-pip git build-essential automake pkg-config libtool libffi-dev libssl-dev libgmp-dev
 
 (+ `libsodium-dev` if you can find it, else build after)
 

--- a/install.sh
+++ b/install.sh
@@ -14,7 +14,7 @@ sha256_verify ()
 deps_install ()
 {
     if [[ ${install_os} == 'debian' ]]; then
-        if deb_deps_install "python-virtualenv curl python-dev python-pip build-essential automake pkg-config libtool"; then
+        if deb_deps_install "python-virtualenv curl python-dev python-pip build-essential automake pkg-config libtool libgmp-dev"; then
             return 0
         else
             return 1
@@ -204,7 +204,7 @@ libffi_install ()
     popd
 }
 
-libsecp256k1-py_build ()
+coincurve_build ()
 {
     if [[ -d "${jm_deps}/secp256k1-${secp256k1_version}" ]]; then
         unlink ./libsecp256k1
@@ -216,19 +216,19 @@ libsecp256k1-py_build ()
     return "$?"
 }
 
-secp256k1-py_install ()
+coincurve_install ()
 {
-    secp256k1_py_version='0.13.2.4'
-    secp256k1_py_lib_tar="${secp256k1_py_version}.tar.gz"
-    secp256k1_py_lib_sha='f7920b1b887fe6745c49aebea40cefe867adddf11eb2c164624f1f2729f74657'
-    secp256k1_py_url='https://github.com/ludbb/secp256k1-py/archive'
+    coincurve_version='9.0.0'
+    coincurve_lib_tar="${coincurve_version}.tar.gz"
+    coincurve_lib_sha='81561e954b4a978231e6611ae6153740bfbaebb214caff7a7b4e71fe9affbe09'
+    coincurve_url='https://github.com/ofek/coincurve/archive'
 
-    rm -rf "./secp256k1-py-${secp256k1_py_version}"
-    if ! dep_get "${secp256k1_py_lib_tar}" "${secp256k1_py_lib_sha}" "${secp256k1_py_url}"; then
+    rm -rf "./coincurve-${coincurve_version}"
+    if ! dep_get "${coincurve_lib_tar}" "${coincurve_lib_sha}" "${coincurve_url}"; then
         return 1
     fi
-    pushd "secp256k1-py-${secp256k1_py_version}"
-    if ! libsecp256k1-py_build; then
+    pushd "coincurve-${coincurve_version}"
+    if ! coincurve_build; then
         return 1
     fi
     popd
@@ -250,7 +250,7 @@ libsecp256k1_install ()
     if ! dep_get "${secp256k1_lib_tar}" "${secp256k1_lib_sha}" "${secp256k1_url}"; then
         return 1
     fi
-    if ! secp256k1-py_install; then
+    if ! coincurve_install; then
         return 1
     fi
 }

--- a/jmbitcoin/jmbitcoin/__init__.py
+++ b/jmbitcoin/jmbitcoin/__init__.py
@@ -1,4 +1,4 @@
-import secp256k1
+import coincurve as secp256k1
 from jmbitcoin.secp256k1_main import *
 from jmbitcoin.secp256k1_transaction import *
 from jmbitcoin.secp256k1_deterministic import *

--- a/jmbitcoin/setup.py
+++ b/jmbitcoin/setup.py
@@ -9,5 +9,5 @@ setup(name='joinmarketbitcoin',
       author_email='',
       license='GPL',
       packages=['jmbitcoin'],
-      install_requires=['future', 'secp256k1',],
+      install_requires=['future', 'coincurve',],
       zip_safe=False)

--- a/test/Dockerfiles/bionic.Dockerfile
+++ b/test/Dockerfiles/bionic.Dockerfile
@@ -5,7 +5,7 @@ SHELL ["/bin/bash", "-c"]
 RUN apt-get update
 RUN apt-get install -y build-essential
 RUN apt-get install -y \
-    automake pkg-config libtool
+    automake pkg-config libtool libgmp-dev
 RUN apt-get install -y \
     python-dev python-pip python-virtualenv python-qt4 python-sip
 

--- a/test/Dockerfiles/centos7.Dockerfile
+++ b/test/Dockerfiles/centos7.Dockerfile
@@ -6,7 +6,7 @@ RUN yum -y groups install 'Development tools'
 RUN yum -y install epel-release && \
     yum -y update
 RUN yum -y install \
-    python-devel python2-pip python-virtualenv
+    python-devel python2-pip python-virtualenv gmp-devel
 
 RUN useradd --home-dir /home/chaum --create-home --shell /bin/bash --skel /etc/skel/ chaum
 ARG core_version

--- a/test/Dockerfiles/fedora27.Dockerfile
+++ b/test/Dockerfiles/fedora27.Dockerfile
@@ -5,7 +5,7 @@ SHELL ["/bin/bash", "-c"]
 RUN dnf -y groups install 'Development tools'
 RUN dnf -y install \
     autoconf libtool pkgconfig \
-    python-devel python-pip python2-virtualenv
+    python-devel python-pip python2-virtualenv gmp-devel
 
 # needed for build time
 # https://stackoverflow.com/questions/34624428/g-error-usr-lib-rpm-redhat-redhat-hardened-cc1-no-such-file-or-directory

--- a/test/Dockerfiles/stretch.Dockerfile
+++ b/test/Dockerfiles/stretch.Dockerfile
@@ -5,7 +5,7 @@ SHELL ["/bin/bash", "-c"]
 RUN apt-get update
 RUN apt-get install -y build-essential
 RUN apt-get install -y \
-    automake pkg-config libtool
+    automake pkg-config libtool libgmp-dev
 RUN apt-get install -y \
     python-dev python-pip python-virtualenv python-qt4 python-sip
 

--- a/test/Dockerfiles/xenial.Dockerfile
+++ b/test/Dockerfiles/xenial.Dockerfile
@@ -5,7 +5,7 @@ SHELL ["/bin/bash", "-c"]
 RUN apt-get update
 RUN apt-get install -y build-essential
 RUN apt-get install -y \
-    automake pkg-config libtool
+    automake pkg-config libtool libgmp-dev
 RUN apt-get install -y \
     python-dev python-pip python-virtualenv python-qt4 python-sip
 


### PR DESCRIPTION
This is pretty much a drop in replacement other than some minor syntax differences. The coincurve secp256k1 bindings are better maintained than the secp256k1-py bindings.