### PR TITLE
Reset http connection on EPROTOTYPE errors.

### DIFF
--- a/jmclient/jmclient/jsonrpc.py
+++ b/jmclient/jmclient/jsonrpc.py
@@ -117,6 +117,11 @@ class JsonRpc(object):
                     self.conn.close()
                     self.conn.connect()
                     continue
+                elif e.errno == errno.EPROTOTYPE:
+                    jlog.warn('Connection had protocol wrong type for socket error, attempting reconnect.')
+                    self.conn.close()
+                    self.conn.connect()
+                    continue
                 else:
                     jlog.error('Unhandled connection error ' + str(e))
                     raise e


### PR DESCRIPTION
This should fix these errors on OSX:
```
builtins.OSError: [Errno 41] Protocol wrong type for socket
```
See [here](https://bugs.python.org/issue33450) for more details.