### PR TITLE
Compute addresses entropy

### DIFF
--- a/jmclient/jmclient/blockchaininterface.py
+++ b/jmclient/jmclient/blockchaininterface.py
@@ -31,6 +31,7 @@ def sync_wallet(wallet, fast=False):
         jm_single().bc_interface.sync_wallet(wallet, fast=True)
     else:
         jm_single().bc_interface.sync_wallet(wallet)
+    wallet.clean_storage()
 
 class BlockchainInterface(object):
     __metaclass__ = abc.ABCMeta

--- a/jmclient/jmclient/boltzmann.py
+++ b/jmclient/jmclient/boltzmann.py
@@ -2,6 +2,7 @@ from __future__ import (absolute_import, division,
                         print_function, unicode_literals)
 from builtins import * # noqa: F401
 
+import math
 import numbers
 
 
@@ -61,6 +62,10 @@ class Boltzmann(object):
         self._check_script(script)
 
         return self._rates.get(script, 1)
+
+    def get_entropy(self, script):
+        rate = self.get_rate(script)
+        return math.log2(rate)
 
     def has_script(self, script):
         self._check_script(script)

--- a/jmclient/jmclient/boltzmann.py
+++ b/jmclient/jmclient/boltzmann.py
@@ -75,7 +75,7 @@ class Boltzmann(object):
 
         self._rates[script] = rate
 
-    def boltzmann(self, ins_scripts, outs, cjscript, changescript, amount):
+    def update(self, ins_scripts, outs, cjscript, changescript, amount):
         assert len(ins_scripts)
         assert all([isinstance(x, str) and len(x) for x in ins_scripts])
         assert all([x['script'] and isinstance(x['script'], str) and is_hex(x['script']) for x in outs])

--- a/jmclient/jmclient/boltzmann.py
+++ b/jmclient/jmclient/boltzmann.py
@@ -73,6 +73,9 @@ class Boltzmann(object):
         self._check_script(script)
         assert isinstance(rate, numbers.Integral) and rate > 0
 
+        if self.has_script(script):
+            rate = min(self.get_rate(script), rate)
+
         self._rates[script] = rate
 
     def update(self, ins_scripts, outs, cjscript, changescript, amount):

--- a/jmclient/jmclient/boltzmann.py
+++ b/jmclient/jmclient/boltzmann.py
@@ -50,23 +50,27 @@ class Boltzmann(object):
     def reset(self):
         self._rates = {}
 
+    @staticmethod
+    def _check_script(script):
+        assert isinstance(script, str) and len(script)
+
     def get_rate(self, script):
-        assert isinstance(script, bytes) and len(script)
+        self._check_script(script)
 
         return self._rates.get(script, 1)
 
     def has_script(self, script):
-        assert isinstance(script, bytes) and len(script)
+        self._check_script(script)
 
         return script in self._rates
 
     def remove_script(self, script):
-        assert isinstance(script, bytes) and len(script)
+        self._check_script(script)
 
         return self._rates.pop(script)
 
     def set_rate(self, script, rate):
-        assert isinstance(script, bytes) and len(script)
+        self._check_script(script)
         assert isinstance(rate, numbers.Integral) and rate > 0
 
         self._rates[script] = rate

--- a/jmclient/jmclient/boltzmann.py
+++ b/jmclient/jmclient/boltzmann.py
@@ -47,23 +47,23 @@ class Boltzmann(object):
         self._rates = {}
 
     def get_rate(self, script):
-        assert isinstance(script, bytes)
+        assert isinstance(script, bytes) and len(script)
 
         return self._rates.get(script, 1)
 
     def has_script(self, script):
-        assert isinstance(script, bytes)
+        assert isinstance(script, bytes) and len(script)
 
         return script in self._rates
 
     def remove_script(self, script):
-        assert isinstance(script, bytes)
+        assert isinstance(script, bytes) and len(script)
 
         return self._rates.pop(script)
 
     def set_rate(self, script, rate):
-        assert isinstance(script, bytes)
-        assert isinstance(rate, numbers.Integral)
+        assert isinstance(script, bytes) and len(script)
+        assert isinstance(rate, numbers.Integral) and rate > 0
 
         self._rates[script] = rate
 

--- a/jmclient/jmclient/boltzmann.py
+++ b/jmclient/jmclient/boltzmann.py
@@ -28,6 +28,9 @@ class Boltzmann(object):
         storage.data[cls.STORAGE_KEY] = {}
 
     def _load_storage(self):
+        # Upgrade wallets: without this initialization only new wallets would work
+        if self.STORAGE_KEY not in self.storage.data:
+            self.initialize(self.storage)
         storage = self.storage.data[self.STORAGE_KEY]
         assert isinstance(storage, dict)
         assert all([isinstance(x, bytes) for x in storage.keys()])

--- a/jmclient/jmclient/boltzmann.py
+++ b/jmclient/jmclient/boltzmann.py
@@ -98,3 +98,9 @@ class Boltzmann(object):
         self.set_rate(cjscript, input_rate * mult)
         if changescript:
             self.set_rate(changescript, input_rate)
