### PR TITLE
JoinMarket-Qt: Display GUI error to user when no password entered on wallet load

### DIFF
--- a/scripts/joinmarket-qt.py
+++ b/scripts/joinmarket-qt.py
@@ -1383,7 +1383,7 @@ class JMMainWindow(QMainWindow):
             self.loadWalletFromBlockchain(firstarg, pwd, restart_cb)
 
     def loadWalletFromBlockchain(self, firstarg=None, pwd=None, restart_cb=None):
-        if (firstarg and pwd) or (firstarg and get_network() == 'testnet'):
+        if firstarg:
             wallet_path = get_wallet_path(str(firstarg), None)
             try:
                 self.wallet = open_test_wallet_maybe(wallet_path, str(firstarg),


### PR DESCRIPTION
Without this change it silently fails with "No wallet loaded" assertion in `loadWalletFromBlockchain()`. So, better just call `open_test_wallet_maybe()` and allow it to fail with exception and visual error for the user.

Empty passwords for mainnet wallets aren't allowed already.