### PR TITLE
fix wallet-tools display/history crashing on unconfirmed transaction

### DIFF
--- a/jmclient/jmclient/electruminterface.py
+++ b/jmclient/jmclient/electruminterface.py
@@ -535,3 +535,19 @@ class ElectrumInterface(BlockchainInterface):
         if not spentfun or wl[3]:
             return
 
+    def rpc(self, method, args):
+        # FIXME: this is very poorly written code
+        if method == 'gettransaction':
+            assert len(args) == 1
+            return self._gettransaction(args[0])
+        else:
+            raise NotImplementedError(method)
+
+    def _gettransaction(self, txid):
+        # FIXME: this is not complete and only implemented to work with
+        # wallet_utils
+        return {
+            'hex': str(self.get_from_electrum('blockchain.transaction.get',
+                                              txid, blocking=True)
+                       .get('result'))
+        }

--- a/jmclient/jmclient/wallet_utils.py
+++ b/jmclient/jmclient/wallet_utils.py
@@ -323,7 +323,7 @@ def get_tx_info(txid):
     cj_amount = value_freq_list[0][0]
     cj_n = value_freq_list[0][1]
     return is_coinjoin, cj_amount, cj_n, output_script_values,\
-        rpctx['blocktime'], txd
+        rpctx.get('blocktime', 0), txd
 
 
 def get_imported_privkey_branch(wallet, m, showprivkey):


### PR DESCRIPTION
wallet-tools `get_tx_info` assumes that bitcoind's rpc response always contains a `blocktime` key, which leads to crashes on unconfirmed transactions (and possibly other occasions). This error has been corrected.

Additionally, a crude fix for #277 is included.