+
+    def clean(self, current_scripts):
+        scripts = set(current_scripts)
+        for key in list(self._rates.keys()):
+            if key not in scripts:
+                del self._rates[key]

--- a/jmclient/jmclient/boltzmann.py
+++ b/jmclient/jmclient/boltzmann.py
@@ -83,5 +83,12 @@ class Boltzmann(object):
         assert isinstance(cjscript, str) and len(cjscript) and is_hex(cjscript)
         assert isinstance(changescript, str) and len(changescript) and is_hex(changescript) or changescript is None
         assert isinstance(amount, numbers.Integral) and amount > 0
+        assert [x['value'] for x in outs if x['script'] == cjscript] == [amount]
+        assert not changescript or [x['script'] for x in outs].count(changescript) == 1
 
-        # raise NotImplementedError
+        input_rate = min(self.get_rate(x) for x in ins_scripts)
+        mult = [x['value'] for x in outs].count(amount)
+
+        self.set_rate(cjscript, input_rate * mult)
+        if changescript:
+            self.set_rate(changescript, input_rate)

--- a/jmclient/jmclient/boltzmann.py
+++ b/jmclient/jmclient/boltzmann.py
@@ -1,0 +1,71 @@
+from __future__ import (absolute_import, division,
+                        print_function, unicode_literals)
+from builtins import * # noqa: F401
+
+import numbers
+
+
+def _int_to_bytestr(i):
+    return str(i).encode('ascii')
+
+
+class Boltzmann(object):
+    STORAGE_KEY = b'boltzmann'
+
+    def __init__(self, storage):
+        self.storage = storage
+        # {hex_script: int_rate}
+        self._rates = None
+        self._load_storage()
+        assert self._rates is not None
+
+    @classmethod
+    def initialize(cls, storage):
+        storage.data[cls.STORAGE_KEY] = {}
+
+    def _load_storage(self):
+        storage = self.storage.data[self.STORAGE_KEY]
+        assert isinstance(storage, dict)
+        assert all([isinstance(x, bytes) for x in storage.keys()])
+        assert all([isinstance(x, bytes) for x in storage.values()])
+
+        self._rates = {}
+        for script, rate in storage.items():
+            self._rates[script] = int(rate)
+
+    def save(self, write=True):
+        new_data = {}
+        self.storage.data[self.STORAGE_KEY] = new_data
+        for script, rate in self._rates.items():
+            rate = _int_to_bytestr(rate)
+            # storage keys must be bytes()
+            new_data[script] = rate
+        if write:
+            self.storage.save()
+
+    def reset(self):
+        self._rates = {}
+
+    def get_rate(self, script):
+        assert isinstance(script, bytes)
+
+        return self._rates.get(script, 1)
+
+    def has_script(self, script):
+        assert isinstance(script, bytes)
+
+        return script in self._rates
+
+    def remove_script(self, script):
+        assert isinstance(script, bytes)
+
+        return self._rates.pop(script)
+
+    def set_rate(self, script, rate):
+        assert isinstance(script, bytes)
+        assert isinstance(rate, numbers.Integral)
+
+        self._rates[script] = rate
+
+    def boltzmann(self, tx):
+        raise NotImplementedError

--- a/jmclient/jmclient/boltzmann.py
+++ b/jmclient/jmclient/boltzmann.py
@@ -4,6 +4,7 @@ from builtins import * # noqa: F401
 
 import math
 import numbers
+from collections.abc import Iterable
 
 
 def _int_to_bytestr(i):
@@ -105,6 +106,9 @@ class Boltzmann(object):
             self.set_rate(changescript, input_rate)
 
     def clean(self, current_scripts):
+        assert len(current_scripts)
+        assert isinstance(current_scripts, Iterable)
+
         scripts = set(current_scripts)
         for key in list(self._rates.keys()):
             if key not in scripts:

--- a/jmclient/jmclient/boltzmann.py
+++ b/jmclient/jmclient/boltzmann.py
@@ -83,8 +83,8 @@ class Boltzmann(object):
         assert isinstance(cjscript, str) and len(cjscript) and is_hex(cjscript)
         assert isinstance(changescript, str) and len(changescript) and is_hex(changescript) or changescript is None
         assert isinstance(amount, numbers.Integral) and amount > 0
-        assert [x['value'] for x in outs if x['script'] == cjscript] == [amount]
-        assert not changescript or [x['script'] for x in outs].count(changescript) == 1
+        assert amount in [x['value'] for x in outs if x['script'] == cjscript]
+        assert not changescript or [x['script'] for x in outs].count(changescript)
 
         input_rate = min(self.get_rate(x) for x in ins_scripts)
         mult = [x['value'] for x in outs].count(amount)

--- a/jmclient/jmclient/boltzmann.py
+++ b/jmclient/jmclient/boltzmann.py
@@ -9,6 +9,10 @@ def _int_to_bytestr(i):
     return str(i).encode('ascii')
 
 
+def is_hex(s):
+    return len(s) % 2 == 0 and all(['0' <= x <= '9' or 'a' <= x.lower() <= 'f' for x in s])
+
+
 class Boltzmann(object):
     STORAGE_KEY = b'boltzmann'
 
