### PR TITLE
Better formatting for a "withdraw" rows in wallet history output

### DIFF
--- a/jmclient/jmclient/wallet_utils.py
+++ b/jmclient/jmclient/wallet_utils.py
@@ -712,7 +712,7 @@ def wallet_fetch_history(wallet, options):
                 tx_type = 'cj withdraw'
                 amount = cj_amount
             else:
-                tx_type = 'withdraw'
+                tx_type = 'withdraw   '
                 #TODO does tx_fee go here? not my_tx_fee only?
                 amount = our_input_value - change_value
                 cj_n = -1


### PR DESCRIPTION
Similar change to #130.

On a related note - history output currently shows PayJoin transactions both at a sender and receiver side as simple "withdraw" transactions. Nothing we can do about it right now, I guess. But in future maybe we could save information about specific transactions being PayJoin send or receive in a wallet file.