### PR TITLE
PoC - verify transactions with libbitcoinconsensus

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -335,6 +335,43 @@ joinmarket_install ()
     done
 }
 
+libcon_install ()
+{
+    libcon_version='0.17.1'
+    libcon_ver_pref="bitcoin-${libcon_version}"
+    libcon_lnx_x86_64_tar="${libcon_ver_pref}-x86_64-linux-gnu.tar.gz"
+    libcon_lnx_x86_64_sha='53ffca45809127c9ba33ce0080558634101ec49de5224b2998c489b6d0fc2b17'
+    libcon_osx64_tar="${libcon_ver_pref}-osx64.tar.gz"
+    libcon_osx64_sha='6aa567381b95a20ac96b0b949701b04729a0c5796c320481bfa1db22da25efdb'
+    libcon_url="https://bitcoincore.org/bin/bitcoin-core-${libcon_version}"
+    libcon_file_pref='libbitcoinconsensus'
+
+    if check_skip_build "${core_version}"; then
+        return 0
+    fi
+    if [[ $(uname) == Linux ]]; then
+        libcon_tar="${libcon_lnx_x86_64_tar}"
+        libcon_sha="${libcon_lnx_x86_64_sha}"
+        libcon_file="${libcon_file_pref}.so"
+    elif [[ $(uname) == Darwin ]]; then
+        libcon_tar="${libcon_osx64_tar}"
+        libcon_sha="${libcon_osx64_sha}"
+        libcon_file="${libcon_file_pref}.dylib"
+    fi
+    if ! dep_get "${libcon_tar}" "${libcon_sha}" "${libcon_url}"; then
+        return 1
+    fi
+    pushd "${libcon_ver_pref}"
+    rm -rf "./bin" "./share"
+    if ! [[ -r "./lib/${libcon_file}" ]]; then
+        return 1
+    fi
+    cp -rfv "./lib/" "./include/" "${jm_root}" && \
+    ln -sfv "${jm_root}/lib/${libcon_file}" "${jm_root}/lib/_libbitcoinconsensus.so" && \
+    popd
+}
+
+
 parse_flags ()
 {
     while :; do
@@ -479,6 +516,9 @@ main ()
     if ! libsodium_install; then
         echo "Libsodium was not built. Exiting."
         return 1
+    fi
+    if ! libcon_install; then
+        echo "Libbitcoinconsensus was not installed.  Exiting"
     fi
     popd
     if ! joinmarket_install; then

--- a/jmbitcoin/jmbitcoin/__init__.py
+++ b/jmbitcoin/jmbitcoin/__init__.py
@@ -7,4 +7,4 @@ from jmbitcoin.secp256k1_transaction import *
 from jmbitcoin.secp256k1_deterministic import *
 from jmbitcoin.btscript import *
 from jmbitcoin.bech32 import *
-
+from jmbitcoin.btc_consensus import libcon

--- a/jmbitcoin/jmbitcoin/btc_consensus.py
+++ b/jmbitcoin/jmbitcoin/btc_consensus.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python
+
+from __future__ import print_function
+import binascii
+import ctypes
+from ctypes import byref, c_int64, c_uint
+from getpass import os
+
+SCRIPT_FLAGS = {
+        "VERIFY_NONE": 0,
+        "VERIFY_P2SH": 1 << 0,
+        "VERIFY_DERSIG": 1 << 2,
+        "VERIFY_NULLDUMMY": 1 << 4,
+        "VERIFY_CHECKLOCKTIMEVERIFY": 1 << 9,
+        "VERIFY_CHECKSEQUENCEVERIFY": 1 << 10,
+        "VERIFY_WITNESS": 1 << 11 }
+SCRIPT_FLAGS["VERIFY_ALL"] = 0
+for i, flag in enumerate(SCRIPT_FLAGS): SCRIPT_FLAGS["VERIFY_ALL"] |= SCRIPT_FLAGS[flag]
+
+ERROR_T = [
+        "ERR_OK",
+        "ERR_TX_INDEX",
+        "ERR_TX_SIZE_MISMATCH",
+        "ERR_TX_DESERIALIZE",
+        "ERR_AMOUNT_REQUIRED",
+        "ERR_INVALID_FLAGS" ]
+
+
+class BitcoinConsensus(object):
+    def __init__(self, path):
+        self.l = ctypes.CDLL(path)
+
+    def version(self):
+        return self.l.bitcoinconsensus_version()
+
+    def verify_script(self, scriptPubKey, txTo, nIn, amount=None, flags=SCRIPT_FLAGS["VERIFY_ALL"]):
+        if not isinstance(scriptPubKey, bytes):
+            scriptPubKey = binascii.unhexlify(scriptPubKey)
+        if not isinstance(txTo, bytes):
+            txTo = binascii.unhexlify(txTo)
+        try:
+            err = ctypes.c_uint32()
+            if not amount:
+                self.l.bitcoinconsensus_verify_script(
+                        scriptPubKey,
+                        c_uint(len(scriptPubKey)),
+                        txTo,
+                        c_uint(len(txTo)),
+                        c_uint(nIn),
+                        c_uint(flags),
+                        byref(err))
+            else:
+                self.l.bitcoinconsensus_verify_script_with_amount(
+                        scriptPubKey,
+                        c_uint(len(scriptPubKey)),
+                        c_int64(amount),
+                        txTo,
+                        c_uint(len(txTo)),
+                        c_uint(nIn),
+                        c_uint(flags),
+                        byref(err))
+
+            if ERROR_T[err.value] != "ERR_OK":
+                print("script_verify failed : %s" % ERROR_T[err.value])
+                return False
+
+            return True
+        except Exception as e:
+            print("script_verify exception : %s" % e.repr())
+            return False
+
+    def lib(self):
+        return self.l
+
+if 'VIRTUAL_ENV' not in os.environ:
+    if 'libbitcoinconsensus_so' not in os.environ:
+        raise EnvironmentError("set an environment variable :\n\
+                export libconsensus_so='/path/to/libbitcoinconsensus[.so|.dylib|-0.dll]'")
+    else:
+        libcon_so = os.environ['libbitcoinconsensus_so']
+else:
+    libcon_so = os.path.join(os.environ['VIRTUAL_ENV'], "lib", "_libbitcoinconsensus.so")
+    if not os.path.exists(libcon_so):
+        raise EnvironmentError("libconsensus not found in :\n%s" % libcon_so)
+
+libcon = BitcoinConsensus(libcon_so)
+
+if __name__ == '__main__':
+    print('API version', libcon.version())
+

--- a/jmclient/jmclient/taker.py
+++ b/jmclient/jmclient/taker.py
@@ -767,6 +767,7 @@ class Taker(object):
             amount = self.input_utxos[utxo]['value']
             our_inputs[index] = (script, amount)
         self.latest_tx = self.wallet.sign_tx(self.latest_tx, our_inputs)
+        assert btc.btc_consensus.libcon.verify_script(script, btc.serialize(self.latest_tx), index, amount)
 
     def push(self):
         tx = btc.serialize(self.latest_tx)


### PR DESCRIPTION
This is a proof of concept for using Core's `script_verify` from `libbitcoinconsensus` (`libcon` hereafter) for transaction verification.
Currently we have `verify_tx_input` which is nice, but verifies only a small subset of what makes a transaction's input valid.

Here I used much of the code from this comment : https://github.com/bitcoin/bitcoin/pull/5235#issuecomment-63364052 , which lets us load the library kinda like coincurve does with libsecp.  The library itself exposes only two meaningful operations, `verify_script` and `verify_script_with_amount` (the latter is used for segwit transactions as you can guess).

Since this is just a PoC, I wanted to change only the minimum required in joinmarket, so I only added one `assert` in the `taker::self_sign` function, to verify a transaction at the point where :

1. We know it's final
2. We have the scriptpubkey and amount readily available


I added support to `install.sh` if anybody else wants to play around with it (I know I do at least for the sake of the python bindings by themselves :) ).  I haven't tested on osx but I /think/ it should be fine if I got the filenames right.

If you don't use `install.sh` and virtualenv, you'll have to download a bitcoin core release, grab the `libbitcoinconsensus*` files from the `./lib` directory and point an environment variable `libbitcoinconsensus_so` to the actual library file path.

If we can make use of `libcon`, it might save a bunch of work that's needed on joinmarket for tx verification.

Travis fails in centos7 docker - looks like the os's libraries are too old (but the lib can probably be compiled on the host).