### PR TITLE
Convert JoinmarketQt to PySide2, qt5reactor

### DIFF
--- a/jmclient/setup.py
+++ b/jmclient/setup.py
@@ -9,5 +9,7 @@ setup(name='joinmarketclient',
       author_email='',
       license='GPL',
       packages=['jmclient'],
-      install_requires=['future', 'configparser;python_version<"3.2"', 'joinmarketbase==0.4.2', 'mnemonic', 'qt4reactor', 'argon2_cffi', 'bencoder.pyx', 'pyaes'],
+      install_requires=['future', 'configparser;python_version<"3.2"',
+                        'joinmarketbase==0.4.2', 'mnemonic', 'argon2_cffi',
+                        'bencoder.pyx', 'pyaes'],
       zip_safe=False)


### PR DESCRIPTION
As per title.

Seems to be working in most functions, as I've tested in Python2 and 3 on regtest, except a rather important bug: it seems that the tumbler repeatably, but non-deterministically (haven't yet seen a pattern, happens "somewhere" in the run) segfaults the Qt app. Doesn't *seem* to happen in Python3, but obviously can't guarantee it.

I'll do a few tests on mainnet now to establish whether there are any further bugs in wallet handling there (since it uses some different code etc.).

For this unfortunate segfault issue, it's going to be hard; I can only wonder if it might have something to do with threading, as an earlier crash problem in Py2/PyQt4 ended up being to do with that; I found it could be fixed using pyqt4reactor and ensuring there was no threading used anywhere. But I could be totally off base there. Any suggestions on a good way to debug and find out the cause would be appreciated.

W.r.t. installation, for now I've just put `PySide2` into the jmclient setup.py; I've found `pip install PySide2` to be working fine on both Py2 and Py3, so I *guess* that's enough?