### PR TITLE
Bugfix crash on unexpected error from gettransaction call.

### DIFF
--- a/jmclient/jmclient/blockchaininterface.py
+++ b/jmclient/jmclient/blockchaininterface.py
@@ -306,7 +306,7 @@ class ElectrumWalletInterface(BlockchainInterface): #pragma: no cover
 
     def estimate_fee_per_kb(self, N):
         if super(ElectrumWalletInterface, self).fee_per_kb_has_been_manually_set(N):
-	     # use a floor of 1000 to not run into node relay problems
+            # use a floor of 1000 to not run into node relay problems
             return int(max(1000, random.uniform(N * float(0.8), N * float(1.2))))
         fee = self.wallet.network.synchronous_get(('blockchain.estimatefee', [N]
                                                   ))
@@ -688,10 +688,12 @@ class BitcoinCoreInterface(BlockchainInterface):
                     res = self.rpc("gettransaction", [tx["txid"], 1])
                 except JsonRpcError as e:
                     #This should never happen (gettransaction is a wallet rpc).
-                    log.info("Failed any gettransaction call")
+                    log.warn("Failed gettransaction call; JsonRpcError")
                     res = None
                 except Exception as e:
-                    log.info(str(e))
+                    log.warn("Failed gettransaction call; unexpected error:")
+                    log.warn(str(e))
+                    res = None
             if not res:
                 continue
             if "confirmations" not in res:


### PR DESCRIPTION
Prior to this commit, if the call to the bitcoin rpc
gettransaction resulted in an exception other than JsonRpcError,
the code would crash as the variable `res` was uninitialized.
This fixes that by always setting res to None in this case, and
also promotes the logging messages for such errors to warning.