### PR TITLE
Native segwit support including basic BIP84 wallet.

### DIFF
--- a/jmbitcoin/jmbitcoin/secp256k1_main.py
+++ b/jmbitcoin/jmbitcoin/secp256k1_main.py
@@ -436,6 +436,32 @@ def privkey_to_pubkey(priv, usehex=True):
 privtopub = privkey_to_pubkey
 
 @hexbin
+def is_valid_pubkey(pubkey, usehex, require_compressed=False):
+    """ Returns True if the serialized pubkey is a valid secp256k1
+    pubkey serialization or False if not; returns False for an
+    uncompressed encoding if require_compressed is True.
+    """
+    # sanity check for public key
+    # see https://github.com/bitcoin/bitcoin/blob/master/src/pubkey.h
+    if require_compressed:
+        valid_uncompressed = False
+    elif len(pubkey) == 65 and pubkey[:1] in (b'\x04', b'\x06', b'\x07'):
+        valid_uncompressed = True
+    else:
+        valid_uncompressed = False
+
+    if not ((len(pubkey) == 33 and pubkey[:1] in (b'\x02', b'\x03')) or
+    valid_uncompressed):
+        return False
+    # serialization is valid, but we must ensure it corresponds
+    # to a valid EC point:
+    try:
+        dummy = secp256k1.PublicKey(pubkey)
+    except:
+        return False
+    return True
+
+@hexbin
 def multiply(s, pub, usehex, rawpub=True, return_serialized=True):
     '''Input binary compressed pubkey P(33 bytes)
     and scalar s(32 bytes), return s*P.

--- a/jmclient/jmclient/__init__.py
+++ b/jmclient/jmclient/__init__.py
@@ -14,7 +14,8 @@ from .old_mnemonic import mn_decode, mn_encode
 from .taker import Taker
 from .wallet import (Mnemonic, estimate_tx_fee, WalletError, BaseWallet, ImportWalletMixin,
                      BIP39WalletMixin, BIP32Wallet, BIP49Wallet, LegacyWallet,
-                     SegwitLegacyWallet, UTXOManager, WALLET_IMPLEMENTATIONS)
+                     SegwitWallet, SegwitLegacyWallet, UTXOManager,
+                     WALLET_IMPLEMENTATIONS)
 from .storage import (Argon2Hash, Storage, StorageError,
                       StoragePasswordError, VolatileStorage)
 from .cryptoengine import BTCEngine, BTC_P2PKH, BTC_P2SH_P2WPKH, EngineError

--- a/jmclient/test/commontest.py
+++ b/jmclient/test/commontest.py
@@ -155,10 +155,10 @@ def make_sign_and_push(ins_full,
     binarize_tx(de_tx)
     de_tx = wallet.sign_tx(de_tx, scripts, hashcode=hashcode)
     #pushtx returns False on any error
-    tx = binascii.hexlify(btc.serialize(de_tx)).decode('ascii')
-    push_succeed = jm_single().bc_interface.pushtx(tx)
+    push_succeed = jm_single().bc_interface.pushtx(btc.serialize(de_tx))
     if push_succeed:
-        return btc.txhash(tx)
+        removed = wallet.remove_old_utxos(de_tx)
+        return btc.txhash(btc.serialize(de_tx))
     else:
         return False
 

--- a/test/test_segwit.py
+++ b/test/test_segwit.py
@@ -112,7 +112,6 @@ def test_spend_p2sh_p2wpkh_multi(setup_segwit, wallet_structure, in_amt, amount,
         {'script': binascii.hexlify(change_script).decode('ascii'),
          'value': change_amt}]
     tx = btc.deserialize(btc.mktx(tx_ins, tx_outs))
-    binarize_tx(tx)
 
     # import new addresses to bitcoind
     jm_single().bc_interface.import_addresses(
@@ -125,18 +124,18 @@ def test_spend_p2sh_p2wpkh_multi(setup_segwit, wallet_structure, in_amt, amount,
     for nsw_in_index in o_ins:
         inp = nsw_ins[nsw_in_index][1]
         scripts[nsw_in_index] = (inp['script'], inp['value'])
-    nsw_wallet.sign_tx(tx, scripts)
+    tx = nsw_wallet.sign_tx(tx, scripts)
 
     scripts = {}
     for sw_in_index in segwit_ins:
         inp = sw_ins[sw_in_index][1]
         scripts[sw_in_index] = (inp['script'], inp['value'])
-    sw_wallet.sign_tx(tx, scripts)
+    tx = sw_wallet.sign_tx(tx, scripts)
 
     print(tx)
 
     # push and verify
-    txid = jm_single().bc_interface.pushtx(binascii.hexlify(btc.serialize(tx)).decode('ascii'))
+    txid = jm_single().bc_interface.pushtx(btc.serialize(tx))
     assert txid
 
     balances = jm_single().bc_interface.get_received_by_addr(


### PR DESCRIPTION
* parsing of scripts and addresses of all segwit types.
* ability to verify arbitrary tx inputs for all segwit types.
* simplify mktx syntax (only allow [],[] args)
* add p2wpkh and p2wsh spending test and fixes to sign calls in wallet
* simplify wallet signing calls in cryptoengine
* add p2wpkh engine, add bip84 wallet

(Edit: this has been rebased on #205 now). First, a couple of notes to @undeath specifically: I realise that this may conflict with #205, and it'd be a bit "off" to not address that first. I'm happy to do that, but during the process of putting this together I realised there were a couple of things about the way `cryptoengine` worked that I wasn't happy with (the obvious: re-doing bitcoin signing logic; that's been addressed here). We can discuss the details, but I'll be reading those changes again next, and if I have to just rebase this after, so be it.

Second, to @undeath , please note there's some refactoring in the wallet classes, most particular is creating an intermediate class for purposed-bip32, so that 49 and 84 can avoid code reuse. I guess this part you'll be fine with, in particular it kind of shows off what's good about what you did in the first place here :) But just generally I'm sure you'll have some thoughts on the various changes there (get_script_code may be of interest, too).

Note that new [tests](https://github.com/JoinMarket-Org/joinmarket-clientserver/pull/268/files#diff-ecb9c3bba46f23ba646ddea4f68ea4e6R210) have been added specifically to check the ability to sign, and verify, p2wpkh and p2wsh type utxos; this is not because we have an urgent desire to start using these in Joinmarket, more that it feels like the various paths forward from here should all involve us being able to handle transactions using these different segwit variants, so we kind of need that infrastructure.

Additionally a [BIP84](https://github.com/bitcoin/bips/blob/master/bip-0084.mediawiki) wallet class has been created; it's an exact analogue of BIP49 but for p2wpkh instead of p2sh-p2wpkh as we currently use. So it switches to bech32 addresses instead of '3' p2sh addresses. Note that this has not been implemented anywhere else in the codebase; to get output like [this](https://0bin.net/paste/pInHlajEMDIyyrTH#UT0E-iexwO83KP8pgFI8XPmMCeP4IEUU8klolBltMZJ) you'd have to add a few hack-lines to the wallet creation code (but it's really just like 3 lines, which is cool :) ).

Obviously implementing a BIP84 wallet for users can, and probably will be done later, but it will involve us deciding what path forward we want with respect to Joinmarket wallets. One option is to have multiple wallets from one seed, on the different HD paths; another (not necessarily different) possibility might be having totally mixed-address coinjoins. Sounds complicated, but I'm really not sure. I guess the 'easy' option is to just migrate to p2wpkh at some point, which will be the most space-economical, but as we've observed historically, there are of course costs to migrating.

Finally to state the obvious there are a lot of little edits in tests and so on, some of it due to the new signing and verifying code in `secp256k1_transaction.py` and some of it due to some edits in the wallet and cryptoengine modules.

Also note that I spent some time carefully thinking about how the signature material is passed from maker to taker, and so that code has changed somewhat.

I also added quite a few additional comments; although I think we're still not commented enough in a lot of functions.