### PR TITLE
Increase timeout waiting for coinjoin TX broadcast

### DIFF
--- a/jmclient/jmclient/configure.py
+++ b/jmclient/jmclient/configure.py
@@ -156,7 +156,7 @@ console_log_level = INFO
 
 [TIMEOUT]
 maker_timeout_sec = 60
-unconfirm_timeout_sec = 90
+unconfirm_timeout_sec = 180
 confirm_timeout_hours = 6
 
 [POLICY]


### PR DESCRIPTION
Noticed (rare) problem on my maker today: it announced a wrong size. Investigating this identified this root cause:

1. a taker was building a big coinjoin with 8+ counterparties and a rather large amount, which meant it had *lots* of inputs
2. Building that TX and receiving all signatures from all makers took longer than the default timeout, that any maker waits for a coinjoin transaction to be broadcast (90 sec). Especially because there's a rate throttling to decrease the load on the IRC servers built in - so the taker intentionally slows down.
3. After around 100 seconds it was indeed broadcast, but the maker was not polling for that TX any more.
4. The TX confirmed. But the maker has no knowledge of this transaction. This means (potentially) he announces amounts that are not correct any more.

This is not a huge problem, but super easy to fix.

Proposed solution: increase timeout. I've checked my logs, I have seen this 'faulty' behavior 3 times in the last 2 months. It always was between 90-130 sec in those cases. Going from 90 sec to 180 should fix this.

Downsides of this change: can't think of any problems with the change. Anyone else?