### PR TITLE
Minor UI/UX tweaks

### DIFF
--- a/jmclient/jmclient/storage.py
+++ b/jmclient/jmclient/storage.py
@@ -277,15 +277,16 @@ class Storage(object):
     def _create_lock(self):
         if self.read_only:
             return
-        self._lock_file = '{}.lock'.format(self.path)
+        lock_filename = '{}.lock'.format(self.path)
+        self._lock_file = lock_filename
         if os.path.exists(self._lock_file):
             with open(self._lock_file, 'r') as f:
                 locked_by_pid = f.read()
             self._lock_file = None
             raise StorageError("File is currently in use (locked by pid {}). "
                                "If this is a leftover from a crashed instance "
-                               "you need to remove the lock file manually" .
-                               format(locked_by_pid))
+                               "you need to remove the lock file `{}` manually." .
+                               format(locked_by_pid, lock_filename))
         #FIXME: in python >=3.3 use mode x
         with open(self._lock_file, 'w') as f:
             f.write(str(os.getpid()))

--- a/scripts/joinmarket-qt.py
+++ b/scripts/joinmarket-qt.py
@@ -1115,6 +1115,8 @@ class JMWalletTab(QWidget):
             self)
         self.label1.setAlignment(QtCore.Qt.AlignTop | QtCore.Qt.AlignLeft)
         v = MyTreeWidget(self, self.create_menu, self.getHeaders())
+        v.header().resizeSection(0, 400)    # size of "Address" column
+        v.header().resizeSection(1, 130)    # size of "Index" column
         v.setSelectionMode(QAbstractItemView.ExtendedSelection)
         v.on_update = self.updateWalletInfo
         v.hide()


### PR DESCRIPTION
* Change default column sizes in "JM Wallet" tab. Aim is to have address and path (index) fully visible, but I'm not sure it will be on all possible OSes / GUIs. But in any case this is better than the very narrow default address column we had before.
* In case of wallet locked, display full path and filename of lockfile. New users may be confused where to find the file we recommend to manually remove in case of crash.