### PR TITLE
Upgrade testing framework to use generatetoaddress.

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -101,9 +101,11 @@ def setup(request):
                                 "-daemon", "-conf=" + bitcoin_conf])
     time.sleep(3)
     #generate blocks; segwit activates around block 500-600
-    for i in range(2):
-        local_command([bitcoin_path + "bitcoin-cli", "-regtest",
+    root_cmd = [bitcoin_path + "bitcoin-cli", "-regtest",
                        "-rpcuser=" + bitcoin_rpcusername,
-                       "-rpcpassword=" + bitcoin_rpcpassword, "generate", "301"])
+                       "-rpcpassword=" + bitcoin_rpcpassword]
+    for i in range(2):
+        destn_addr = local_command(root_cmd + ["getnewaddress"])
+        local_command(root_cmd + ["generatetoaddress", "301", destn_addr])
         time.sleep(1)
     

--- a/jmclient/jmclient/blockchaininterface.py
+++ b/jmclient/jmclient/blockchaininterface.py
@@ -916,6 +916,7 @@ class RegtestBitcoinCoreInterface(BitcoinCoreInterface): #pragma: no cover
         self.absurd_fees = False
         self.simulating = False
         self.shutdown_signal = False
+        self.destn_addr = self.rpc("getnewaddress", [])
 
     def estimate_fee_per_kb(self, N):
         if not self.absurd_fees:
@@ -960,7 +961,7 @@ class RegtestBitcoinCoreInterface(BitcoinCoreInterface): #pragma: no cover
         instruct to mine n blocks.
         """
         try:
-            self.rpc('generate', [n])
+            self.rpc('generatetoaddress', [n, self.destn_addr])
         except JsonRpcConnectionError:
             #can happen if the blockchain is shut down
             #automatically at the end of tests; this shouldn't


### PR DESCRIPTION
Prior to this commit, the regtest testing framework
used the bitcoin rpc command `generate` to mine coins
in preparation for tests, and to tick forward the
chain for confirmations. This rpc command is deprecated
and will be removed in 0.19. Hence this commit changes
the two usages of `generate` to `generatetoaddress` and
specifies a mining address created with `getnewaddress`.