### PR TITLE
Add hostid to "On disconnect fired, nicks_seen is now" log message

### DIFF
--- a/jmdaemon/jmdaemon/message_channel.py
+++ b/jmdaemon/jmdaemon/message_channel.py
@@ -394,7 +394,7 @@ class MessageChannelCollection(object):
         self.mc_status[mc] = 2
         self.flush_nicks()
         log.debug("On disconnect fired, nicks_seen is now: " + str(
-            self.nicks_seen))
+            self.nicks_seen) + " " + mc.hostid)
         if not any([x == 1 for x in self.mc_status.values()]):
             if self.on_disconnect:
                 self.on_disconnect()


### PR DESCRIPTION
When there is some bad IRC server in config, this one spams a lot, each few seconds.