### PR TITLE
Fix bugs in bigstring and test_commands

### DIFF
--- a/jmbase/jmbase/bigstring.py
+++ b/jmbase/jmbase/bigstring.py
@@ -43,7 +43,7 @@ class BigString(amp.Argument):
             nextChunk = value.read(CHUNK_MAX)
             if not nextChunk:
                 break
-            strings["%s.%d" % (name, counter)] = nextChunk
+            strings["{}.{}".format(name, counter).encode('ascii')] = nextChunk
             counter += 1
 
     def fromvalue(self, value):

--- a/jmbase/test/test_commands.py
+++ b/jmbase/test/test_commands.py
@@ -66,8 +66,8 @@ class JMTestServerProtocol(JMBaseProtocol):
         return {'accepted': True}
 
     @JMSetup.responder
-    def on_JM_SETUP(self, role, n_counterparties):
-        show_receipt("JMSETUP", role,n_counterparties)
+    def on_JM_SETUP(self, role, initdata):
+        show_receipt("JMSETUP", role, initdata)
         d = self.callRemote(JMSetupDone)
         self.defaultCallbacks(d)
         return {'accepted': True}
@@ -157,7 +157,7 @@ class JMTestClientProtocol(JMBaseProtocol):
         show_receipt("JMUP")
         d = self.callRemote(JMSetup,
                             role="TAKER",
-                            n_counterparties=4) #TODO this number should be set
+                            initdata="none")
         self.defaultCallbacks(d)
         return {'accepted': True}
 


### PR DESCRIPTION
The keys created in the bigstring.py module in case of message
length greater than 65535 were unicode and this was unsupported
by amp.py, this fixes the key to be ascii.
Additionally the tests in test_commands.py were failing silently
due to an unupgraded command syntax in JM_SETUP, it's now upgraded
and now tests, as originally, the large orderbook case, which now
passes due to the previously mentioned bugfix in bigstring for the
new Py3 compatibilty mode (builtins).