### PR TITLE
Log initial offerlist on startup for a Maker

### DIFF
--- a/jmclient/jmclient/maker.py
+++ b/jmclient/jmclient/maker.py
@@ -45,6 +45,7 @@ class Maker(object):
         if not self.offerlist:
             jlog.info("Failed to create offers, giving up.")
             sys.exit(0)
+        jlog.info('offerlist={}'.format(self.offerlist))
 
     def on_auth_received(self, nick, offer, commitment, cr, amount, kphex):
         """Receives data on proposed transaction offer from daemon, verifies


### PR DESCRIPTION
We already output that in `modify_orders()`. I like to see this info on startup too.