### PR TITLE
Trivial: more detailed logging 

### DIFF
--- a/jmclient/jmclient/yieldgenerator.py
+++ b/jmclient/jmclient/yieldgenerator.py
@@ -104,7 +104,7 @@ class YieldGeneratorBasic(YieldGenerator):
         jlog.debug('mix depths that have enough = ' + str(filtered_mix_balance))
         filtered_mix_balance = sorted(filtered_mix_balance, key=lambda x: x[0])
         mixdepth = filtered_mix_balance[0][0]
-        jlog.info('filling offer, mixdepth=' + str(mixdepth))
+        jlog.info('filling offer, mixdepth=' + str(mixdepth) + ', amount=' + str(amount))
 
         # mixdepth is the chosen depth we'll be spending from
         cj_addr = self.wallet.get_internal_addr(

--- a/jmdaemon/jmdaemon/message_channel.py
+++ b/jmdaemon/jmdaemon/message_channel.py
@@ -784,8 +784,9 @@ class MessageChannel(object):
                                        minsize, maxsize, txfee, cjfee)
             except IndexError as e:
                 log.debug(e)
-                log.debug('index error parsing chunks, possibly malformed'
-                          'offer by other party. No user action required.')
+                log.debug('index error parsing chunks, possibly malformed '
+                          'offer by other party. No user action required. '
+                          'Triggered by: ' + str(nick))
                 # TODO what now? just ignore iirc
             finally:
                 return True


### PR DESCRIPTION
Logs:

- the nick of the counterparty which triggered a malformed offer and
- the coinjoin amount on mixdepth-selection

I've had this in my personal debugging JM forever, but gets lost each time I update. Maybe helpful to others as well.

I've tested this on mainnet and triggered the changed code parts, works as expected.