### PR TITLE
Don't show password when loading wallet in JoinmarketQt

### DIFF
--- a/scripts/joinmarket-qt.py
+++ b/scripts/joinmarket-qt.py
@@ -1359,7 +1359,7 @@ class JMMainWindow(QMainWindow):
                 text, ok = QInputDialog.getText(self,
                                                 'Decrypt wallet',
                                                 'Enter your password:',
-                                                mode=QLineEdit.Password)
+                                                echo=QLineEdit.Password)
                 if not ok:
                     return
                 pwd = str(text).strip()


### PR DESCRIPTION
Wrong parameter name, guess a bug introduced with 8e5826d4ead136eb6073cae6aa56ad4f62f13758.