### PR TITLE
generic exception handler

### DIFF
--- a/jmbase/jmbase/support.py
+++ b/jmbase/jmbase/support.py
@@ -7,7 +7,9 @@ import sys
 
 import logging
 import pprint
+import traceback
 from getpass import getpass
+from functools import wraps
 
 logFormatter = logging.Formatter(
     "%(asctime)s [%(threadName)-12.12s] [%(levelname)-5.5s]  %(message)s")
@@ -76,3 +78,16 @@ def debug_dump_object(obj, skip_fields=None):
             log.debug(pprint.pformat(v))
         else:
             log.debug(str(v))
+
+
+def log_exception(f, response=None):
+    @wraps(f)
+    def wrapper(*a, **kw):
+        try:
+            return f(*a, **kw)
+        except Exception:
+            log.critical("Unhandled exception in {}".format(f.__name__))
+            traceback.print_exc()
+            return response
+
+    return wrapper


### PR DESCRIPTION
This adds generic exception handler to prevent crashes in maker and taker, hopefully preventing most (if not all) maker DoS attacks. If such an exception is caught it is logged and the trace printed to stderr but everything will continue running as normal.

This should prevent crashes on bugs such as 66875aed6e1596cec3eac5323eddabc45e3bafb2 and #226 and probably even #105 and also the one recently discussed on irc.

I have successfully tested this on testnet.