### PR TITLE
show hostname in logs for signedOn and joined

### DIFF
--- a/jmdaemon/jmdaemon/irc.py
+++ b/jmdaemon/jmdaemon/irc.py
@@ -259,11 +259,11 @@ class txIRC_Client(irc.IRCClient, object):
     # ---------------------------------------------
 
     def signedOn(self):
-        wlog('signedOn:')
+        wlog('signedOn: ', self.hostname)
         self.join(self.factory.channel)
 
     def joined(self, channel):
-        wlog('joined: ', channel)
+        wlog('joined: ', channel, self.hostname)
         #Use as trigger for start to mcc:
         reactor.callLater(0.0, self.wrapper.on_welcome, self.wrapper)
 


### PR DESCRIPTION
I had an issue when the script stalled at the start. I checked the logs, and I find that it had two `signedOn:` messages, but only one `joined:  #joinmarket-pit`. Meaning the script hangs because cannot join to the #joinmarket-pit channel on one of the servers.
This patch helped me to figure it out at which server cannot join to channel.
