### PR TITLE
Trivial: hint for bitcoin-cli rescanblockchain in restart_msg

### DIFF
--- a/jmclient/jmclient/blockchaininterface.py
+++ b/jmclient/jmclient/blockchaininterface.py
@@ -383,7 +383,8 @@ class BitcoinCoreInterface(BlockchainInterface):
         if jm_single().config.get("BLOCKCHAIN",
                                   "blockchain_source") != 'regtest': #pragma: no cover
             #Exit conditions cannot be included in tests
-            restart_msg = ("restart Bitcoin Core with -rescan if you're "
+            restart_msg = ("restart Bitcoin Core with -rescan or use "
+                           "`bitcoin-cli rescanblockchain` if you're "
                            "recovering an existing wallet from backup seed\n"
                            "Otherwise just restart this joinmarket application.")
             if restart_cb:


### PR DESCRIPTION
I think calling `bitcoin-cli` is more simpler than restarting bitcoind/bitcoin-qt. Also you can specify partial rescan if you know oldest block height you're interested in (wanted to add hint to that, but it made this message too long and not so nice, probably it's worth mentioning somewhere in documentation). But it will not be option for all users, as `bitcoin-cli` might not be installed with Bitcoin Core.