### PR TITLE
require minimum bencoder.pyx version

### DIFF
--- a/jmclient/setup.py
+++ b/jmclient/setup.py
@@ -11,5 +11,5 @@ setup(name='joinmarketclient',
       packages=['jmclient'],
       install_requires=['future', 'configparser;python_version<"3.2"',
                         'joinmarketbase==0.5.0', 'mnemonic', 'argon2_cffi',
-                        'bencoder.pyx', 'pyaes'],
+                        'bencoder.pyx>=2.0.0', 'pyaes'],
       zip_safe=False)


### PR DESCRIPTION
`bencoder.pyx` prior to 2.0.0 is incompatible with the futures library, leading to the crash reported in #255 

This adds a minimum version requirement.