### PR TITLE
fix crash on IRC notice with non-ascii characters

### DIFF
--- a/jmdaemon/jmdaemon/irc.py
+++ b/jmdaemon/jmdaemon/irc.py
@@ -19,11 +19,20 @@ log = get_log()
 def wlog(*x):
     """Simplifier to add lists to the debug log
     """
+    def conv(s):
+        # note: this only works because of the future package
+        if isinstance(s, str):
+            return s
+        elif isinstance(s, bytes):
+            return s.decode('utf-8', errors='ignore')
+        else:
+            return str(s)
+
     if x[0] == "WARNING":
-        msg = " ".join([str(a) for a in x[1:]])
+        msg = " ".join([conv(a) for a in x[1:]])
         log.warn(msg)
     else:
-        msg = " ".join([str(a) for a in x])
+        msg = " ".join([conv(a) for a in x])
         log.debug(msg)
 
 def get_irc_text(line):


### PR DESCRIPTION
When receiving a notice on IRC that includes common formatting codes bytes or other non-ascii characters the daemon will crash.

crash trace:

	Unhandled Error
	Traceback (most recent call last):
	  File "/lib/python2.7/site-packages/twisted/protocols/policies.py", line 120, in dataReceived
	    self.wrappedProtocol.dataReceived(data)
	  File "/lib/python2.7/site-packages/twisted/words/protocols/irc.py", line 2631, in dataReceived
	    basic.LineReceiver.dataReceived(self, data)
	  File "/lib/python2.7/site-packages/twisted/protocols/basic.py", line 572, in dataReceived
	    why = self.lineReceived(line)
	  File "/lib/python2.7/site-packages/twisted/words/protocols/irc.py", line 2644, in lineReceived
	    self.handleCommand(command, prefix, params)
	--- <exception caught here> ---
	  File "/lib/python2.7/site-packages/twisted/words/protocols/irc.py", line 2699, in handleCommand
	    method(prefix, params)
	  File "/lib/python2.7/site-packages/twisted/words/protocols/irc.py", line 2076, in irc_NOTICE
	    self.noticed(user, channel, message)
	  File "jmdaemon/jmdaemon/irc.py", line 405, in noticed
	    wlog('(unhandled) noticed: ', user, channel, message)
	  File "jmdaemon/jmdaemon/irc.py", line 26, in wlog
	    msg = " ".join([str(a) for a in x])
	  File "/lib/python2.7/site-packages/future/types/newstr.py", line 102, in __new__
	    return super(newstr, cls).__new__(cls, value)
	exceptions.UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 60: ordinal not in range(128)