@@ -67,5 +71,13 @@ class Boltzmann(object):
 
         self._rates[script] = rate
 
-    def boltzmann(self, tx):
-        raise NotImplementedError
+    def boltzmann(self, ins_scripts, outs, cjscript, changescript, amount):
+        assert len(ins_scripts)
+        assert all([isinstance(x, str) and len(x) for x in ins_scripts])
+        assert all([x['script'] and isinstance(x['script'], str) and is_hex(x['script']) for x in outs])
+        assert all([x['value'] > 0 for x in outs])
+        assert isinstance(cjscript, bytes) and len(cjscript)
+        assert isinstance(changescript, bytes) and len(changescript) or changescript is None
+        assert isinstance(amount, numbers.Integral) and amount > 0
+
+        # raise NotImplementedError

--- a/jmclient/jmclient/boltzmann.py
+++ b/jmclient/jmclient/boltzmann.py
@@ -35,7 +35,7 @@ class Boltzmann(object):
 
         self._rates = {}
         for script, rate in storage.items():
-            self._rates[script] = int(rate)
+            self._rates[script.decode('ascii')] = int(rate)
 
     def save(self, write=True):
         new_data = {}
@@ -43,7 +43,7 @@ class Boltzmann(object):
         for script, rate in self._rates.items():
             rate = _int_to_bytestr(rate)
             # storage keys must be bytes()
-            new_data[script] = rate
+            new_data[script.encode('ascii')] = rate
         if write:
             self.storage.save()
 

--- a/jmclient/jmclient/boltzmann.py
+++ b/jmclient/jmclient/boltzmann.py
@@ -106,8 +106,11 @@ class Boltzmann(object):
             self.set_rate(changescript, input_rate)
 
     def clean(self, current_scripts):
-        assert len(current_scripts)
         assert isinstance(current_scripts, Iterable)
+
+        # Do not clean if current_scripts is not initialized
+        if not current_scripts:
+            return
 
         scripts = set(current_scripts)
         for key in list(self._rates.keys()):

--- a/jmclient/jmclient/boltzmann.py
+++ b/jmclient/jmclient/boltzmann.py
@@ -76,8 +76,8 @@ class Boltzmann(object):
         assert all([isinstance(x, str) and len(x) for x in ins_scripts])
         assert all([x['script'] and isinstance(x['script'], str) and is_hex(x['script']) for x in outs])
         assert all([x['value'] > 0 for x in outs])
-        assert isinstance(cjscript, bytes) and len(cjscript)
-        assert isinstance(changescript, bytes) and len(changescript) or changescript is None
+        assert isinstance(cjscript, str) and len(cjscript) and is_hex(cjscript)
+        assert isinstance(changescript, str) and len(changescript) and is_hex(changescript) or changescript is None
         assert isinstance(amount, numbers.Integral) and amount > 0
 
         # raise NotImplementedError

--- a/jmclient/jmclient/maker.py
+++ b/jmclient/jmclient/maker.py
@@ -133,6 +133,7 @@ class Maker(object):
         utxos = offerinfo["utxos"]
 
         our_inputs = {}
+        our_scripts = set()
         for index, ins in enumerate(tx['ins']):
             utxo = ins['outpoint']['hash'] + ':' + str(ins['outpoint']['index'])
             if utxo not in utxos:
@@ -140,6 +141,14 @@ class Maker(object):
             script = self.wallet.addr_to_script(utxos[utxo]['address'])
             amount = utxos[utxo]['value']
             our_inputs[index] = (script, amount)
+            our_scripts.add(script)
+
+        # boltzmann data
+        cjscript = self.wallet.addr_to_script(offerinfo['cjaddr'])
+        changescript = self.wallet.addr_to_script(offerinfo['changeaddr'])
+        amount = offerinfo['amount']
+        self.wallet.botlzmann(our_scripts, tx['outs'], cjscript, changescript, amount)
+        self.wallet.save()
 
         txs = self.wallet.sign_tx(btc.deserialize(unhexlify(txhex)), our_inputs)
         for index in our_inputs:

--- a/jmclient/jmclient/maker.py
+++ b/jmclient/jmclient/maker.py
@@ -138,14 +138,14 @@ class Maker(object):
             utxo = ins['outpoint']['hash'] + ':' + str(ins['outpoint']['index'])
             if utxo not in utxos:
                 continue
-            script = self.wallet.addr_to_script(utxos[utxo]['address'])
+            script = btc.address_to_script(utxos[utxo]['address'])
             amount = utxos[utxo]['value']
-            our_inputs[index] = (script, amount)
+            our_inputs[index] = (unhexlify(script), amount)
             our_scripts.add(script)
 
         # boltzmann data
-        cjscript = self.wallet.addr_to_script(offerinfo['cjaddr'])
-        changescript = self.wallet.addr_to_script(offerinfo['changeaddr'])
+        cjscript = btc.address_to_script(offerinfo['cjaddr'])
+        changescript = btc.address_to_script(offerinfo['changeaddr'])
         amount = offerinfo['amount']
         self.wallet.boltzmann(our_scripts, tx['outs'], cjscript, changescript, amount)
         self.wallet.save()

