### PR TITLE
fix possible crash on tx with odd scripts

### DIFF
--- a/jmclient/jmclient/blockchaininterface.py
+++ b/jmclient/jmclient/blockchaininterface.py
@@ -837,9 +837,13 @@ class BitcoinCoreInterface(BlockchainInterface):
             if ret is None:
                 result.append(None)
             else:
+                if ret['scriptPubKey'].get('addresses'):
+                    address = ret['scriptPubKey']['addresses'][0]
+                else:
+                    address = None
                 result_dict = {'value': int(Decimal(str(ret['value'])) *
                                             Decimal('1e8')),
-                               'address': ret['scriptPubKey']['addresses'][0],
+                               'address': address,
                                'script': ret['scriptPubKey']['hex']}
                 if includeconf:
                     result_dict['confirms'] = int(ret['confirmations'])

--- a/jmclient/jmclient/commitment_utils.py
+++ b/jmclient/jmclient/commitment_utils.py
@@ -56,7 +56,7 @@ def validate_utxo_data(utxo_datas, retrieve=False, segwit=False):
             return False
         if res[0]['address'] != addr:
             print("privkey corresponds to the wrong address for utxo: " + str(u))
-            print("blockchain returned address: " + res[0]['address'])
+            print("blockchain returned address: {}".format(res[0]['address']))
             print("your privkey gave this address: " + addr)
             return False
         if retrieve:


### PR DESCRIPTION
When faced with a transaction that includes an unusual output script which cannot be matched to a valid bitcoin address, `BitcoinCoreInterface.query_utxo_set()` will raise an `IndexError`.

This can be exploited to crash a maker.