### PR TITLE
No coins fallback if mixdepth empty

### DIFF
--- a/jmclient/jmclient/maker.py
+++ b/jmclient/jmclient/maker.py
@@ -570,9 +570,8 @@ class P2EPMaker(Maker):
             except Exception:
                 # TODO probably not logical to always sweep here.
                 self.user_info("Sweeping all coins in this mixdepth.")
-                try:
-                    my_utxos = self.wallet.get_utxos_by_mixdepth()[self.mixdepth]
-                except:
+                my_utxos = self.wallet.get_utxos_by_mixdepth()[self.mixdepth]
+                if my_utxos == {}:
                     return self.no_coins_fallback()
         if not_uih2:
             self.user_info("The proposed tx does not trigger UIH2, which "


### PR DESCRIPTION
The code prior to this commit incorrectly only chose the
no-coins fallback in PayJoin on receiver side if the call
to wallet.get_utxos_by_mixdepth()[mixdepth] resulted in a
raised exception, but of course it returns an empty dict,
so after this commit the self.no_coins_fallback is called in
case an empty dict is returned; note that the prior case
still resulted in the same behaviour of publishing a non-CJ
transaction, but now the info messages/prompts are clear.