--- a/jmclient/jmclient/maker.py
+++ b/jmclient/jmclient/maker.py
@@ -147,7 +147,7 @@ class Maker(object):
         cjscript = self.wallet.addr_to_script(offerinfo['cjaddr'])
         changescript = self.wallet.addr_to_script(offerinfo['changeaddr'])
         amount = offerinfo['amount']
-        self.wallet.botlzmann(our_scripts, tx['outs'], cjscript, changescript, amount)
+        self.wallet.boltzmann(our_scripts, tx['outs'], cjscript, changescript, amount)
         self.wallet.save()
 
         txs = self.wallet.sign_tx(btc.deserialize(unhexlify(txhex)), our_inputs)

--- a/jmclient/jmclient/taker.py
+++ b/jmclient/jmclient/taker.py
@@ -515,7 +515,7 @@ class Taker(object):
         outputs = self.outputs.copy()
         for output in outputs:
             output['script'] = self.wallet.addr_to_script(output['address'])
-        self.wallet.botlzmann(our_scripts, outputs, cjscript, changescript, self.cjamount)
+        self.wallet.boltzmann(our_scripts, outputs, cjscript, changescript, self.cjamount)
         self.wallet.save()
 
         self.latest_tx = btc.deserialize(tx)

--- a/jmclient/jmclient/taker.py
+++ b/jmclient/jmclient/taker.py
@@ -507,14 +507,14 @@ class Taker(object):
             assert False, 'Invalid utxo: {}'.format(utxo)
 
         our_scripts = {get_script(x) for x in self.input_utxos.values()}
-        cjscript = self.wallet.addr_to_script(self.my_cj_addr)
+        cjscript = btc.address_to_script(self.my_cj_addr)
         if self.my_change_addr:
-            changescript = self.wallet.addr_to_script(self.my_change_addr)
+            changescript = btc.address_to_script(self.my_change_addr)
         else:
             changescript = None
         outputs = self.outputs.copy()
         for output in outputs:
-            output['script'] = self.wallet.addr_to_script(output['address'])
+            output['script'] = btc.address_to_script((output['address']))
         self.wallet.boltzmann(our_scripts, outputs, cjscript, changescript, self.cjamount)
         self.wallet.save()
 

--- a/jmclient/jmclient/taker.py
+++ b/jmclient/jmclient/taker.py
@@ -512,7 +512,10 @@ class Taker(object):
             changescript = self.wallet.addr_to_script(self.my_change_addr)
         else:
             changescript = None
-        self.wallet.botlzmann(our_scripts, tx['outs'], cjscript, changescript, self.cjamount)
+        outputs = self.outputs.copy()
+        for output in outputs:
+            output['script'] = self.wallet.addr_to_script(output['address'])
+        self.wallet.botlzmann(our_scripts, outputs, cjscript, changescript, self.cjamount)
         self.wallet.save()
 
         self.latest_tx = btc.deserialize(tx)

--- a/jmclient/jmclient/wallet.py
+++ b/jmclient/jmclient/wallet.py
@@ -840,7 +840,7 @@ class BaseWallet(object):
         raise NotImplementedError()
 
     def boltzmann(self, ins_scripts, outs, cjscript, changescript, amount):
-        return self._boltzmann(self, ins_scripts, outs, cjscript, changescript, amount)
+        return self._boltzmann.update(self, ins_scripts, outs, cjscript, changescript, amount)
 
     def close(self):
         self._storage.close()

--- a/jmclient/jmclient/wallet.py
+++ b/jmclient/jmclient/wallet.py
@@ -843,7 +843,19 @@ class BaseWallet(object):
     def clean_storage(self):
         """Remove used scripts from botlzmann storage.
         Utxo set must be synced"""
-        pass
+        scripts = []
+        utxo = self._utxos._utxo
+        # utxo: [md: int][(txid: bytes, index: int)] -> (path: tuple, value: int)
+        utxo_paths = set(chain(*[[y[0] for y in x.values()] for x in utxo.values()]))
+
+        # Convert paths to scripts
+        for script, path in self._script_map.items():
+            if path in utxo_paths:
+                scripts.append(hexlify(script).decode('ascii'))
+
+        if scripts:
+            self._boltzmann.clean(scripts)
+            self.save()
 
     def boltzmann(self, ins_scripts, outs, cjscript, changescript, amount):
         return self._boltzmann.update(ins_scripts, outs, cjscript, changescript, amount)

--- a/jmclient/jmclient/wallet.py
+++ b/jmclient/jmclient/wallet.py
@@ -288,6 +288,7 @@ class BaseWallet(object):
         """
         Write data to associated storage object and trigger persistent update.
         """
+        self._boltzmann.save()
         self._storage.save()
 
     @classmethod

--- a/jmclient/jmclient/wallet.py
+++ b/jmclient/jmclient/wallet.py
@@ -844,7 +844,8 @@ class BaseWallet(object):
         return self._boltzmann.update(ins_scripts, outs, cjscript, changescript, amount)
 
     def boltzmann_get(self, script):
-        return self._boltzmann.get_rate(script)
+        if self._boltzmann.has_script(script):
+            return self._boltzmann.get_entropy(script)
 
     def close(self):
         self._storage.close()

