### PR TITLE
Improve manually selected tx fee documentation

### DIFF
--- a/jmclient/jmclient/configure.py
+++ b/jmclient/jmclient/configure.py
@@ -169,15 +169,17 @@ segwit = true
 # but don't forget to bump your miner fees!
 merge_algorithm = default
 
-# the fee estimate is based on a projection of how many satoshis
+# The fee estimate is based on a projection of how many satoshis
 # per kB are needed to get in one of the next N blocks, N set here
-# as the value of 'tx_fees'. This estimate is high if you set N=1, 
-# so we choose N=3 for a more reasonable figure,
-# as our default.
+# as the value of 'tx_fees'. This cost estimate is high if you set 
+# N=1, so we choose 3 for a more reasonable figure, as our default.
 # You can also set your own fee/kb: any number higher than 144 will
 # be interpreted as the fee in satoshi per kB that you wish to use
 # example: N=30000 will use 30000 sat/kB as a fee, while N=5
 # will use the estimate from your selected blockchain source
+# Note that there will be a 20% variation around any manually chosen
+# values, so if you set N=10000, it might use any value between
+# 8000 and 12000 for your transactions.
 tx_fees = 3
 
 # For users getting transaction fee estimates over an API,


### PR DESCRIPTION
No code changes. Just clarifying comment, as this lead to an unintentionally low fee for a user today (set 1k sat/kbyte, but ended up with <1k sat, which was then not relayed by bitcoin nodes.....)