### PR TITLE
Fix bug in convert_old_wallet after Py3 upgrade

### DIFF
--- a/scripts/convert_old_wallet.py
+++ b/scripts/convert_old_wallet.py
@@ -51,7 +51,7 @@ def decrypt_entropy_extension(enc_data, key):
 
 
 def decrypt_wallet_data(data, password):
-    key = double_sha256(password.encode('utf-8'))
+    key = double_sha256(password)
 
     enc_entropy = data.get('encrypted_seed') or data.get('encrypted_entropy')
     enc_entropy_ext = data.get('encrypted_mnemonic_extension')


### PR DESCRIPTION
In the Python3 compatibility upgrade, jmbase.support.getpassword
was changed and now returns bytes, therefore the password should
not be utf-8 encoded in the function decrypt_wallet_data. Without
this change, the conversion script errors; this fixes that error.