--- a/jmclient/jmclient/wallet.py
+++ b/jmclient/jmclient/wallet.py
@@ -840,7 +840,7 @@ class BaseWallet(object):
         raise NotImplementedError()
 
     def boltzmann(self, ins_scripts, outs, cjscript, changescript, amount):
-        return self._boltzmann.update(self, ins_scripts, outs, cjscript, changescript, amount)
+        return self._boltzmann.update(ins_scripts, outs, cjscript, changescript, amount)
 
     def close(self):
         self._storage.close()

--- a/jmclient/jmclient/wallet.py
+++ b/jmclient/jmclient/wallet.py
@@ -19,6 +19,7 @@ from numbers import Integral
 
 
 from .configure import jm_single
+from .boltzmann import Boltzmann
 from .support import select_gradual, select_greedy, select_greediest, \
     select
 from .cryptoengine import TYPE_P2PKH, TYPE_P2SH_P2WPKH,\
@@ -233,6 +234,7 @@ class BaseWallet(object):
         self.gap_limit = gap_limit
         self._storage = storage
         self._utxos = None
+        self._boltzmann = None
         # highest mixdepth ever used in wallet, important for synching
         self.max_mixdepth = None
         # effective maximum mixdepth to be used by joinmarket
@@ -280,6 +282,7 @@ class BaseWallet(object):
                             .format(self.TYPE))
         self.network = self._storage.data[b'network'].decode('ascii')
         self._utxos = UTXOManager(self._storage, self.merge_algorithm)
+        self._boltzmann = Boltzmann(self._storage)
 
     def save(self):
         """
@@ -317,6 +320,7 @@ class BaseWallet(object):
         storage.data[b'wallet_type'] = cls.TYPE
 
         UTXOManager.initialize(storage)
+        Boltzmann.initialize(storage)
 
         if write:
             storage.save()
@@ -834,6 +838,9 @@ class BaseWallet(object):
         Warning: improper use of 'force' will cause undefined behavior!
         """
         raise NotImplementedError()
+
+    def boltzmann(self, ins_scripts, outs, cjscript, changescript, amount):
+        return self._boltzmann(self, ins_scripts, outs, cjscript, changescript, amount)
 
     def close(self):
         self._storage.close()

--- a/jmclient/jmclient/wallet.py
+++ b/jmclient/jmclient/wallet.py
@@ -843,6 +843,9 @@ class BaseWallet(object):
     def boltzmann(self, ins_scripts, outs, cjscript, changescript, amount):
         return self._boltzmann.update(ins_scripts, outs, cjscript, changescript, amount)
 
+    def boltzmann_get(self, script):
+        return self._boltzmann.get_rate(script)
+
     def close(self):
         self._storage.close()
 

