### PR TITLE
Basic coin control.

### DIFF
--- a/jmclient/jmclient/__init__.py
+++ b/jmclient/jmclient/__init__.py
@@ -45,7 +45,7 @@ from .taker_utils import (tumbler_taker_finished_update, restart_waiter,
 from .wallet_utils import (
     wallet_tool_main, wallet_generate_recover_bip39, open_wallet,
     open_test_wallet_maybe, create_wallet, get_wallet_cls, get_wallet_path,
-    wallet_display)
+    wallet_display, get_utxos_enabled_disabled)
 from .maker import Maker, P2EPMaker
 from .yieldgenerator import YieldGenerator, YieldGeneratorBasic, ygmain
 # Set default logging handler to avoid "No handler found" warnings.

--- a/jmclient/test/test_wallet.py
+++ b/jmclient/test/test_wallet.py
@@ -333,6 +333,22 @@ def test_signing_simple(setup_wallet, wallet_cls, type_check):
     txout = jm_single().bc_interface.pushtx(btc.serialize(tx))
     assert txout
 
+def test_get_bbm(setup_wallet):
+    jm_single().config.set('BLOCKCHAIN', 'network', 'testnet')
+    amount = 10**8
+    num_tx = 3
+    wallet = get_populated_wallet(amount, num_tx)
+    # disable a utxo and check we can correctly report
+    # balance with the disabled flag off:
+    utxo_1 = list(wallet._utxos.get_utxos_by_mixdepth()[0].keys())[0]
+    wallet.disable_utxo(*utxo_1)
+    balances = wallet.get_balance_by_mixdepth(include_disabled=True)
+    assert balances[0] == num_tx * amount
+    balances = wallet.get_balance_by_mixdepth()
+    assert balances[0] == (num_tx - 1) * amount
+    wallet.toggle_disable_utxo(*utxo_1)
+    balances = wallet.get_balance_by_mixdepth()
+    assert balances[0] == num_tx * amount
 
 def test_add_utxos(setup_wallet):
     jm_single().config.set('BLOCKCHAIN', 'network', 'testnet')

--- a/scripts/add-utxo.py
+++ b/scripts/add-utxo.py
@@ -182,6 +182,9 @@ def main():
         while not jm_single().bc_interface.wallet_synced:
             sync_wallet(wallet, fast=options.fastsync)
 
+        # minor note: adding a utxo from an external wallet for commitments, we
+        # default to not allowing disabled utxos to avoid a privacy leak, so the
+        # user would have to explicitly enable.
         for md, utxos in wallet.get_utxos_by_mixdepth_().items():
             for (txid, index), utxo in utxos.items():
                 txhex = binascii.hexlify(txid).decode('ascii') + ':' + str(index)

--- a/scripts/joinmarket-qt.py
+++ b/scripts/joinmarket-qt.py
@@ -1032,7 +1032,7 @@ class CoinsTab(QWidget):
         def show_blank():
             m_item = QTreeWidgetItem(["No coins", "", ""])
             self.cTW.addChild(m_item)
-            self.show()
+            self.cTW.show()
 
         if not w.wallet:
             show_blank()
@@ -1073,7 +1073,7 @@ class CoinsTab(QWidget):
                         #if rows[i][forchange][j][3] != 'new':
                         #    item.setForeground(3, QBrush(QColor('red')))
                         seq_item.addChild(item)
-        self.show()
+                    m_item.setExpanded(True)
 
     def toggle_utxo_disable(self, txid, idx):
         txid_bytes = btc.safe_from_hex(txid)


### PR DESCRIPTION
Wallet persists utxo metadata; currently only
contains a field 'disabled' indexed by utxo.
User can switch this on or off (enabled) via
wallet-tool 'disable' method.
Disabled utxos will not be used in coin
selection in any transaction.
Wallet still displays all utxo balances in
display method. No GUI update yet.