### PR TITLE
build minimal libsodium

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -288,8 +288,13 @@ libsecp256k1_install ()
 
 libsodium_build ()
 {
+    make uninstall
+    make distclean
     ./autogen.sh
-    ./configure --enable-shared --prefix="${jm_root}"
+    ./configure \
+        --enable-minimal \
+        --enable-shared \
+        --prefix="${jm_root}"
     make uninstall
     make
     if ! make check; then


### PR DESCRIPTION
This change makes the install process build a minimal subset of `libsodium`.  Tests pass so it seems that we can afford to do it, and imo "less is more".
In terms of build time, the difference is only slightly noticable, and in terms of storage it's only a 1.7mb savings.

Also worth to note that the build flow in `install.sh` had to be changed to account for uninstalling and cleaning up an existing `libsodium` build directory, otherwise we get many linker errors.  This means that "upgrading" from full to minimal build works correctly, but going back requires manual deletion of the `./deps/libsodium-1.0.13/` directory and full re-install of the virtualenv.

I ran `nm --defined-only jmvenv/lib/libsodium.so` on each the full and minimal built libraries, and then diff'ed using 
```
diff <(cut -d' ' -f3 sodium.minimal | sort -u) <(cut -d' ' -f3 sodium.full | sort -u)
```

So we can eyeball if anything looks like it's used but for some reason isn't tested.
The result is :

```diff
0a1
> alloc_region
24a26,27
> blockmix_salsa8
> blockmix_salsa8_xor
118a122,142
> crypto_box_curve25519xchacha20poly1305_beforenm
> crypto_box_curve25519xchacha20poly1305_beforenmbytes
> crypto_box_curve25519xchacha20poly1305_detached
> crypto_box_curve25519xchacha20poly1305_detached_afternm
> crypto_box_curve25519xchacha20poly1305_easy
> crypto_box_curve25519xchacha20poly1305_easy_afternm
> crypto_box_curve25519xchacha20poly1305_keypair
> crypto_box_curve25519xchacha20poly1305_macbytes
> crypto_box_curve25519xchacha20poly1305_noncebytes
> crypto_box_curve25519xchacha20poly1305_open_detached
> crypto_box_curve25519xchacha20poly1305_open_detached_afternm
> crypto_box_curve25519xchacha20poly1305_open_easy
> crypto_box_curve25519xchacha20poly1305_open_easy_afternm
> crypto_box_curve25519xchacha20poly1305_publickeybytes
> crypto_box_curve25519xchacha20poly1305_seal
> crypto_box_curve25519xchacha20poly1305_sealbytes
> _crypto_box_curve25519xchacha20poly1305_seal_nonce
> crypto_box_curve25519xchacha20poly1305_seal_open
> crypto_box_curve25519xchacha20poly1305_secretkeybytes
> crypto_box_curve25519xchacha20poly1305_seedbytes
> crypto_box_curve25519xchacha20poly1305_seed_keypair
203a228
> crypto_core_salsa
204a230,239
> crypto_core_salsa2012
> crypto_core_salsa2012_constbytes
> crypto_core_salsa2012_inputbytes
> crypto_core_salsa2012_keybytes
> crypto_core_salsa2012_outputbytes
> crypto_core_salsa208
> crypto_core_salsa208_constbytes
> crypto_core_salsa208_inputbytes
> crypto_core_salsa208_keybytes
> crypto_core_salsa208_outputbytes
381a417,435
> crypto_pwhash_scryptsalsa208sha256
> crypto_pwhash_scryptsalsa208sha256_bytes_max
> crypto_pwhash_scryptsalsa208sha256_bytes_min
> crypto_pwhash_scryptsalsa208sha256_ll
> crypto_pwhash_scryptsalsa208sha256_memlimit_interactive
> crypto_pwhash_scryptsalsa208sha256_memlimit_max
> crypto_pwhash_scryptsalsa208sha256_memlimit_min
> crypto_pwhash_scryptsalsa208sha256_memlimit_sensitive
> crypto_pwhash_scryptsalsa208sha256_opslimit_interactive
> crypto_pwhash_scryptsalsa208sha256_opslimit_max
> crypto_pwhash_scryptsalsa208sha256_opslimit_min
> crypto_pwhash_scryptsalsa208sha256_opslimit_sensitive
> crypto_pwhash_scryptsalsa208sha256_passwd_max
> crypto_pwhash_scryptsalsa208sha256_passwd_min
> crypto_pwhash_scryptsalsa208sha256_saltbytes
> crypto_pwhash_scryptsalsa208sha256_str
> crypto_pwhash_scryptsalsa208sha256_strbytes
> crypto_pwhash_scryptsalsa208sha256_strprefix
> crypto_pwhash_scryptsalsa208sha256_str_verify
439a494,500
> crypto_secretbox_xchacha20poly1305_detached
> crypto_secretbox_xchacha20poly1305_easy
> crypto_secretbox_xchacha20poly1305_keybytes
> crypto_secretbox_xchacha20poly1305_macbytes
> crypto_secretbox_xchacha20poly1305_noncebytes
> crypto_secretbox_xchacha20poly1305_open_detached
> crypto_secretbox_xchacha20poly1305_open_easy
456a518,520
> crypto_shorthash_siphashx24
> crypto_shorthash_siphashx24_bytes
> crypto_shorthash_siphashx24_keybytes
481a546,548
> crypto_sign_edwards25519sha512batch
> crypto_sign_edwards25519sha512batch_keypair
> crypto_sign_edwards25519sha512batch_open
495a563,592
> crypto_stream_aes128ctr
> crypto_stream_aes128ctr_afternm
> crypto_stream_aes128ctr_beforenm
> crypto_stream_aes128ctr_beforenmbytes
> crypto_stream_aes128ctr_keybytes
> crypto_stream_aes128ctr_nacl_add_uint32_big
> crypto_stream_aes128ctr_nacl_and2
> crypto_stream_aes128ctr_nacl_BS0
> crypto_stream_aes128ctr_nacl_BS1
> crypto_stream_aes128ctr_nacl_BS2
> crypto_stream_aes128ctr_nacl_copy2
> crypto_stream_aes128ctr_nacl_EXPB0
> crypto_stream_aes128ctr_nacl_lshift64_littleendian
> crypto_stream_aes128ctr_nacl_M0
> crypto_stream_aes128ctr_nacl_M0SWAP
> crypto_stream_aes128ctr_nacl_or2
> crypto_stream_aes128ctr_nacl_ROTB
> crypto_stream_aes128ctr_nacl_rshift32_littleendian
> crypto_stream_aes128ctr_nacl_rshift64_littleendian
> crypto_stream_aes128ctr_nacl_shufb
> crypto_stream_aes128ctr_nacl_shufd
> crypto_stream_aes128ctr_nacl_SR
> crypto_stream_aes128ctr_nacl_SRM0
> crypto_stream_aes128ctr_nacl_SWAP32
> crypto_stream_aes128ctr_nacl_toggle
> crypto_stream_aes128ctr_nacl_xor2
> crypto_stream_aes128ctr_nacl_xor_rcon
> crypto_stream_aes128ctr_noncebytes
> crypto_stream_aes128ctr_xor
> crypto_stream_aes128ctr_xor_afternm
517a615,624
> crypto_stream_salsa2012
> crypto_stream_salsa2012_keybytes
> crypto_stream_salsa2012_keygen
> crypto_stream_salsa2012_noncebytes
> crypto_stream_salsa2012_xor
> crypto_stream_salsa208
> crypto_stream_salsa208_keybytes
> crypto_stream_salsa208_keygen
> crypto_stream_salsa208_noncebytes
> crypto_stream_salsa208_xor
525a633,638
> crypto_stream_xchacha20
> crypto_stream_xchacha20_keybytes
> crypto_stream_xchacha20_keygen
> crypto_stream_xchacha20_noncebytes
> crypto_stream_xchacha20_xor
> crypto_stream_xchacha20_xor_ic
540a654,655
> decode64_one
> decode64_uint32.constprop.0
552a668
> encode64
554a671,676
> escrypt_free_local
> escrypt_gensalt_r
> escrypt_init_local
> escrypt_kdf_nosse
> escrypt_kdf_sse
> escrypt_r
568a691
> free_region
600a724,725
> PBKDF2_SHA256
> pickparams
641a767
> salsa20_8
706a833
> zero.3221
```
