### PR TITLE
display[all] extended usage status

### DIFF
--- a/scripts/joinmarket-qt.py
+++ b/scripts/joinmarket-qt.py
@@ -1093,7 +1093,7 @@ class JMWalletTab(QWidget):
                     for j in range(len(rows[i][forchange])):
                         item = QTreeWidgetItem(rows[i][forchange][j])
                         item.setFont(0, QFont(MONOSPACE_FONT))
-                        if rows[i][forchange][j][3] == 'used':
+                        if rows[i][forchange][j][3] != 'new':
                             item.setForeground(3, QBrush(QColor('red')))
                         seq_item.addChild(item)
 


### PR DESCRIPTION
This PR extends the usage status shown in wallet-tool's `display[all]` method.

Previously only the status `new`, `used` and `empty` (for imported addresses) was used. This PR retrieves and shows additional status information for addresses that previously only showed `used` and have unspent outputs.

Instead of `used` this will show one of the following values for such addresses:
* `cj-out` for coinjoin outputs
* `cj-change` for coinjoin change outputs
* `deposit` for non-coinjoin outputs
* `reused` if there is more than one unspent output

To implement this some slight refactoring was done because related functionality was already implemented in the `wallet_fetch_history` function. This was extracted into the `get_tx_info` function.

note: I looked at the `joinmarket-qt` code and this did not appear to cause any issues there, but I have not tested the code with `joinmarket-qt`