### PR TITLE
Support payjoin when daemon run separately (joinmarketd)

### DIFF
--- a/jmclient/jmclient/client_protocol.py
+++ b/jmclient/jmclient/client_protocol.py
@@ -550,6 +550,11 @@ def start_reactor(host, port, factory, ish=True, daemon=False, rs=True,
                     jlog.error("Tried 100 ports but cannot listen on any of them. Quitting.")
                     sys.exit(1)
                 port += 1
+    else:
+        # if daemon run separately, and we do p2ep, we are using
+        # the protocol server at port+1
+        if p2ep:
+            port += 1
     if usessl:
         ctx = ClientContextFactory()
         reactor.connectSSL(host, port, factory, ctx)

--- a/scripts/joinmarketd.py
+++ b/scripts/joinmarketd.py
@@ -6,7 +6,8 @@ from twisted.internet import reactor
 from twisted.python.log import startLogging
 import jmdaemon
 
-def startup_joinmarketd(host, port, usessl, finalizer=None, finalizer_args=None):
+def startup_joinmarketd(host, port, usessl, factories=None,
+                        finalizer=None, finalizer_args=None):
     """Start event loop for joinmarket daemon here.
     Args:
     port : port over which to serve the daemon
@@ -14,9 +15,13 @@ def startup_joinmarketd(host, port, usessl, finalizer=None, finalizer_args=None)
     finalizer_args : arguments to finalizer function.
     """
     startLogging(sys.stdout)
-    factory = jmdaemon.JMDaemonServerProtocolFactory()
-    jmdaemon.start_daemon(host, port, factory, usessl,
-                          './ssl/key.pem', './ssl/cert.pem')
+    if not factories:
+        factories = [jmdaemon.JMDaemonServerProtocolFactory(),
+                     jmdaemon.P2EPDaemonServerProtocolFactory()]
+    for factory in factories:
+        jmdaemon.start_daemon(host, port, factory, usessl,
+                              './ssl/key.pem', './ssl/cert.pem')
+        port += 1
     if finalizer:
         reactor.addSystemEventTrigger("after", "shutdown", finalizer,
                                       finalizer_args)


### PR DESCRIPTION
Prior to this commit, running joinmarketd as an isolated
process only supported serving the Joinmarket protocol;
attempting PayJoin would result in silent failure as the
receiver would reject the !pubkey message.
After this commit, the joinmarketd daemon serves both
protocols with the PayJoin protocol being served at port+1