### PR TITLE
Fix "AttributeError: 'NoneType' object has no attribute 'replace'" for wallet-tool.py history

### DIFF
--- a/jmbase/jmbase/support.py
+++ b/jmbase/jmbase/support.py
@@ -83,11 +83,12 @@ def jmprint(msg, level="info"):
     if not level in jm_color_map.keys():
         raise Exception("Unsupported formatting")
 
-    # .colorize_message function does a .format() on the string,
-    # which does not work with string-ified json; this should
-    # result in output as intended:
-    msg = msg.replace('{', '{{')
-    msg = msg.replace('}', '}}')
+    if msg is not None:
+        # .colorize_message function does a .format() on the string,
+        # which does not work with string-ified json; this should
+        # result in output as intended:
+        msg = msg.replace('{', '{{')
+        msg = msg.replace('}', '}}')
 
     fmtfn = eval(level)
     print(jm_colorizer.colorize_message(fmtfn(msg)))

--- a/jmclient/jmclient/wallet_utils.py
+++ b/jmclient/jmclient/wallet_utils.py
@@ -825,6 +825,8 @@ def wallet_fetch_history(wallet, options):
     if utxo_count != wallet_utxo_count:
         jmprint(('BUG ERROR: wallet utxo count (%d) does not match utxo count from ' +
             'history (%s)') % (wallet_utxo_count, utxo_count))
+    # wallet-tool.py prints return value, so return empty string instead of None here
+    return ''
 
 
 def wallet_showseed(wallet):


### PR DESCRIPTION
Fix for an error at the end of `wallet-tool.py history` output.
```
Traceback (most recent call last):
  File "wallet-tool.py", line 11, in <module>
    jmprint(wallet_tool_main("wallets"), "success")
  File "XXX/joinmarket-clientserver/jmbase/jmbase/support.py", line 89, in jmprint
    msg = msg.replace('{', '{{')
AttributeError: 'NoneType' object has no attribute 'replace'
```
Bug introduced with c139067be48377dba9d29fc45c1424d199676a9a