### PR TITLE
Small testing related changes

### DIFF
--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -2,7 +2,7 @@
 
 This is a rough sketch, some more background is found in [JM wiki](https://github.com/Joinmarket-Org/joinmarket/wiki/Testing)
 
-Make sure to have [bitcoind](https://bitcoin.org/en/full-node) installed. Also need miniircd installed to the root (i.e. in your `joinmarket-clientserver` directory):
+Make sure to have [bitcoind](https://bitcoin.org/en/full-node) 0.17 or newer installed. Also need miniircd installed to the root (i.e. in your `joinmarket-clientserver` directory):
 
     cd ~/joinmarket-clientserver
     git clone https://github.com/Joinmarket-Org/miniircd

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -63,7 +63,7 @@ run_jm_tests ()
     python -m pytest ${HAS_JOSH_K_SEAL_OF_APPROVAL+--cov=jmclient --cov=jmbitcoin --cov=jmbase --cov=jmdaemon --cov-report html} --btcpwd=123456abcdef --btcconf=${jm_test_datadir}/bitcoin.conf --btcuser=bitcoinrpc --nirc=2 -p no:warnings --ignore test/test_full_coinjoin.py
     local success="$?"
     unlink ./joinmarket.cfg
-    if read bitcoind_pid <"${jm_test_datadir}/bitcoind.pid"; then
+    if [ -f "${jm_test_datadir}/bitcoind.pid" ] && read bitcoind_pid <"${jm_test_datadir}/bitcoind.pid"; then
         kill -15 ${bitcoind_pid} || kill -9 ${bitcoind_pid}
     fi
     if [[ "${HAS_JOSH_K_SEAL_OF_APPROVAL}" == true ]] && (( ${success} != 0 )); then


### PR DESCRIPTION
* Silence no pidfile error at the end of `run_tests.sh`.
* Mention `bitcoind` 0.17+ requirement in testing docs, payjoin tests fail on 0.16.