### PR TITLE
Fix F632 use ==/!= to compare str, bytes, and int literals flake8 errors

### DIFF
--- a/jmclient/test/test_utxomanager.py
+++ b/jmclient/test/test_utxomanager.py
@@ -81,11 +81,11 @@ def test_utxomanager_select(setup_env_nodeps):
 
     um.add_utxo(txid, index, path, value, mixdepth)
 
-    assert len(um.select_utxos(mixdepth, value)) is 1
-    assert len(um.select_utxos(mixdepth+1, value)) is 0
+    assert len(um.select_utxos(mixdepth, value)) == 1
+    assert len(um.select_utxos(mixdepth+1, value)) == 0
 
     um.add_utxo(txid, index+1, path, value, mixdepth)
-    assert len(um.select_utxos(mixdepth, value)) is 2
+    assert len(um.select_utxos(mixdepth, value)) == 2
 
 
 @pytest.fixture

--- a/scripts/obwatch/ob-watcher.py
+++ b/scripts/obwatch/ob-watcher.py
@@ -212,7 +212,7 @@ class OrderbookPageRequestHeader(http.server.SimpleHTTPRequestHandler):
         else:
             bins = 30
         plt.hist(ordersizes, bins, histtype='bar', rwidth=0.8)
-        if bins is not 30:
+        if bins != 30:
             fig.axes[0].set_xscale('log')
         plt.grid()
         plt.xlabel('Order sizes / btc')


### PR DESCRIPTION
This should fix the current failing tests.