### PR TITLE
clean up and re-enable test_configure

### DIFF
--- a/jmclient/test/test_configure.py
+++ b/jmclient/test/test_configure.py
@@ -1,4 +1,3 @@
-#! /usr/bin/env python
 from __future__ import absolute_import
 '''test configure module.'''
 
@@ -6,7 +5,7 @@ import pytest
 from jmclient import load_program_config, jm_single, get_irc_mchannels
 from jmclient.configure import (get_config_irc_channel, get_p2sh_vbyte,
                                 get_p2pk_vbyte, get_blockchain_interface_instance)
-import os
+
 
 def test_attribute_dict():
     from jmclient.configure import AttributeDict
@@ -16,21 +15,15 @@ def test_attribute_dict():
     assert ad.baz.x == 3
     assert ad["foo"] == 1
 
-def test_load_config():
+
+def test_load_config(tmpdir):
     load_program_config(bs="regtest")
-    os.makedirs("dummydirforconfig")
-    ncp = os.path.join(os.getcwd(), "dummydirforconfig")
     jm_single().config_location = "joinmarket.cfg"
-    #TODO hack: load from default implies a connection error unless
-    #actually mainnet, but tests cannot; for now catch the connection error
-    with pytest.raises(Exception) as e_info:
-        load_program_config(config_path=ncp, bs="regtest")
-    assert str(e_info.value) in ["[Errno 111] Connection refused", "authentication for JSON-RPC failed",
-                                 "JSON-RPC connection failed. Err:error(111, 'Connection refused')"]
-    os.remove("dummydirforconfig/joinmarket.cfg")
-    os.removedirs("dummydirforconfig")
+    with pytest.raises(SystemExit):
+        load_program_config(config_path=str(tmpdir), bs="regtest")
     jm_single().config_location = "joinmarket.cfg"
     load_program_config()
+
 
 def test_config_get_irc_channel():
     load_program_config()
@@ -41,10 +34,12 @@ def test_config_get_irc_channel():
     get_irc_mchannels()
     load_program_config()
 
+
 def test_net_byte():
     load_program_config()
     assert get_p2pk_vbyte() == 0x6f
     assert get_p2sh_vbyte() == 196
+
 
 def test_blockchain_sources():
     load_program_config()
@@ -58,8 +53,3 @@ def test_blockchain_sources():
         else:
             get_blockchain_interface_instance(jm_single().config)
     load_program_config()
-
-        
-
-        
-    

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -45,7 +45,7 @@ run_jm_tests ()
     cp -f ./test/bitcoin.conf "${jm_test_datadir}/bitcoin.conf"
     ${orig_umask}
     echo "datadir=${jm_test_datadir}" >> "${jm_test_datadir}/bitcoin.conf"
-    python -m pytest ${HAS_JOSH_K_SEAL_OF_APPROVAL+--cov=jmclient --cov=jmbitcoin --cov=jmbase --cov=jmdaemon --cov-report html} --btcpwd=123456abcdef --btcconf=${jm_test_datadir}/bitcoin.conf --btcuser=bitcoinrpc --nirc=2 -p no:warnings -k "not configure" --ignore test/test_full_coinjoin.py
+    python -m pytest ${HAS_JOSH_K_SEAL_OF_APPROVAL+--cov=jmclient --cov=jmbitcoin --cov=jmbase --cov=jmdaemon --cov-report html} --btcpwd=123456abcdef --btcconf=${jm_test_datadir}/bitcoin.conf --btcuser=bitcoinrpc --nirc=2 -p no:warnings --ignore test/test_full_coinjoin.py
     local success="$?"
     unlink ./joinmarket.cfg
     if read bitcoind_pid <"${jm_test_datadir}/bitcoind.pid"; then


### PR DESCRIPTION
test_configure was disabled in #146 but fixed in #149 and never re-enabled.

It broke again on 0d7a91ff6a8fb7ecfa7cd766808c8a116213c87c

This PR cleans up, fixes and re-enables the test.