--- a/jmclient/jmclient/wallet.py
+++ b/jmclient/jmclient/wallet.py
@@ -840,6 +840,11 @@ class BaseWallet(object):
         """
         raise NotImplementedError()
 
+    def clean_storage(self):
+        """Remove used scripts from botlzmann storage.
+        Utxo set must be synced"""
+        pass
+
     def boltzmann(self, ins_scripts, outs, cjscript, changescript, amount):
         return self._boltzmann.update(ins_scripts, outs, cjscript, changescript, amount)
 

--- a/jmclient/jmclient/wallet.py
+++ b/jmclient/jmclient/wallet.py
@@ -843,6 +843,10 @@ class BaseWallet(object):
     def clean_storage(self):
         """Remove used scripts from botlzmann storage.
         Utxo set must be synced"""
+
+        if self._storage.read_only:
+            return
+
         scripts = []
         utxo = self._utxos._utxo
         # utxo: [md: int][(txid: bytes, index: int)] -> (path: tuple, value: int)

--- a/jmclient/jmclient/wallet_utils.py
+++ b/jmclient/jmclient/wallet_utils.py
@@ -164,7 +164,7 @@ class WalletViewBase(object):
         return "{0:.08f}".format(self.get_balance(include_unconf))
 
 class WalletViewEntry(WalletViewBase):
-    def __init__(self, wallet_path_repr, account, forchange, aindex, addr, amounts,
+    def __init__(self, wallet_path_repr, account, forchange, aindex, addr, amounts, boltzmann,
                  used = 'new', serclass=str, priv=None, custom_separator=None):
         super(WalletViewEntry, self).__init__(wallet_path_repr, serclass=serclass,
                                               custom_separator=custom_separator)
@@ -176,6 +176,7 @@ class WalletViewEntry(WalletViewBase):
         self.aindex = aindex
         self.address = addr
         self.unconfirmed_amount, self.confirmed_amount = amounts
+        self.boltzmann = boltzmann
         #note no validation here
         self.private_key = priv
         self.used = used
@@ -210,6 +211,7 @@ class WalletViewEntry(WalletViewBase):
 
     def serialize_extra_data(self):
         ed = self.used
+        ed += self.separator + self.serclass(self.boltzmann)
         if self.private_key:
             ed += self.separator + self.serclass(self.private_key)
         return self.serclass(ed)
@@ -422,6 +424,7 @@ def wallet_display(wallet, gaplimit, showprivkey, displayall=False,
             for k in range(unused_index + gaplimit):
                 path = wallet.get_path(m, forchange, k)
                 addr = wallet.get_addr_path(path)
+                boltzmann = wallet.boltzmann_get(btc.address_to_script(addr))
                 balance, used = get_addr_status(
                     path, utxos[m], k >= unused_index, forchange)
                 if showprivkey:
@@ -432,7 +435,7 @@ def wallet_display(wallet, gaplimit, showprivkey, displayall=False,
                         (used == 'new' and forchange == 0)):
                     entrylist.append(WalletViewEntry(
                         wallet.get_path_repr(path), m, forchange, k, addr,
-                        [balance, balance], priv=privkey, used=used))
+                        [balance, balance], boltzmann, priv=privkey, used=used))
             wallet.set_next_index(m, forchange, unused_index)
             path = wallet.get_path_repr(wallet.get_path(m, forchange))
             branchlist.append(WalletViewBranch(path, m, forchange, entrylist,

--- a/jmclient/jmclient/wallet_utils.py
+++ b/jmclient/jmclient/wallet_utils.py
@@ -364,9 +364,11 @@ def wallet_showutxos(wallet, showprivkey):
             key = wallet.get_key_from_addr(av['address'])
             tries = podle.get_podle_tries(u, key, max_tries)
             tries_remaining = max(0, max_tries - tries)
+            script = binascii.hexlify(av['script']).decode('ascii')
+            entropy = wallet.boltzmann_get(script) or 0
             unsp[u] = {'address': av['address'], 'value': av['value'],
                        'tries': tries, 'tries_remaining': tries_remaining,
-                       'external': False}
+                       'external': False, 'entropy': entropy}
             if showprivkey:
                 unsp[u]['privkey'] = wallet.get_wif_path(av['path'])
 

--- a/jmclient/jmclient/wallet_utils.py
+++ b/jmclient/jmclient/wallet_utils.py
@@ -29,7 +29,7 @@ def get_wallettool_parser():
     description = (
         'Use this script to monitor and manage your Joinmarket wallet.\n'
         'The method is one of the following: \n'
-        '(display) Shows addresses and balances.\n'
+        '(display) Shows addresses, balances and entropy.\n'
         '(displayall) Shows ALL addresses and balances.\n'
         '(summary) Shows a summary of mixing depth balances.\n'
         '(generate) Generates a new wallet.\n'
@@ -210,10 +210,13 @@ class WalletViewEntry(WalletViewBase):
         return self.serclass("{0:.08f}".format(self.unconfirmed_amount/1e8))
 
     def serialize_extra_data(self):
-        ed = self.used
         if self.boltzmann:
             # Defined and >0
-            ed += self.separator + self.serclass("{0:.1f}".format(self.boltzmann))
+            ed = self.serclass("{0:.1f}".format(self.boltzmann))
+        else:
+            # Placeholder
+            ed = '   '
+        ed += self.separator + self.used
         if self.private_key:
             ed += self.separator + self.serclass(self.private_key)
         return self.serclass(ed)

--- a/jmclient/jmclient/wallet_utils.py
+++ b/jmclient/jmclient/wallet_utils.py
@@ -211,7 +211,9 @@ class WalletViewEntry(WalletViewBase):
 
     def serialize_extra_data(self):
         ed = self.used
-        ed += self.separator + self.serclass(self.boltzmann)
+        if self.boltzmann:
+            # Defined and >0
+            ed += self.separator + self.serclass("{0:.1f}".format(self.boltzmann))
         if self.private_key:
             ed += self.separator + self.serclass(self.private_key)
         return self.serclass(ed)

--- a/jmclient/test/test_boltzmann.py
+++ b/jmclient/test/test_boltzmann.py
@@ -16,9 +16,9 @@ def test_boltzmann_persist():
     Boltzmann.initialize(storage)
     bz = Boltzmann(storage)
 
-    script0 = b'\x00' * 7
-    script1 = b'\x01' * 7
-    script2 = b'\x02' * 7
+    script0 = '00' * 7
+    script1 = '01' * 7
+    script2 = '02' * 7
     rate0 = 3
     rate1 = 5 ** 13
 

--- a/jmclient/test/test_boltzmann.py
+++ b/jmclient/test/test_boltzmann.py
@@ -112,6 +112,6 @@ def test_update(ins_scripts, outs, cjscript, changescript, amount, setup, expect
     bz = Boltzmann(storage)
     set_initial(bz, setup)
 
-    bz.boltzmann(ins_scripts, outs, cjscript, changescript, amount)
+    bz.update(ins_scripts, outs, cjscript, changescript, amount)
 
     check_result(bz, expected)

--- a/jmclient/test/test_boltzmann.py
+++ b/jmclient/test/test_boltzmann.py
@@ -57,13 +57,15 @@ def test_boltzmann_persist():
     assert not bz.has_script(script0)
 
 
-def _test_boltzmann(setup_env_nodeps):
+@pytest.mark.parametrize("ins_scripts, outs, cjscript, changescript, amount", [
+    (['00'], [{'script': '00', 'value': 123}], '00', None, 123),
+])
+def test_boltzmann(setup_env_nodeps, ins_scripts, outs, cjscript, changescript, amount):
     storage = MockStorage(None, 'wallet.jmdat', None, create=True)
     Boltzmann.initialize(storage)
     bz = Boltzmann(storage)
 
-    tx = {}  # TODO
-    bz.boltzmann(tx)
+    bz.boltzmann(ins_scripts, outs, cjscript, changescript, amount)
 
 
 @pytest.fixture

--- a/jmclient/test/test_boltzmann.py
+++ b/jmclient/test/test_boltzmann.py
@@ -70,6 +70,11 @@ def test_set_rate():
     assert bz.get_rate(script) == 10
 
 
+def test_not_init_storage():
+    storage = MockStorage(None, 'wallet.jmdat', None, create=True)
+    Boltzmann(storage)
+
+
 @pytest.fixture
 def setup_env_nodeps(monkeypatch):
     monkeypatch.setattr(jmclient.configure, 'get_blockchain_interface_instance',

--- a/jmclient/test/test_boltzmann.py
+++ b/jmclient/test/test_boltzmann.py
@@ -1,0 +1,73 @@
+from __future__ import (absolute_import, division,
+                        print_function, unicode_literals)
+
+from jmclient.boltzmann import Boltzmann
+
+from test_storage import MockStorage
+import pytest
+
+from jmclient import load_program_config
+import jmclient
+from commontest import DummyBlockchainInterface
+
+
+def test_boltzmann_persist():
+    storage = MockStorage(None, 'wallet.jmdat', None, create=True)
+    Boltzmann.initialize(storage)
+    bz = Boltzmann(storage)
+
+    script0 = b'\x00' * 7
+    script1 = b'\x01' * 7
+    script2 = b'\x02' * 7
+    rate0 = 3
+    rate1 = 5 ** 13
+
+    bz.set_rate(script0, rate0)
+    bz.set_rate(script1, rate1)
+
+    bz.save()
+    del bz
+
+    bz = Boltzmann(storage)
+
+    assert bz.get_rate(script0) == rate0
+    assert bz.has_script(script0)
+    assert bz.get_rate(script1) == rate1
+    assert bz.has_script(script1)
+    assert bz.get_rate(script2) == 1
+    assert not bz.has_script(script2)
+
+    bz.remove_script(script1)
+
+    bz.save()
+    del bz
+
+    bz = Boltzmann(storage)
+
+    assert bz.has_script(script0)
+    assert not bz.has_script(script1)
+    assert not bz.has_script(script2)
+
+    bz.reset()
+    bz.save()
+    del bz
+
+    bz = Boltzmann(storage)
+
+    assert not bz.has_script(script0)
+
+
+def _test_boltzmann(setup_env_nodeps):
+    storage = MockStorage(None, 'wallet.jmdat', None, create=True)
+    Boltzmann.initialize(storage)
+    bz = Boltzmann(storage)
+
+    tx = {}  # TODO
+    bz.boltzmann(tx)
+
+
+@pytest.fixture
+def setup_env_nodeps(monkeypatch):
+    monkeypatch.setattr(jmclient.configure, 'get_blockchain_interface_instance',
+                        lambda x: DummyBlockchainInterface())
+    load_program_config()

--- a/jmclient/test/test_boltzmann.py
+++ b/jmclient/test/test_boltzmann.py
@@ -57,6 +57,19 @@ def test_boltzmann_persist():
     assert not bz.has_script(script0)
 
 
+def test_set_rate():
+    """After set rate to a script, it cannot be increased"""
+    storage = MockStorage(None, 'wallet.jmdat', None, create=True)
+    Boltzmann.initialize(storage)
+    bz = Boltzmann(storage)
+
+    script = '00' * 7
+    bz.set_rate(script, 10)
+    assert bz.get_rate(script) == 10
+    bz.set_rate(script, 20)
+    assert bz.get_rate(script) == 10
+
+
 @pytest.fixture
 def setup_env_nodeps(monkeypatch):
     monkeypatch.setattr(jmclient.configure, 'get_blockchain_interface_instance',

--- a/jmclient/test/test_client_protocol.py
+++ b/jmclient/test/test_client_protocol.py
@@ -8,6 +8,8 @@ from jmbase import get_log
 from jmclient import load_program_config, Taker,\
     JMClientProtocolFactory, jm_single, Maker
 from jmclient.client_protocol import JMTakerClientProtocol
+from jmclient.boltzmann import Boltzmann
+from jmclient import VolatileStorage
 from twisted.python.log import msg as tmsg
 from twisted.internet import protocol, reactor, task
 from twisted.internet.defer import inlineCallbacks
@@ -80,9 +82,16 @@ class DummyTaker(Taker):
 
 
 class DummyWallet(object):
+    def __init__(self):
+        self.storage = VolatileStorage()
+        Boltzmann.initialize(self.storage)
+        self._boltzmann = Boltzmann(self.storage)
+
     def get_wallet_id(self):
         return 'aaaa'
 
+    def boltzmann(self, ins_scripts, outs, cjscript, changescript, amount):
+        return self._boltzmann.update(ins_scripts, outs, cjscript, changescript, amount)
 
 class DummyMaker(Maker):
     def __init__(self):

--- a/jmclient/test/test_wallet.py
+++ b/jmclient/test/test_wallet.py
@@ -6,6 +6,7 @@ from builtins import * # noqa: F401
 import os
 import json
 from binascii import hexlify, unhexlify
+from itertools import chain
 
 import pytest
 import jmbitcoin as btc
@@ -14,7 +15,7 @@ from jmbase import get_log
 from jmclient import load_program_config, jm_single, \
     SegwitLegacyWallet,BIP32Wallet, BIP49Wallet, LegacyWallet,\
     VolatileStorage, get_network, cryptoengine, WalletError,\
-    SegwitWallet
+    SegwitWallet, sync_wallet
 from test_blockchaininterface import sync_test_wallet
 
 testdir = os.path.dirname(os.path.realpath(__file__))
@@ -643,6 +644,40 @@ def test_wallet_mixdepth_decrease(setup_wallet):
     # wallet.select_utxos will still return utxos from higher mixdepths
     # because we explicitly ask for a specific mixdepth
     assert utxo in new_wallet.select_utxos_(max_mixdepth, 10**7)
+
+
+def test_clean_storage(setup_wallet):
+    """Boltzmann rates set must be minimal after notification of sync_unspent event"""
+    wallet = get_populated_wallet(num=2)
+    sync_wallet(wallet)
+
+    assert wallet._utxos._utxo
+    assert wallet._script_map
+
+    utxo = wallet._utxos._utxo
+    # utxo: [md: int][(txid: bytes, index: int)] -> (path: tuple, value: int)
+    utxo_paths = set(chain(*[[y[0] for y in x.values()] for x in utxo.values()]))
+    scripts = []
+    for script, path in wallet._script_map.items():
+        if path in utxo_paths:
+            scripts.append(hexlify(script).decode('ascii'))
+
+    assert len(scripts) >= 2
+
+    # Initialize boltzmann storage
+    # Add almost all utxos' scripts
+    for script in scripts[:-1]:
+        wallet._boltzmann.set_rate(script, 7)
+    # Add used scripts
+    wallet._boltzmann.set_rate('07' * 23, 7)
+    wallet._boltzmann.set_rate('08' * 23, 7)
+    wallet._boltzmann.set_rate('09' * 23, 7)
+
+    wallet.clean_storage()
+
+    # Check that boltzmann does not include used scripts
+    for script in wallet._boltzmann._rates.keys():
+        assert script in scripts
 
 
 @pytest.fixture(scope='module')

--- a/jmclient/test/test_wallet.py
+++ b/jmclient/test/test_wallet.py
@@ -655,7 +655,6 @@ def test_clean_storage(setup_wallet):
     assert wallet._script_map
 
     utxo = wallet._utxos._utxo
-    # utxo: [md: int][(txid: bytes, index: int)] -> (path: tuple, value: int)
     utxo_paths = set(chain(*[[y[0] for y in x.values()] for x in utxo.values()]))
     scripts = []
     for script, path in wallet._script_map.items():

--- a/jmclient/test/test_wallet.py
+++ b/jmclient/test/test_wallet.py
@@ -646,10 +646,7 @@ def test_wallet_mixdepth_decrease(setup_wallet):
     assert utxo in new_wallet.select_utxos_(max_mixdepth, 10**7)
 
 
-def test_clean_storage(setup_wallet):
-    """Boltzmann rates set must be minimal after notification of sync_unspent event"""
-    wallet = get_populated_wallet(num=2)
-    sync_wallet(wallet)
+def fill_boltzmann(wallet):
 
     assert wallet._utxos._utxo
     assert wallet._script_map
@@ -672,11 +669,29 @@ def test_clean_storage(setup_wallet):
     wallet._boltzmann.set_rate('08' * 23, 7)
     wallet._boltzmann.set_rate('09' * 23, 7)
 
+    return scripts
+
+
+def test_clean_storage(setup_wallet):
+    """Boltzmann rates set must be minimal after notification of sync_unspent event"""
+    wallet = get_populated_wallet(num=2)
+    sync_wallet(wallet)
+    utxos_stripts = fill_boltzmann(wallet)
+
     wallet.clean_storage()
 
     # Check that boltzmann does not include used scripts
     for script in wallet._boltzmann._rates.keys():
-        assert script in scripts
+        assert script in utxos_stripts
+
+
+def test_clean_read_only_storage(setup_wallet):
+    wallet = get_populated_wallet(num=2)
+    wallet._storage.read_only = True
+    sync_wallet(wallet)
+    fill_boltzmann(wallet)
+
+    wallet.clean_storage()
 
 
 @pytest.fixture(scope='module')


### PR DESCRIPTION
I used [this](https://github.com/Samourai-Wallet/boltzmann) definition of entropy.

When a cj transaction occurs are assigned rates to output scripts.
The rate represents the number of mapping of user inputs to tx outputs. The output rates are multiplied by the input rate, in order to track privacy among transactions.

This allows users to estimate the quality of their utxos.

Rates are saved into the wallet; rates of spent txo are deleted to avoid to bloat the wallet.