### PR TITLE
Do not raise exception when privmsg fails

### DIFF
--- a/jmdaemon/jmdaemon/message_channel.py
+++ b/jmdaemon/jmdaemon/message_channel.py
@@ -258,9 +258,18 @@ class MessageChannelCollection(object):
                                      for x in self.available_channels()
                                      if mc == x.hostid]
                 if len(matching_channels) != 1: #pragma: no cover
-                    #raise because implies logic error
-                    raise Exception(
-                        "Tried to privmsg on an unavailable message channel.")
+                    #this can happen if an IRC goes down shortly before a message
+                    #is supposed to be sent. There used to be an exception raise.
+                    #to prevent a crash (especially in makers), we just inform
+                    #the user about it for now
+                    log.error("Tried to communicate on this IRC server but"
+                              "failed: " + str(mc))
+                    log.error("You might have to comment out this IRC server "
+                              "in joinmarket.cfg and restart.")
+                    log.error("No action needed for makers / yield generators!")
+                    # todo: add logic to continue on other available mc
+                    # mind comment in on_order_seen_trigger() when implementing
+                    return
                 mc = matching_channels[0]
                 mc.privmsg(nick, cmd, message)
                 return


### PR DESCRIPTION
This is the first mitigation of issue #105 , so it doesnt crash and prints useful log output for users to handle this issue.
Fixing this problem by switching to another message channel is way more complex.

Will add more info to #105 of what I found out in the last hours.