### PR TITLE
add help menu to install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -356,11 +356,9 @@ parse_flags ()
             --with-qt)
                 with_qt='1'
                 ;;
-            -?*)
-                echo "warning.  unknown flag : $1" 1>&2
-                ;;
             *)
-                break
+                echo -e "\nUsage: "${0}" [options]\n\nOptions:\n\n--develop       code remains editable in place\n--python, -p    python version: python2 or python3 (default: python2)\n--with-qt       build the Qt GUI (incompatible with python2)\n"
+                exit 1
         esac
         shift
     done

--- a/install.sh
+++ b/install.sh
@@ -357,7 +357,7 @@ parse_flags ()
                 with_qt='1'
                 ;;
             *)
-                echo -e "\nUsage: "${0}" [options]\n\nOptions:\n\n--develop       code remains editable in place\n--python, -p    python version: python2 or python3 (default: python2)\n--with-qt       build the Qt GUI (incompatible with python2)\n"
+                echo -e "\nUsage: "${0}" [options]\n\nOptions:\n\n--develop       code remains editable in place\n--python, -p    python version (default: python2)\n--with-qt       build the Qt GUI (incompatible with python2)\n"
                 exit 1
         esac
         shift

--- a/install.sh
+++ b/install.sh
@@ -356,9 +356,21 @@ parse_flags ()
             --with-qt)
                 with_qt='1'
                 ;;
+            "")
+                break
+                ;;
             *)
-                echo -e "\nUsage: "${0}" [options]\n\nOptions:\n\n--develop       code remains editable in place\n--python, -p    python version (default: python2)\n--with-qt       build the Qt GUI (incompatible with python2)\n"
-                exit 1
+                echo "
+Usage: "${0}" [options]
+
+Options:
+
+--develop       code remains editable in place
+--python, -p    python version (default: python2)
+--with-qt       build the Qt GUI (incompatible with python2)
+"
+                return 1
+                ;;
         esac
         shift
     done


### PR DESCRIPTION
I tried to run the install script yesterday without first checking the readme, and I ended up having to look into the code to find out what options I could add. This PR adds a help menu to the install script which will be presented to the user any time they add any flag which is not supported (including `-h` or `--help`).

I removed the error message about "unknown flag" and replaced it with this menu. IMO this is more helpful. ~~I added an `exit`  after the help menu which some may prefer as `exit 1`.~~

Whoops, looks like I left it `exit 1`. Happy to change it to whichever is preferred.