### PR TITLE
Default to python3 install

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,16 +19,16 @@ Joinmarket is coinjoin software, and includes a wallet, which requires Bitcoin C
 
 Once you've downloaded this repo, either as a zip file, and extracted it, or via `git clone`:
 
-    ./install.sh -p python3
+    ./install.sh
     (follow instructions on screen; provide sudo password when prompted)
     source jmvenv/bin/activate
     cd scripts
 
-(You can omit `-p python3` if you want to use Python2. You can also add `--develop` as an extra flag to `install.sh` to make the Joinmarket code editable in-place.)
+(You can add `-p python2` if you want to use Python2. You can also add `--develop` as an extra flag to `install.sh` to make the Joinmarket code editable in-place.)
 
 For the Qt GUI, pass the `--with-qt` flag to `install.sh` as well :
 
-    ./install.sh -p python3 --with-qt
+    ./install.sh --with-qt
 
 Do note, Python 2 is incompatible with the Qt GUI.
 

--- a/install.sh
+++ b/install.sh
@@ -371,7 +371,7 @@ Usage: "${0}" [options]
 Options:
 
 --develop       code remains editable in place
---python, -p    python version (default: python2)
+--python, -p    python version (default: python3)
 --with-qt       build the Qt GUI (incompatible with python2)
 "
                 return 1
@@ -403,6 +403,9 @@ is_python3 ()
 {
     if [[ ${python} == 'python3' ]]; then
         return 0
+    fi
+    if [[ ${python} == 'python2' ]]; then
+        return 1
     fi
     if eval "${python} -c 'import sys; sys.exit(0) if sys.version_info >= (3,0) else sys.exit(1)'"; then
         return 0
@@ -442,7 +445,7 @@ main ()
     # flags
     develop_build=''
     no_gpg_validation=''
-    python='python2'
+    python='python3'
     with_qt=''
     reinstall='false'
     if ! parse_flags ${@}; then

--- a/test/Dockerfiles/bionic-py2.Dockerfile
+++ b/test/Dockerfiles/bionic-py2.Dockerfile
@@ -33,5 +33,5 @@ RUN bitcoind --version | head -1
 
 # install script
 WORKDIR ${repo_name}
-RUN ./install.sh
+RUN ./install.sh --python=python2
 RUN source jmvenv/bin/activate && ./test/run_tests.sh

--- a/test/Dockerfiles/centos7-py2.Dockerfile
+++ b/test/Dockerfiles/centos7-py2.Dockerfile
@@ -29,5 +29,5 @@ RUN bitcoind --version | head -1
 
 # install script
 WORKDIR ${repo_name}
-RUN ./install.sh
+RUN ./install.sh --python=python2
 RUN source jmvenv/bin/activate && ./test/run_tests.sh

--- a/test/Dockerfiles/fedora27-py2.Dockerfile
+++ b/test/Dockerfiles/fedora27-py2.Dockerfile
@@ -32,5 +32,5 @@ RUN bitcoind --version | head -1
 
 # install script
 WORKDIR ${repo_name}
-RUN ./install.sh
+RUN ./install.sh --python=python2
 RUN source jmvenv/bin/activate && ./test/run_tests.sh

--- a/test/Dockerfiles/stretch-py2.Dockerfile
+++ b/test/Dockerfiles/stretch-py2.Dockerfile
@@ -33,5 +33,5 @@ RUN bitcoind --version | head -1
 
 # install script
 WORKDIR ${repo_name}
-RUN ./install.sh
+RUN ./install.sh --python=python2
 RUN source jmvenv/bin/activate && ./test/run_tests.sh

--- a/test/Dockerfiles/xenial-py2.Dockerfile
+++ b/test/Dockerfiles/xenial-py2.Dockerfile
@@ -33,5 +33,5 @@ RUN bitcoind --version | head -1
 
 # install script
 WORKDIR ${repo_name}
-RUN ./install.sh
+RUN ./install.sh --python=python2
 RUN source jmvenv/bin/activate && ./test/run_tests.sh


### PR DESCRIPTION
I think at this point it now makes sense to have python3 be the default since the GUI works on it but not python2 and there don't seem to be any regressions left.