### PR TITLE
pin coverage+pytest-cov versions, upgrade core to 0.17.1 on docker

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,9 +1,9 @@
 # matplotlib
 # numpy
 pexpect
-coverage
+coverage==4.0.3
 pytest
-pytest-cov
+pytest-cov>=2.4.0,<2.6
 python-coveralls
 mock
 flake8

--- a/test/Dockerfiles/build_docker.sh
+++ b/test/Dockerfiles/build_docker.sh
@@ -15,7 +15,7 @@ build_docker ()
         return 0
     fi
 
-    core_version='0.16.3'
+    core_version='0.17.1'
     core_dist="bitcoin-${core_version}-x86_64-linux-gnu.tar.gz"
     core_url="https://bitcoincore.org/bin/bitcoin-core-${core_version}/${core_dist}"
     libffi_lib_tar='v3.2.1.tar.gz'


### PR DESCRIPTION
Fixes travis errors. (done on top of master)