### PR TITLE
Fix UIH2 avoidance algo when sender input utxo > payment

### DIFF
--- a/jmclient/jmclient/maker.py
+++ b/jmclient/jmclient/maker.py
@@ -563,7 +563,7 @@ class P2EPMaker(Maker):
             # fairly conservative (but guess by necessity).
             fee_for_select = estimate_tx_fee(len(tx['ins']) + 4, 2,
                                              txtype=self.wallet.get_txtype())
-            approx_sum = max_sender_amt - largest_out + fee_for_select
+            approx_sum = max_sender_amt - self.receiving_amount + fee_for_select
             try:
                 my_utxos = self.wallet.select_utxos(self.mixdepth, approx_sum)
                 not_uih2 = True


### PR DESCRIPTION
Prior to this commit, if at least one sender utxo was larger
than the payment amount, the algorithm used by the receiver
to attempt to find coins to avoid triggering the UIH2 condition
was wrong, resulting in UIH2 being triggered where it was not
necessary, in a reasonable fraction of cases. This fixes the
algorithm to be in line with what was written in the linked gist
(see comment to P2EPMaker.on_tx_received).