### PR TITLE
adapt install.sh for Qt with python3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,6 @@ matrix:
              key_url: 'http://keyserver.ubuntu.com:11371/pks/lookup?op=get&search=0xD46F45428842CE5E'
            packages:
              - bitcoind
-             - python-qt4 python-sip
     - os: linux
       services: docker
       env: DOCKER_IMG_JM=xenial-py2
@@ -55,7 +54,7 @@ install:
   - mkdir -p "$HOME/downloads"
   - mkdir -p "$TRAVIS_BUILD_DIR/deps/cache/"
   - find "$HOME/downloads" -type f -exec cp -v {} "$TRAVIS_BUILD_DIR/deps/cache/" \;
-  - on_host ./install.sh --develop
+  - on_host ./install.sh --develop --python=python3 --with-qt
   - on_host find "$TRAVIS_BUILD_DIR/deps/cache/" -type f -exec cp -v {} "$HOME/downloads/" \;
 before_script:
   - on_host source jmvenv/bin/activate

--- a/README.md
+++ b/README.md
@@ -26,6 +26,12 @@ Once you've downloaded this repo, either as a zip file, and extracted it, or via
 
 (You can omit `-p python3` if you want to use Python2. You can also add `--develop` as an extra flag to `install.sh` to make the Joinmarket code editable in-place.)
 
+For the Qt GUI, pass the `--with-qt` flag to `install.sh` as well :
+
+    ./install.sh -p python3 --with-qt
+
+Do note, Python 2 is incompatible with the Qt GUI.
+
 You should now be able to run the scripts like `python wallet-tool.py` etc., just as you did in the previous Joinmarket version.
 
 Alternative to this "quickstart" (including for MacOS): follow the [install guide](docs/INSTALL.md).
@@ -47,11 +53,11 @@ It's possible but unlikely that the Python2 version will be fixed, but in any ca
 
 If binaries are built, they will be gpg signed and announced on the Releases page.
 
-To run the script `joinmarket-qt.py` from the command line, you need to install two more packages: use these 2 commands:
+If you haven't used the `--with-qt` flag during installation with `install.sh`, then to run the script `joinmarket-qt.py` from the command line you will need to install two more packages.  Use these 2 commands while the `jmvenv` virtual environment is activated:
 
 ```
 pip install PySide2
-pip install git+git://github.com/sunu/qt5reactor.git@58410aaead2185e9917ae9cac9c50fe7b70e4a60
+pip install https://github.com/sunu/qt5reactor/archive/58410aaead2185e9917ae9cac9c50fe7b70e4a60.zip
 ```
 After this, the command `python joinmarket-qt.py` from within the `scripts` subdirectory should work.
 There is a [walkthrough](docs/JOINMARKET-QT-GUIDE.md) for what to do next.

--- a/test/Dockerfiles/bionic-py3.Dockerfile
+++ b/test/Dockerfiles/bionic-py3.Dockerfile
@@ -33,5 +33,5 @@ RUN bitcoind --version | head -1
 
 # install script
 WORKDIR ${repo_name}
-RUN ./install.sh --python=python3
+RUN echo y | ./install.sh --python=python3
 RUN source jmvenv/bin/activate && ./test/run_tests.sh

--- a/test/Dockerfiles/fedora27-py3.Dockerfile
+++ b/test/Dockerfiles/fedora27-py3.Dockerfile
@@ -32,5 +32,5 @@ RUN bitcoind --version | head -1
 
 # install script
 WORKDIR ${repo_name}
-RUN ./install.sh --python=python3
+RUN echo y | ./install.sh --python=python3
 RUN source jmvenv/bin/activate && ./test/run_tests.sh

--- a/test/Dockerfiles/stretch-py3.Dockerfile
+++ b/test/Dockerfiles/stretch-py3.Dockerfile
@@ -33,5 +33,5 @@ RUN bitcoind --version | head -1
 
 # install script
 WORKDIR ${repo_name}
-RUN ./install.sh --python=python3
+RUN echo y | ./install.sh --python=python3
 RUN source jmvenv/bin/activate && ./test/run_tests.sh

--- a/test/Dockerfiles/xenial-py3.Dockerfile
+++ b/test/Dockerfiles/xenial-py3.Dockerfile
@@ -33,5 +33,5 @@ RUN bitcoind --version | head -1
 
 # install script
 WORKDIR ${repo_name}
-RUN ./install.sh --python=python3
+RUN echo y | ./install.sh --python=python3
 RUN source jmvenv/bin/activate && ./test/run_tests.sh


### PR DESCRIPTION
* Adds the `--with-qt` flag to `install.sh` - Only valid when `python` is `python3` by default or `-p python3` is used
* Set native travis tests (xenial, osx) to use python3 and install Qt
* Update readme with details about `--with-qt`