### PR TITLE
Improvements to wallet syncing and monitoring

### DIFF
--- a/jmbase/jmbase/__init__.py
+++ b/jmbase/jmbase/__init__.py
@@ -4,6 +4,7 @@ from builtins import *
 
 from .support import (get_log, chunks, debug_silence, jmprint,
                       joinmarket_alert, core_alert, get_password,
-                      set_logging_level, set_logging_color)
+                      set_logging_level, set_logging_color,
+                      JM_WALLET_NAME_PREFIX)
 from .commands import *
 

--- a/jmbase/jmbase/support.py
+++ b/jmbase/jmbase/support.py
@@ -5,6 +5,9 @@ from builtins import * # noqa: F401
 import logging
 from getpass import getpass
 
+# global Joinmarket constants
+JM_WALLET_NAME_PREFIX = "joinmarket-wallet-"
+
 from chromalog.log import (
     ColorizingStreamHandler,
     ColorizingFormatter,

--- a/jmbitcoin/jmbitcoin/secp256k1_transaction.py
+++ b/jmbitcoin/jmbitcoin/secp256k1_transaction.py
@@ -9,6 +9,8 @@ import copy
 import re
 import os
 import struct
+# note, only used for non-cryptographic randomness:
+import random
 from jmbitcoin.secp256k1_main import *
 from jmbitcoin.bech32 import *
 
@@ -871,3 +873,15 @@ def mktx(ins, outs, version=1, locktime=0):
         txobj["outs"].append(outobj)
     return serialize(txobj)
 
+def make_shuffled_tx(ins, outs, deser=True, version=1, locktime=0):
+    """ Simple utility to ensure transaction
+    inputs and outputs are randomly ordered.
+    Can possibly be replaced by BIP69 in future
+    """
+    random.shuffle(ins)
+    random.shuffle(outs)
+    tx = mktx(ins, outs, version=version, locktime=locktime)
+    if deser:
+        return deserialize(tx)
+    else:
+        return tx

--- a/jmclient/jmclient/__init__.py
+++ b/jmclient/jmclient/__init__.py
@@ -16,7 +16,7 @@ from .taker import Taker, P2EPTaker
 from .wallet import (Mnemonic, estimate_tx_fee, WalletError, BaseWallet, ImportWalletMixin,
                      BIP39WalletMixin, BIP32Wallet, BIP49Wallet, LegacyWallet,
                      SegwitWallet, SegwitLegacyWallet, UTXOManager,
-                     WALLET_IMPLEMENTATIONS, make_shuffled_tx)
+                     WALLET_IMPLEMENTATIONS)
 from .storage import (Argon2Hash, Storage, StorageError,
                       StoragePasswordError, VolatileStorage)
 from .cryptoengine import BTCEngine, BTC_P2PKH, BTC_P2SH_P2WPKH, EngineError
@@ -24,7 +24,7 @@ from .configure import (
     load_program_config, get_p2pk_vbyte, jm_single, get_network,
     validate_address, get_irc_mchannels, get_blockchain_interface_instance,
     get_p2sh_vbyte, set_config, is_segwit_mode, is_native_segwit_mode)
-from .blockchaininterface import (BlockchainInterface, sync_wallet,
+from .blockchaininterface import (BlockchainInterface,
                                   RegtestBitcoinCoreInterface, BitcoinCoreInterface)
 from .electruminterface import ElectrumInterface
 from .client_protocol import (JMTakerClientProtocol, JMClientProtocolFactory,
@@ -46,6 +46,7 @@ from .wallet_utils import (
     wallet_tool_main, wallet_generate_recover_bip39, open_wallet,
     open_test_wallet_maybe, create_wallet, get_wallet_cls, get_wallet_path,
     wallet_display, get_utxos_enabled_disabled)
+from .wallet_service import WalletService
 from .maker import Maker, P2EPMaker
 from .yieldgenerator import YieldGenerator, YieldGeneratorBasic, ygmain
 # Set default logging handler to avoid "No handler found" warnings.

--- a/jmclient/jmclient/output.py
+++ b/jmclient/jmclient/output.py
@@ -4,11 +4,11 @@ from builtins import * # noqa: F401
 from binascii import hexlify
 
 
-def fmt_utxos(utxos, wallet, prefix=''):
+def fmt_utxos(utxos, wallet_service, prefix=''):
     output = []
     for u in utxos:
         utxo_str = '{}{} - {}'.format(
-            prefix, fmt_utxo(u), fmt_tx_data(utxos[u], wallet))
+            prefix, fmt_utxo(u), fmt_tx_data(utxos[u], wallet_service))
         output.append(utxo_str)
     return '\n'.join(output)
 
@@ -17,13 +17,13 @@ def fmt_utxo(utxo):
     return '{}:{}'.format(hexlify(utxo[0]).decode('ascii'), utxo[1])
 
 
-def fmt_tx_data(tx_data, wallet):
+def fmt_tx_data(tx_data, wallet_service):
     return 'path: {}, address: {}, value: {}'.format(
-        wallet.get_path_repr(wallet.script_to_path(tx_data['script'])),
-        wallet.script_to_addr(tx_data['script']), tx_data['value'])
+        wallet_service.get_path_repr(wallet_service.script_to_path(tx_data['script'])),
+        wallet_service.script_to_addr(tx_data['script']), tx_data['value'])
 
 
-def generate_podle_error_string(priv_utxo_pairs, to, ts, wallet, cjamount,
+def generate_podle_error_string(priv_utxo_pairs, to, ts, wallet_service, cjamount,
                                 taker_utxo_age, taker_utxo_amtpercent):
     """Gives detailed error information on why commitment sourcing failed.
     """
@@ -64,9 +64,9 @@ def generate_podle_error_string(priv_utxo_pairs, to, ts, wallet, cjamount,
                "with 'python add-utxo.py --help'\n\n")
     errmsg += ("***\nFor reference, here are the utxos in your wallet:\n")
 
-    for md, utxos in wallet.get_utxos_by_mixdepth_().items():
+    for md, utxos in wallet_service.get_utxos_by_mixdepth(hexfmt=False).items():
         if not utxos:
             continue
         errmsg += ("\nmixdepth {}:\n{}".format(
-            md, fmt_utxos(utxos, wallet, prefix='    ')))
+            md, fmt_utxos(utxos, wallet_service, prefix='    ')))
     return (errmsgheader, errmsg)

--- a/jmclient/jmclient/storage.py
+++ b/jmclient/jmclient/storage.py
@@ -217,6 +217,9 @@ class Storage(object):
         with open(self.path, 'rb') as fh:
             return fh.read()
 
+    def get_location(self):
+        return self.path
+
     @staticmethod
     def _serialize(data):
         return bencoder.bencode(data)
@@ -334,3 +337,6 @@ class VolatileStorage(Storage):
 
     def _read_file(self):
         return self.file_data
+
+    def get_location(self):
+        return None

--- a/jmclient/jmclient/taker.py
+++ b/jmclient/jmclient/taker.py
@@ -7,17 +7,18 @@ from future.utils import iteritems
 import base64
 import pprint
 import random
-from twisted.internet import reactor
+from twisted.internet import reactor, task
 from binascii import hexlify, unhexlify
 
 from jmbitcoin import SerializationError, SerializationTruncationError
 import jmbitcoin as btc
-from jmclient.configure import get_p2sh_vbyte, jm_single, validate_address
+from jmclient.configure import jm_single, validate_address
 from jmbase.support import get_log
 from jmclient.support import (calc_cj_fee, weighted_order_choose, choose_orders,
                               choose_sweep_orders)
-from jmclient.wallet import estimate_tx_fee, make_shuffled_tx
+from jmclient.wallet import estimate_tx_fee
 from jmclient.podle import generate_podle, get_podle_commitments, PoDLE
+from jmclient.wallet_service import WalletService
 from .output import generate_podle_error_string
 from .cryptoengine import EngineError
 
@@ -31,7 +32,7 @@ class JMTakerError(Exception):
 class Taker(object):
 
     def __init__(self,
-                 wallet,
+                 wallet_service,
                  schedule,
                  order_chooser=weighted_order_choose,
                  callbacks=None,
@@ -80,7 +81,8 @@ class Taker(object):
         None
         """
         self.aborted = False
-        self.wallet = wallet
+        assert isinstance(wallet_service, WalletService)
+        self.wallet_service = wallet_service
         self.schedule = schedule
         self.order_chooser = order_chooser
         self.max_cj_fee = max_cj_fee
@@ -173,7 +175,7 @@ class Taker(object):
                 #mixdepth in tumble schedules:
                 if self.schedule_index == 0 or si[0] != self.schedule[
                     self.schedule_index - 1]:
-                    self.mixdepthbal = self.wallet.get_balance_by_mixdepth(
+                    self.mixdepthbal = self.wallet_service.get_balance_by_mixdepth(
                         )[self.mixdepth]
                 #reset to satoshis
                 self.cjamount = int(self.cjamount * self.mixdepthbal)
@@ -183,15 +185,20 @@ class Taker(object):
                     self.cjamount = jm_single().mincjamount
             self.n_counterparties = si[2]
             self.my_cj_addr = si[3]
+            # for sweeps to external addresses we need an in-wallet import
+            # for the transaction monitor (this will be a no-op for txs to
+            # in-wallet addresses).
+            if self.cjamount == 0:
+                self.wallet_service.import_non_wallet_address(self.my_cj_addr)
+
             #if destination is flagged "INTERNAL", choose a destination
             #from the next mixdepth modulo the maxmixdepth
             if self.my_cj_addr == "INTERNAL":
                 next_mixdepth = (self.mixdepth + 1) % (
-                    self.wallet.mixdepth + 1)
+                    self.wallet_service.mixdepth + 1)
                 jlog.info("Choosing a destination from mixdepth: " + str(
                     next_mixdepth))
-                self.my_cj_addr = self.wallet.get_internal_addr(next_mixdepth,
-                                                bci=jm_single().bc_interface)
+                self.my_cj_addr = self.wallet_service.get_internal_addr(next_mixdepth)
                 jlog.info("Chose destination address: " + self.my_cj_addr)
             self.outputs = []
             self.cjfee_total = 0
@@ -277,8 +284,7 @@ class Taker(object):
         self.my_change_addr = None
         if self.cjamount != 0:
             try:
-                self.my_change_addr = self.wallet.get_internal_addr(self.mixdepth,
-                                                    bci=jm_single().bc_interface)
+                self.my_change_addr = self.wallet_service.get_internal_addr(self.mixdepth)
             except:
                 self.taker_info_callback("ABORT", "Failed to get a change address")
                 return False
@@ -291,15 +297,15 @@ class Taker(object):
             total_amount = self.cjamount + self.total_cj_fee + self.total_txfee
             jlog.info('total estimated amount spent = ' + str(total_amount))
             try:
-                self.input_utxos = self.wallet.select_utxos(self.mixdepth,
-                                                            total_amount)
+                self.input_utxos = self.wallet_service.select_utxos(self.mixdepth, total_amount,
+                                                        minconfs=1)
             except Exception as e:
                 self.taker_info_callback("ABORT",
                                     "Unable to select sufficient coins: " + repr(e))
                 return False
         else:
             #sweep
-            self.input_utxos = self.wallet.get_utxos_by_mixdepth()[self.mixdepth]
+            self.input_utxos = self.wallet_service.get_utxos_by_mixdepth()[self.mixdepth]
             #do our best to estimate the fee based on the number of
             #our own utxos; this estimate may be significantly higher
             #than the default set in option.txfee * makercount, where
@@ -310,7 +316,7 @@ class Taker(object):
             est_outs = 2*self.n_counterparties + 1
             jlog.debug("Estimated outs: "+str(est_outs))
             estimated_fee = estimate_tx_fee(est_ins, est_outs,
-                                            txtype=self.wallet.get_txtype())
+                                            txtype=self.wallet_service.get_txtype())
             jlog.debug("We have a fee estimate: "+str(estimated_fee))
             jlog.debug("And a requested fee of: "+str(
                 self.txfee_default * self.n_counterparties))
@@ -387,7 +393,7 @@ class Taker(object):
             auth_pub_bin = unhexlify(auth_pub)
             for inp in utxo_data:
                 try:
-                    if self.wallet.pubkey_has_script(
+                    if self.wallet_service.pubkey_has_script(
                             auth_pub_bin, unhexlify(inp['script'])):
                         break
                 except EngineError:
@@ -454,7 +460,7 @@ class Taker(object):
             #Estimate fee per choice of next/3/6 blocks targetting.
             estimated_fee = estimate_tx_fee(
                 len(sum(self.utxos.values(), [])), len(self.outputs) + 2,
-                txtype=self.wallet.get_txtype())
+                txtype=self.wallet_service.get_txtype())
             jlog.info("Based on initial guess: " + str(self.total_txfee) +
                      ", we estimated a miner fee of: " + str(estimated_fee))
             #reset total
@@ -495,7 +501,7 @@ class Taker(object):
                         for u in sum(self.utxos.values(), [])]
         self.outputs.append({'address': self.coinjoin_address(),
                              'value': self.cjamount})
-        tx = make_shuffled_tx(self.utxo_tx, self.outputs, False)
+        tx = btc.make_shuffled_tx(self.utxo_tx, self.outputs, False)
         jlog.info('obtained tx\n' + pprint.pformat(btc.deserialize(tx)))
 
         self.latest_tx = btc.deserialize(tx)
@@ -687,7 +693,7 @@ class Taker(object):
             new_utxos_dict = {k: v for k, v in utxos.items() if k in new_utxos}
             for k, v in iteritems(new_utxos_dict):
                 addr = v['address']
-                priv = self.wallet.get_key_from_addr(addr)
+                priv = self.wallet_service.get_key_from_addr(addr)
                 if priv:  #can be null from create-unsigned
                     priv_utxo_pairs.append((priv, k))
             return priv_utxo_pairs, too_old, too_small
@@ -714,9 +720,9 @@ class Taker(object):
             #in the transaction, about to be consumed, rather than use
             #random utxos that will persist after. At this step we also
             #allow use of external utxos in the json file.
-            if any(self.wallet.get_utxos_by_mixdepth_().values()):
+            if any(self.wallet_service.get_utxos_by_mixdepth(hexfmt=False).values()):
                 utxos = {}
-                for mdutxo in self.wallet.get_utxos_by_mixdepth().values():
+                for mdutxo in self.wallet_service.get_utxos_by_mixdepth().values():
                     utxos.update(mdutxo)
                 priv_utxo_pairs, to, ts = priv_utxo_pairs_from_utxos(
                     utxos, age, amt)
@@ -740,7 +746,7 @@ class Taker(object):
                     "Commitment sourced OK")
         else:
             errmsgheader, errmsg = generate_podle_error_string(priv_utxo_pairs,
-                        to, ts, self.wallet, self.cjamount,
+                        to, ts, self.wallet_service, self.cjamount,
                         jm_single().config.get("POLICY", "taker_utxo_age"),
                         jm_single().config.get("POLICY", "taker_utxo_amtpercent"))
 
@@ -766,10 +772,10 @@ class Taker(object):
             utxo = ins['outpoint']['hash'] + ':' + str(ins['outpoint']['index'])
             if utxo not in self.input_utxos.keys():
                 continue
-            script = self.wallet.addr_to_script(self.input_utxos[utxo]['address'])
+            script = self.wallet_service.addr_to_script(self.input_utxos[utxo]['address'])
             amount = self.input_utxos[utxo]['value']
             our_inputs[index] = (script, amount)
-        self.latest_tx = self.wallet.sign_tx(self.latest_tx, our_inputs)
+        self.latest_tx = self.wallet_service.sign_tx(self.latest_tx, our_inputs)
 
     def push(self):
         tx = btc.serialize(self.latest_tx)
@@ -783,13 +789,21 @@ class Taker(object):
             notify_addr = btc.address_to_script(self.my_cj_addr)
         else:
             notify_addr = self.my_cj_addr
-        #add the txnotify callbacks *before* pushing in case the
-        #walletnotify is triggered before the notify callbacks are set up;
+        #add the callbacks *before* pushing to ensure triggering;
         #this does leave a dangling notify callback if the push fails, but
         #that doesn't cause problems.
-        jm_single().bc_interface.add_tx_notify(self.latest_tx,
-                    self.unconfirm_callback, self.confirm_callback,
-                    notify_addr, vb=get_p2sh_vbyte())
+        self.wallet_service.register_callbacks([self.unconfirm_callback], self.txid,
+                                   "unconfirmed")
+        self.wallet_service.register_callbacks([self.confirm_callback], self.txid,
+                                   "confirmed")
+        task.deferLater(reactor,
+                        float(jm_single().config.getint(
+                            "TIMEOUT", "unconfirm_timeout_sec")),
+                        self.wallet_service.check_callback_called,
+                        self.txid, self.unconfirm_callback,
+                        "unconfirmed",
+        "transaction with txid: " + str(self.txid) + " not broadcast.")
+
         tx_broadcast = jm_single().config.get('POLICY', 'tx_broadcast')
         nick_to_use = None
         if tx_broadcast == 'self':
@@ -820,22 +834,44 @@ class Taker(object):
         self.self_sign()
         return self.push()
 
+    def tx_match(self, txd):
+        # Takers process only in series, so this should not occur:
+        assert self.latest_tx is not None
+        # check if the transaction matches our created tx:
+        if txd['outs'] != self.latest_tx['outs']:
+            return False
+        return True
+
     def unconfirm_callback(self, txd, txid):
+        if not self.tx_match(txd):
+            return False
         jlog.info("Transaction seen on network, waiting for confirmation")
         #To allow client to mark transaction as "done" (e.g. by persisting state)
         self.on_finished_callback(True, fromtx="unconfirmed")
         self.waiting_for_conf = True
+        confirm_timeout_sec = float(jm_single().config.get(
+            "TIMEOUT", "confirm_timeout_hours")) * 3600
+        task.deferLater(reactor, confirm_timeout_sec,
+                        self.wallet_service.check_callback_called,
+                        txid, self.confirm_callback, "confirmed",
+                        "transaction with txid " + str(txid) + " not confirmed.")
+        return True
 
     def confirm_callback(self, txd, txid, confirmations):
+        if not self.tx_match(txd):
+            return False
         self.waiting_for_conf = False
         if self.aborted:
-            #do not trigger on_finished processing (abort whole schedule)
-            return
+            #do not trigger on_finished processing (abort whole schedule),
+            # but we still return True as we have finished our listening
+            # for this tx:
+            return True
         jlog.debug("Confirmed callback in taker, confs: " + str(confirmations))
         fromtx=False if self.schedule_index + 1 == len(self.schedule) else True
         waittime = self.schedule[self.schedule_index][4]
         self.on_finished_callback(True, fromtx=fromtx, waittime=waittime,
                                   txdetails=(txd, txid))
+        return True
 
 class P2EPTaker(Taker):
     """ The P2EP Taker will initialize its protocol directly
@@ -845,8 +881,8 @@ class P2EPTaker(Taker):
     improves the privacy of the operation.
     """
 
-    def __init__(self, counterparty, wallet, schedule, callbacks):
-        super(P2EPTaker, self).__init__(wallet, schedule, callbacks=callbacks)
+    def __init__(self, counterparty, wallet_service, schedule, callbacks):
+        super(P2EPTaker, self).__init__(wallet_service, schedule, callbacks=callbacks)
         self.p2ep_receiver_nick = counterparty
         # Callback to request user permission (for e.g. GUI)
         # args: (1) message, as string
@@ -951,7 +987,7 @@ class P2EPTaker(Taker):
         # estimate the fee for the version of the transaction which is
         # not coinjoined:
         est_fee = estimate_tx_fee(len(self.input_utxos), 2,
-                                  txtype=self.wallet.get_txtype())
+                                  txtype=self.wallet_service.get_txtype())
         my_change_value = my_total_in - self.cjamount - est_fee
         if my_change_value <= 0:
             # as discussed in initialize(), this should be an extreme edge case.
@@ -973,7 +1009,7 @@ class P2EPTaker(Taker):
             "getblockchaininfo", [])["blocks"]
         # As for JM coinjoins, the `None` key is used for our own inputs
         # to the transaction; this preparatory version contains only those.
-        tx = make_shuffled_tx(self.utxos[None], self.outputs,
+        tx = btc.make_shuffled_tx(self.utxos[None], self.outputs,
                               False, 2, currentblock)
         jlog.info('Created proposed fallback tx\n' + pprint.pformat(
             btc.deserialize(tx)))
@@ -984,10 +1020,10 @@ class P2EPTaker(Taker):
         dtx = btc.deserialize(tx)
         for index, ins in enumerate(dtx['ins']):
             utxo = ins['outpoint']['hash'] + ':' + str(ins['outpoint']['index'])
-            script = self.wallet.addr_to_script(self.input_utxos[utxo]['address'])
+            script = self.wallet_service.addr_to_script(self.input_utxos[utxo]['address'])
             amount = self.input_utxos[utxo]['value']
             our_inputs[index] = (script, amount)
-        self.signed_noncj_tx = btc.serialize(self.wallet.sign_tx(dtx, our_inputs))
+        self.signed_noncj_tx = btc.serialize(self.wallet_service.sign_tx(dtx, our_inputs))
         self.taker_info_callback("INFO", "Built tx proposal, sending to receiver.")
         return (True, [self.p2ep_receiver_nick], self.signed_noncj_tx)
 
@@ -1153,7 +1189,7 @@ class P2EPTaker(Taker):
         # in joinmarket.cfg; allow either (a) automatic agreement for any value within
         # a range of 0.3 to 3x this figure, or (b) user to agree on prompt.
         fee_est = estimate_tx_fee(len(tx['ins']), len(tx['outs']),
-                                  txtype=self.wallet.get_txtype())
+                                  txtype=self.wallet_service.get_txtype())
         fee_ok = False
         if btc_fee > 0.3 * fee_est and btc_fee < 3 * fee_est:
             fee_ok = True

--- a/jmclient/jmclient/wallet_service.py
+++ b/jmclient/jmclient/wallet_service.py
@@ -1,0 +1,661 @@
+#! /usr/bin/env python
+from __future__ import (absolute_import, division,
+                        print_function, unicode_literals)
+
+import collections
+import time
+import ast
+import binascii
+from decimal import Decimal
+from copy import deepcopy
+from twisted.internet import reactor
+from twisted.internet import task
+from twisted.application.service import Service
+from numbers import Integral
+from jmclient.configure import jm_single, get_log
+from jmclient.output import fmt_tx_data
+from jmclient.jsonrpc import JsonRpcError
+from jmclient.blockchaininterface import INF_HEIGHT
+"""Wallet service
+
+The purpose of this independent service is to allow
+running applications to keep an up to date, asynchronous
+view of the current state of its wallet, deferring any
+polling mechanisms needed against the backend blockchain
+interface here.
+"""
+
+jlog = get_log()
+
+class WalletService(Service):
+    EXTERNAL_WALLET_LABEL = "joinmarket-notify"
+
+    def __init__(self, wallet):
+        # The two principal member variables
+        # are the blockchaininterface instance,
+        # which is currently global in JM but
+        # could be more flexible in future, and
+        # the JM wallet object.
+        self.bci = jm_single().bc_interface
+        # keep track of the quasi-real-time blockheight
+        # (updated in main monitor loop)
+        self.update_blockheight()
+        self.wallet = wallet
+        self.synced = False
+
+        # Dicts of registered callbacks, by type
+        # and then by txinfo, for events
+        # on transactions.
+        self.callbacks = {}
+        self.callbacks["all"] = []
+        self.callbacks["unconfirmed"] = {}
+        self.callbacks["confirmed"] = {}
+
+        self.restart_callback = None
+
+        # transactions we are actively monitoring,
+        # i.e. they are not new but we want to track:
+        self.active_txids = []
+        # to ensure transactions are only logged once:
+        self.logged_txids = []
+
+    def update_blockheight(self):
+        """ Can be called manually (on startup, or for tests)
+        but will be called as part of main monitoring
+        loop to ensure new transactions are added at
+        the right height.
+        """
+        try:
+            self.current_blockheight = self.bci.rpc("getblockcount", [])
+            assert isinstance(self.current_blockheight, Integral)
+        except Exception as e:
+            jlog.error("Failure to get blockheight from Bitcoin Core:")
+            jlog.error(repr(e))
+            return
+
+    def startService(self):
+        """ Encapsulates start up actions.
+        Here wallet sync.
+        """
+        super(WalletService, self).startService()
+        self.request_sync_wallet()
+
+    def stopService(self):
+        """ Encapsulates shut down actions.
+        Here shut down main tx monitoring loop.
+        """
+        self.monitor_loop.stop()
+        super(WalletService, self).stopService()
+
+    def isRunning(self):
+        if self.running == 1:
+            return True
+        return False
+
+    def add_restart_callback(self, callback):
+        """ Sets the function that will be
+        called in the event that the wallet
+        sync completes with a restart warning.
+        The only argument is a message string,
+        which the calling function displays to
+        the user before quitting gracefully.
+        """
+        self.restart_callback = callback
+
+    def request_sync_wallet(self):
+        """ Ensures wallet sync is complete
+        before the main event loop starts.
+        """
+        d = task.deferLater(reactor, 0.0, self.sync_wallet)
+        d.addCallback(self.start_wallet_monitoring)
+
+    def register_callbacks(self, callbacks, txinfo, cb_type="all"):
+        """ Register callbacks that will be called by the
+        transaction monitor loop, on transactions stored under
+        our wallet label (see WalletService.get_wallet_name()).
+        Callback arguments are currently (txd, txid) and return
+        is boolean, except "confirmed" callbacks which have
+        arguments (txd, txid, confirmations).
+        Note that callbacks MUST correctly return True if they
+        recognized the transaction and processed it, and False
+        if not. The True return value will be used to remove
+        the callback from the list.
+        Arguments:
+        `callbacks` - a list of functions with signature as above
+        and return type boolean.
+        `txinfo` - either a txid expected for the transaction, if
+        known, or a tuple of the ordered output set, of the form
+        (('script': script), ('value': value), ..). This can be
+        constructed from jmbitcoin.deserialize output, key "outs",
+        using tuple(). See WalletService.transaction_monitor().
+        `cb_type` - must be one of "all", "unconfirmed", "confirmed";
+        the first type will be called back once for every new
+        transaction, the second only once when the number of
+        confirmations is 0, and the third only once when the number
+        of confirmations is > 0.
+        """
+        if cb_type == "all":
+            # note that in this case, txid is ignored.
+            self.callbacks["all"].extend(callbacks)
+        elif cb_type in ["unconfirmed", "confirmed"]:
+            if txinfo not in self.callbacks[cb_type]:
+                self.callbacks[cb_type][txinfo] = []
+            self.callbacks[cb_type][txinfo].extend(callbacks)
+        else:
+            assert False, "Invalid argument: " + cb_type
+
+
+    def start_wallet_monitoring(self, syncresult):
+        """ Once the initialization of the service
+        (currently, means: wallet sync) is complete,
+        we start the main monitoring jobs of the
+        wallet service (currently, means: monitoring
+        all new transactions on the blockchain that
+        are recognised as belonging to the Bitcoin
+        Core wallet with the JM wallet's label).
+        """
+        if not syncresult:
+            jlog.error("Failed to sync the bitcoin wallet. Shutting down.")
+            reactor.stop()
+            return
+        jlog.info("Starting transaction monitor in walletservice")
+        self.monitor_loop = task.LoopingCall(
+            self.transaction_monitor)
+        self.monitor_loop.start(5.0)
+
+    def import_non_wallet_address(self, address):
+        """ Used for keeping track of transactions which
+        have no in-wallet destinations. External wallet
+        label is used to avoid breaking fast sync (which
+        assumes label => wallet)
+        """
+        if not self.bci.is_address_imported(address):
+            self.bci.import_addresses([address], self.EXTERNAL_WALLET_LABEL,
+                                  restart_cb=self.restart_callback)
+
+    def transaction_monitor(self):
+        """Keeps track of any changes in the wallet (new transactions).
+        Intended to be run as a twisted task.LoopingCall so that this
+        Service is constantly in near-realtime sync with the blockchain.
+        """
+
+        self.update_blockheight()
+
+        txlist = self.bci.list_transactions(100)
+        new_txs = []
+        for x in txlist:
+            # process either (a) a completely new tx or
+            # (b) a tx that reached unconf status but we are still
+            # waiting for conf (active_txids)
+            if x['txid'] in self.active_txids or x['txid'] not in self.old_txs:
+                new_txs.append(x)
+        # reset for next polling event:
+        self.old_txs = [x['txid'] for x in txlist]
+
+        for tx in new_txs:
+            txid = tx["txid"]
+            res = self.bci.get_transaction(txid)
+            if not res:
+                continue
+            confs = res["confirmations"]
+            if not isinstance(confs, Integral):
+                jlog.warning("Malformed gettx result: " + str(res))
+                continue
+            if confs < 0:
+                jlog.info(
+                    "Transaction: " + txid + " has a conflict, abandoning.")
+                continue
+            if confs == 0:
+                height = None
+            else:
+                height = self.current_blockheight - confs + 1
+
+            txd = self.bci.get_deser_from_gettransaction(res)
+            if txd is None:
+                continue
+            removed_utxos, added_utxos = self.wallet.process_new_tx(txd, txid, height)
+            # TODO note that this log message will be missed if confirmation
+            # is absurdly fast, this is considered acceptable compared with
+            # additional complexity.
+            if txid not in self.logged_txids:
+                self.log_new_tx(removed_utxos, added_utxos, txid)
+                self.logged_txids.append(txid)
+
+            # first fire 'all' type callbacks, irrespective of if the
+            # transaction pertains to anything known (but must
+            # have correct label per above); filter on this Joinmarket wallet label,
+            # or the external monitoring label:
+            if "label" in tx and tx["label"] in [
+                self.EXTERNAL_WALLET_LABEL, self.get_wallet_name()]:
+                for f in self.callbacks["all"]:
+                    # note we need no return value as we will never
+                    # remove these from the list
+                    f(txd, txid)
+
+            # The tuple given as the second possible key for the dict
+            # is such because dict keys must be hashable types, so a simple
+            # replication of the entries in the list tx["outs"], where tx
+            # was generated via jmbitcoin.deserialize, is unacceptable to
+            # Python, since they are dicts. However their keyset is deterministic
+            # so it is sufficient to convert these dicts to tuples with fixed
+            # ordering, thus it can be used as a key into the self.callbacks
+            # dicts. (This is needed because txid is not always available
+            # at the time of callback registration).
+            possible_keys = [txid, tuple(
+                    (x["script"], x["value"]) for x in txd["outs"])]
+
+            # note that len(added_utxos) > 0 is not a sufficient condition for
+            # the tx being new, since wallet.add_new_utxos will happily re-add
+            # a utxo that already exists; but this does not cause re-firing
+            # of callbacks since we in these cases delete the callback after being
+            # called once.
+            # Note also that it's entirely possible that there are only removals,
+            # not additions, to the utxo set, specifically in sweeps to external
+            # addresses. In this case, since removal can by definition only
+            # happen once, we must allow entries in self.active_txids through the
+            # filter.
+            if len(added_utxos) > 0 or len(removed_utxos) > 0 \
+               or txid in self.active_txids:
+                if confs == 0:
+                    for k in possible_keys:
+                        if k in self.callbacks["unconfirmed"]:
+                            for f in self.callbacks["unconfirmed"][k]:
+                                # True implies success, implies removal:
+                                if f(txd, txid):
+                                    self.callbacks["unconfirmed"][k].remove(f)
+                                    # keep monitoring for conf > 0:
+                                    self.active_txids.append(txid)
+                elif confs > 0:
+                    for k in possible_keys:
+                        if k in self.callbacks["confirmed"]:
+                            for f in self.callbacks["confirmed"][k]:
+                                if f(txd, txid, confs):
+                                    self.callbacks["confirmed"][k].remove(f)
+                                    if txid in self.active_txids:
+                                        self.active_txids.remove(txid)
+
+    def check_callback_called(self, txinfo, callback, cbtype, msg):
+        """ Intended to be a deferred Task to be scheduled some
+        set time after the callback was registered. "all" type
+        callbacks do not expire and are not included.
+        """
+        assert cbtype in ["unconfirmed", "confirmed"]
+        if txinfo in self.callbacks[cbtype]:
+            if callback in self.callbacks[cbtype][txinfo]:
+                # the callback was not called, drop it and warn
+                self.callbacks[cbtype][txinfo].remove(callback)
+                # TODO - dangling txids in self.active_txids will
+                # be caused by this, but could also happen for
+                # other reasons; possibly add logic to ensure that
+                # this never occurs, although their presence should
+                # not cause a functional error.
+                jlog.info("Timed out: " + msg)
+                # if callback is not in the list, it was already
+                # processed and so do nothing.
+
+    def log_new_tx(self, removed_utxos, added_utxos, txid):
+        """ Changes to the wallet are logged at INFO level by
+        the WalletService.
+        """
+        def report_changed(x, utxos):
+            if len(utxos.keys()) > 0:
+                jlog.info(x + ' utxos=\n{}'.format('\n'.join(
+                    '{} - {}'.format(u, fmt_tx_data(tx_data, self))
+                    for u, tx_data in utxos.items())))
+
+        report_changed("Removed", removed_utxos)
+        report_changed("Added", added_utxos)
+
+
+        """ Wallet syncing code
+        """
+
+    def sync_wallet(self, fast=True):
+        """ Syncs wallet; note that if slow sync
+        requires multiple rounds this must be called
+        until self.synced is True.
+        Before starting the event loop, we cache
+        the current most recent transactions as
+        reported by the blockchain interface, since
+        we are interested in deltas.
+        """
+        # If this is called when syncing already complete:
+        if self.synced:
+            return True
+        if fast:
+            self.sync_wallet_fast()
+        else:
+            self.sync_addresses()
+            self.sync_unspent()
+        # Don't attempt updates on transactions that existed
+        # before startup
+        self.old_txs = [x['txid'] for x in self.bci.list_transactions(100)]
+        return self.synced
+
+    def resync_wallet(self, fast=True):
+        """ The self.synced state is generally
+        updated to True, once, at the start of
+        a run of a particular program. Here we
+        can manually force re-sync.
+        """
+        self.synced = False
+        self.sync_wallet(fast=fast)
+
+    def sync_wallet_fast(self):
+        """Exploits the fact that given an index_cache,
+        all addresses necessary should be imported, so we
+        can just list all used addresses to find the right
+        index values.
+        """
+        self.get_address_usages()
+        self.sync_unspent()
+
+    def get_address_usages(self):
+        """Use rpc `listaddressgroupings` to locate all used
+        addresses in the account (whether spent or unspent outputs).
+        This will not result in a full sync if working with a new
+        Bitcoin Core instance, in which case "fast" should have been
+        specifically disabled by the user.
+        """
+        wallet_name = self.get_wallet_name()
+        agd = self.bci.rpc('listaddressgroupings', [])
+        # flatten all groups into a single list; then, remove duplicates
+        fagd = (tuple(item) for sublist in agd for item in sublist)
+        # "deduplicated flattened address grouping data" = dfagd
+        dfagd = set(fagd)
+        used_addresses = set()
+        for addr_info in dfagd:
+            if len(addr_info) < 3 or addr_info[2] != wallet_name:
+                continue
+            used_addresses.add(addr_info[0])
+
+        # for a first run, import first chunk
+        if not used_addresses:
+            jlog.info("Detected new wallet, performing initial import")
+            # delegate inital address import to sync_addresses
+            # this should be fast because "getaddressesbyaccount" should return
+            # an empty list in this case
+            self.sync_addresses()
+            self.synced = True
+            return
+
+        # Wallet has been used; scan forwards.
+        jlog.debug("Fast sync in progress. Got this many used addresses: " + str(
+            len(used_addresses)))
+        # Need to have wallet.index point to the last used address
+        # Algo:
+        #    1. Scan batch 1 of each branch, record matched wallet addresses.
+        #    2. Check if all addresses in 'used addresses' have been matched, if
+        #       so, break.
+        #    3. Repeat the above for batch 2, 3.. up to max 20 batches.
+        #    4. If after all 20 batches not all used addresses were matched,
+        #       quit with error.
+        #    5. Calculate used indices.
+        #    6. If all used addresses were matched, set wallet index to highest
+        #       found index in each branch and mark wallet sync complete.
+        # Rationale for this algo:
+        #    Retrieving addresses is a non-zero computational load, so batching
+        #    and then caching allows a small sync to complete *reasonably*
+        #    quickly while a larger one is not really negatively affected.
+        #    The downside is another free variable, batch size, but this need
+        #    not be exposed to the user; it is not the same as gap limit, in fact,
+        #    the concept of gap limit does not apply to this kind of sync, which
+        #    *assumes* that the most recent usage of addresses is indeed recorded.
+        remaining_used_addresses = used_addresses.copy()
+        addresses, saved_indices = self.collect_addresses_init()
+        for addr in addresses:
+            remaining_used_addresses.discard(addr)
+
+        BATCH_SIZE = 100
+        MAX_ITERATIONS = 20
+        current_indices = deepcopy(saved_indices)
+        for j in range(MAX_ITERATIONS):
+            if not remaining_used_addresses:
+                break
+            for addr in \
+                self.collect_addresses_gap(gap_limit=BATCH_SIZE):
+                remaining_used_addresses.discard(addr)
+
+            # increase wallet indices for next iteration
+            for md in current_indices:
+                current_indices[md][0] += BATCH_SIZE
+                current_indices[md][1] += BATCH_SIZE
+            self.rewind_wallet_indices(current_indices, current_indices)
+        else:
+            self.rewind_wallet_indices(saved_indices, saved_indices)
+            raise Exception("Failed to sync in fast mode after 20 batches; "
+                            "please re-try wallet sync with --recoversync flag.")
+
+        # creating used_indices on-the-fly would be more efficient, but the
+        # overall performance gain is probably negligible
+        used_indices = self.get_used_indices(used_addresses)
+        self.rewind_wallet_indices(used_indices, saved_indices)
+        self.synced = True
+
+    def sync_addresses(self):
+        """ Triggered by use of --recoversync option in scripts,
+        attempts a full scan of the blockchain without assuming
+        anything about past usages of addresses (does not use
+        wallet.index_cache as hint).
+        """
+        jlog.debug("requesting detailed wallet history")
+        wallet_name = self.get_wallet_name()
+        addresses, saved_indices = self.collect_addresses_init()
+        try:
+            imported_addresses = set(self.bci.rpc('getaddressesbyaccount',
+                                                  [wallet_name]))
+        except JsonRpcError:
+            if wallet_name in self.bci.rpc('listlabels', []):
+                imported_addresses = set(self.bci.rpc('getaddressesbylabel',
+                                                      [wallet_name]).keys())
+            else:
+                imported_addresses = set()
+
+        if not addresses.issubset(imported_addresses):
+            self.bci.add_watchonly_addresses(addresses - imported_addresses,
+                                             wallet_name, self.restart_callback)
+            return
+
+        used_addresses_gen = (tx['address']
+                              for tx in self.bci._yield_transactions(wallet_name)
+                              if tx['category'] == 'receive')
+        used_indices = self.get_used_indices(used_addresses_gen)
+        jlog.debug("got used indices: {}".format(used_indices))
+        gap_limit_used = not self.check_gap_indices(used_indices)
+        self.rewind_wallet_indices(used_indices, saved_indices)
+
+        new_addresses = self.collect_addresses_gap()
+        if not new_addresses.issubset(imported_addresses):
+            jlog.debug("Syncing iteration finished, additional step required")
+            self.bci.add_watchonly_addresses(new_addresses - imported_addresses,
+                                             wallet_name, self.restart_callback)
+            self.synced = False
+        elif gap_limit_used:
+            jlog.debug("Syncing iteration finished, additional step required")
+            self.synced = False
+        else:
+            jlog.debug("Wallet successfully synced")
+            self.rewind_wallet_indices(used_indices, saved_indices)
+            self.synced = True
+
+    def sync_unspent(self):
+        st = time.time()
+        # block height needs to be real time for addition to our utxos:
+        current_blockheight = self.bci.rpc("getblockcount", [])
+        wallet_name = self.get_wallet_name()
+        self.reset_utxos()
+
+        listunspent_args = []
+        if 'listunspent_args' in jm_single().config.options('POLICY'):
+            listunspent_args = ast.literal_eval(jm_single().config.get(
+                'POLICY', 'listunspent_args'))
+
+        unspent_list = self.bci.rpc('listunspent', listunspent_args)
+        unspent_list = [x for x in unspent_list if "label" in x]
+        # filter on label, but note (a) in certain circumstances (in-
+        # wallet transfer) it is possible for the utxo to be labeled
+        # with the external label, and (b) the wallet will know if it
+        # belongs or not anyway (is_known_addr):
+        our_unspent_list = [x for x in unspent_list if x["label"] in [
+            wallet_name, self.EXTERNAL_WALLET_LABEL]]
+        for u in our_unspent_list:
+            if not self.is_known_addr(u['address']):
+                continue
+            self._add_unspent_utxo(u, current_blockheight)
+        et = time.time()
+        jlog.debug('bitcoind sync_unspent took ' + str((et - st)) + 'sec')
+
+    def _add_unspent_utxo(self, utxo, current_blockheight):
+        """
+        Add a UTXO as returned by rpc's listunspent call to the wallet.
+
+        params:
+            utxo: single utxo dict as returned by listunspent
+            current_blockheight: blockheight as integer, used to
+            set the block in which a confirmed utxo is included.
+        """
+        txid = binascii.unhexlify(utxo['txid'])
+        script = binascii.unhexlify(utxo['scriptPubKey'])
+        value = int(Decimal(str(utxo['amount'])) * Decimal('1e8'))
+        confs = int(utxo['confirmations'])
+        # wallet's utxo database needs to store an absolute rather
+        # than relative height measure:
+        height = None
+        if confs < 0:
+            jlog.warning("Utxo not added, has a conflict: " + str(utxo))
+            return
+        if confs >=1 :
+            height = current_blockheight - confs + 1
+        self.add_utxo(txid, int(utxo['vout']), script, value, height)
+
+
+    """ The following functions mostly are not pure
+    pass through to the underlying wallet, so declared
+    here; the remainder are covered by the __getattr__
+    fallback.
+    """
+
+    def save_wallet(self):
+        self.wallet.save()
+
+    def get_utxos_by_mixdepth(self, include_disabled=False,
+                              verbose=False, hexfmt=True, includeconfs=False):
+        """ Returns utxos by mixdepth in a dict, optionally including
+        information about how many confirmations each utxo has.
+        TODO clean up underlying wallet.get_utxos_by_mixdepth (including verbosity
+        and formatting options) to make this less confusing.
+        """
+        def height_to_confs(x):
+            # convert height entries to confirmations:
+            ubym_conv = collections.defaultdict(dict)
+            for m, i in x.items():
+                for u, d in i.items():
+                    ubym_conv[m][u] = d
+                    h = ubym_conv[m][u].pop("height")
+                    if h == INF_HEIGHT:
+                        confs = 0
+                    else:
+                        confs = self.current_blockheight - h + 1
+                    ubym_conv[m][u]["confs"] = confs
+            return ubym_conv
+
+        if hexfmt:
+            ubym = self.wallet.get_utxos_by_mixdepth(verbose=verbose,
+                                                     includeheight=includeconfs)
+            if not includeconfs:
+                return ubym
+            else:
+                return height_to_confs(ubym)
+        else:
+            ubym = self.wallet.get_utxos_by_mixdepth_(
+            include_disabled=include_disabled, includeheight=includeconfs)
+            if not includeconfs:
+                return ubym
+            else:
+                return height_to_confs(ubym)
+
+    def select_utxos(self, mixdepth, amount, utxo_filter=None, select_fn=None,
+                     minconfs=None):
+        """ Request utxos from the wallet in a particular mixdepth to satisfy
+        a certain total amount, optionally set the selector function (or use
+        the currently configured function set by the wallet, and optionally
+        require a minimum of minconfs confirmations (default none means
+        unconfirmed are allowed).
+        """
+        if minconfs is None:
+            maxheight = None
+        else:
+            maxheight = self.current_blockheight - minconfs + 1
+        return self.wallet.select_utxos(mixdepth, amount, utxo_filter=utxo_filter,
+                                    select_fn=select_fn, maxheight=maxheight)
+
+    def get_balance_by_mixdepth(self, verbose=True,
+                                include_disabled=False,
+                                minconfs=None):
+        if minconfs is None:
+            maxheight = None
+        else:
+            maxheight = self.current_blockheight - minconfs + 1
+        return self.wallet.get_balance_by_mixdepth(verbose=verbose,
+                                                   include_disabled=include_disabled,
+                                                   maxheight=maxheight)
+
+    def get_internal_addr(self, mixdepth):
+        if self.bci is not None and hasattr(self.bci, 'import_addresses'):
+            addr = self.wallet.get_internal_addr(mixdepth)
+            self.bci.import_addresses([addr],
+                                      self.wallet.get_wallet_name())
+        return addr
+
+    def collect_addresses_init(self):
+        """ Collects the "current" set of addresses,
+        as defined by the indices recorded in the wallet's
+        index cache (persisted in the wallet file usually).
+        Note that it collects up to the current indices plus
+        the gap limit.
+        """
+        addresses = set()
+        saved_indices = dict()
+
+        for md in range(self.max_mixdepth + 1):
+            saved_indices[md] = [0, 0]
+            for internal in (0, 1):
+                next_unused = self.get_next_unused_index(md, internal)
+                for index in range(next_unused):
+                    addresses.add(self.get_addr(md, internal, index))
+                for index in range(self.gap_limit):
+                    addresses.add(self.get_new_addr(md, internal))
+                # reset the indices to the value we had before the
+                # new address calls:
+                self.set_next_index(md, internal, next_unused)
+                saved_indices[md][internal] = next_unused
+            # include any imported addresses
+            for path in self.yield_imported_paths(md):
+                addresses.add(self.get_addr_path(path))
+
+        return addresses, saved_indices
+
+    def collect_addresses_gap(self, gap_limit=None):
+        gap_limit = gap_limit or self.gap_limit
+        addresses = set()
+
+        for md in range(self.max_mixdepth + 1):
+            for internal in (True, False):
+                old_next = self.get_next_unused_index(md, internal)
+                for index in range(gap_limit):
+                    addresses.add(self.get_new_addr(md, internal))
+                self.set_next_index(md, internal, old_next)
+
+        return addresses
+
+    def get_external_addr(self, mixdepth):
+        if self.bci is not None and hasattr(self.bci, 'import_addresses'):
+            addr = self.wallet.get_external_addr(mixdepth)
+            self.bci.import_addresses([addr],
+                                      self.wallet.get_wallet_name())
+        return addr
+
+    def __getattr__(self, attr):
+        # any method not present here is passed
+        # to the wallet:
+        return getattr(self.wallet, attr)

--- a/jmclient/test/test_blockchaininterface.py
+++ b/jmclient/test/test_blockchaininterface.py
@@ -9,16 +9,16 @@ from commontest import create_wallet_for_sync
 
 import pytest
 from jmbase import get_log
-from jmclient import load_program_config, jm_single, sync_wallet
+from jmclient import load_program_config, jm_single
 
 log = get_log()
 
 
-def sync_test_wallet(fast, wallet):
+def sync_test_wallet(fast, wallet_service):
     sync_count = 0
-    jm_single().bc_interface.wallet_synced = False
-    while not jm_single().bc_interface.wallet_synced:
-        sync_wallet(wallet, fast=fast)
+    wallet_service.synced = False
+    while not wallet_service.synced:
+        wallet_service.sync_wallet(fast=fast)
         sync_count += 1
         # avoid infinite loop
         assert sync_count < 10
@@ -27,15 +27,15 @@ def sync_test_wallet(fast, wallet):
 
 @pytest.mark.parametrize('fast', (False, True))
 def test_empty_wallet_sync(setup_wallets, fast):
-    wallet = create_wallet_for_sync([0, 0, 0, 0, 0], ['test_empty_wallet_sync'])
+    wallet_service = create_wallet_for_sync([0, 0, 0, 0, 0], ['test_empty_wallet_sync'])
 
-    sync_test_wallet(fast, wallet)
+    sync_test_wallet(fast, wallet_service)
 
     broken = True
-    for md in range(wallet.max_mixdepth + 1):
+    for md in range(wallet_service.max_mixdepth + 1):
         for internal in (True, False):
             broken = False
-            assert 0 == wallet.get_next_unused_index(md, internal)
+            assert 0 == wallet_service.get_next_unused_index(md, internal)
     assert not broken
 
 
@@ -44,106 +44,115 @@ def test_empty_wallet_sync(setup_wallets, fast):
         (True, False), (True, True)))
 def test_sequentially_used_wallet_sync(setup_wallets, fast, internal):
     used_count = [1, 3, 6, 2, 23]
-    wallet = create_wallet_for_sync(
+    wallet_service = create_wallet_for_sync(
         used_count, ['test_sequentially_used_wallet_sync'],
         populate_internal=internal)
 
-    sync_test_wallet(fast, wallet)
+    sync_test_wallet(fast, wallet_service)
 
     broken = True
     for md in range(len(used_count)):
         broken = False
-        assert used_count[md] == wallet.get_next_unused_index(md, internal)
+        assert used_count[md] == wallet_service.get_next_unused_index(md, internal)
     assert not broken
 
 
-@pytest.mark.parametrize('fast', (False, True))
+@pytest.mark.parametrize('fast', (False,))
 def test_gap_used_wallet_sync(setup_wallets, fast):
+    """ After careful examination this test now only includes the Recovery sync.
+    Note: pre-Aug 2019, because of a bug, this code was not in fact testing both
+    Fast and Recovery sync, but only Recovery (twice). Also, the scenario set
+    out in this test (where coins are funded to a wallet which has no index-cache,
+    and initially no imports) is only appropriate for recovery-mode sync, not for
+    fast-mode (the now default).
+    """
     used_count = [1, 3, 6, 2, 23]
-    wallet = create_wallet_for_sync(used_count, ['test_gap_used_wallet_sync'])
-    wallet.gap_limit = 20
+    wallet_service = create_wallet_for_sync(used_count, ['test_gap_used_wallet_sync'])
+    wallet_service.gap_limit = 20
 
     for md in range(len(used_count)):
         x = -1
         for x in range(md):
-            assert x <= wallet.gap_limit, "test broken"
+            assert x <= wallet_service.gap_limit, "test broken"
             # create some unused addresses
-            wallet.get_new_script(md, True)
-            wallet.get_new_script(md, False)
+            wallet_service.get_new_script(md, True)
+            wallet_service.get_new_script(md, False)
         used_count[md] += x + 2
-        jm_single().bc_interface.grab_coins(wallet.get_new_addr(md, True), 1)
-        jm_single().bc_interface.grab_coins(wallet.get_new_addr(md, False), 1)
+        jm_single().bc_interface.grab_coins(wallet_service.get_new_addr(md, True), 1)
+        jm_single().bc_interface.grab_coins(wallet_service.get_new_addr(md, False), 1)
 
     # reset indices to simulate completely unsynced wallet
-    for md in range(wallet.max_mixdepth + 1):
-        wallet.set_next_index(md, True, 0)
-        wallet.set_next_index(md, False, 0)
-
-    sync_test_wallet(fast, wallet)
+    for md in range(wallet_service.max_mixdepth + 1):
+        wallet_service.set_next_index(md, True, 0)
+        wallet_service.set_next_index(md, False, 0)
+    sync_test_wallet(fast, wallet_service)
 
     broken = True
     for md in range(len(used_count)):
         broken = False
-        assert md + 1 == wallet.get_next_unused_index(md, True)
-        assert used_count[md] == wallet.get_next_unused_index(md, False)
+        assert md + 1 == wallet_service.get_next_unused_index(md, True)
+        assert used_count[md] == wallet_service.get_next_unused_index(md, False)
     assert not broken
 
 
-@pytest.mark.parametrize('fast', (False, True))
+@pytest.mark.parametrize('fast', (False,))
 def test_multigap_used_wallet_sync(setup_wallets, fast):
+    """ See docstring for test_gap_used_wallet_sync; exactly the
+    same applies here.
+    """
     start_index = 5
     used_count = [start_index, 0, 0, 0, 0]
-    wallet = create_wallet_for_sync(used_count, ['test_multigap_used_wallet_sync'])
-    wallet.gap_limit = 5
+    wallet_service = create_wallet_for_sync(used_count, ['test_multigap_used_wallet_sync'])
+    wallet_service.gap_limit = 5
 
     mixdepth = 0
     for w in range(5):
-        for x in range(int(wallet.gap_limit * 0.6)):
-            assert x <= wallet.gap_limit, "test broken"
+        for x in range(int(wallet_service.gap_limit * 0.6)):
+            assert x <= wallet_service.gap_limit, "test broken"
             # create some unused addresses
-            wallet.get_new_script(mixdepth, True)
-            wallet.get_new_script(mixdepth, False)
+            wallet_service.get_new_script(mixdepth, True)
+            wallet_service.get_new_script(mixdepth, False)
         used_count[mixdepth] += x + 2
-        jm_single().bc_interface.grab_coins(wallet.get_new_addr(mixdepth, True), 1)
-        jm_single().bc_interface.grab_coins(wallet.get_new_addr(mixdepth, False), 1)
+        jm_single().bc_interface.grab_coins(wallet_service.get_new_addr(mixdepth, True), 1)
+        jm_single().bc_interface.grab_coins(wallet_service.get_new_addr(mixdepth, False), 1)
 
     # reset indices to simulate completely unsynced wallet
-    for md in range(wallet.max_mixdepth + 1):
-        wallet.set_next_index(md, True, 0)
-        wallet.set_next_index(md, False, 0)
+    for md in range(wallet_service.max_mixdepth + 1):
+        wallet_service.set_next_index(md, True, 0)
+        wallet_service.set_next_index(md, False, 0)
 
-    sync_test_wallet(fast, wallet)
+    sync_test_wallet(fast, wallet_service)
 
-    assert used_count[mixdepth] - start_index == wallet.get_next_unused_index(mixdepth, True)
-    assert used_count[mixdepth] == wallet.get_next_unused_index(mixdepth, False)
+    assert used_count[mixdepth] - start_index == wallet_service.get_next_unused_index(mixdepth, True)
+    assert used_count[mixdepth] == wallet_service.get_next_unused_index(mixdepth, False)
 
 
 @pytest.mark.parametrize('fast', (False, True))
 def test_retain_unused_indices_wallet_sync(setup_wallets, fast):
     used_count = [0, 0, 0, 0, 0]
-    wallet = create_wallet_for_sync(used_count, ['test_retain_unused_indices_wallet_sync'])
+    wallet_service = create_wallet_for_sync(used_count, ['test_retain_unused_indices_wallet_sync'])
 
     for x in range(9):
-        wallet.get_new_script(0, 1)
+        wallet_service.get_new_script(0, 1)
 
-    sync_test_wallet(fast, wallet)
+    sync_test_wallet(fast, wallet_service)
 
-    assert wallet.get_next_unused_index(0, 1) == 9
+    assert wallet_service.get_next_unused_index(0, 1) == 9
 
 
 @pytest.mark.parametrize('fast', (False, True))
 def test_imported_wallet_sync(setup_wallets, fast):
     used_count = [0, 0, 0, 0, 0]
-    wallet = create_wallet_for_sync(used_count, ['test_imported_wallet_sync'])
-    source_wallet = create_wallet_for_sync(used_count, ['test_imported_wallet_sync_origin'])
+    wallet_service = create_wallet_for_sync(used_count, ['test_imported_wallet_sync'])
+    source_wallet_service = create_wallet_for_sync(used_count, ['test_imported_wallet_sync_origin'])
 
-    address = source_wallet.get_new_addr(0, 1)
-    wallet.import_private_key(0, source_wallet.get_wif(0, 1, 0))
+    address = source_wallet_service.get_internal_addr(0)
+    wallet_service.import_private_key(0, source_wallet_service.get_wif(0, 1, 0))
     txid = binascii.unhexlify(jm_single().bc_interface.grab_coins(address, 1))
 
-    sync_test_wallet(fast, wallet)
+    sync_test_wallet(fast, wallet_service)
 
-    assert wallet._utxos.have_utxo(txid, 0) == 0
+    assert wallet_service._utxos.have_utxo(txid, 0) == 0
 
 
 @pytest.fixture(scope='module')

--- a/jmclient/test/test_maker.py
+++ b/jmclient/test/test_maker.py
@@ -6,7 +6,7 @@ from builtins import * # noqa: F401
 
 import jmbitcoin as btc
 from jmclient import Maker, get_p2sh_vbyte, get_p2pk_vbyte, \
-    load_program_config, jm_single
+    load_program_config, jm_single, WalletService
 import jmclient
 from commontest import DummyBlockchainInterface
 from test_taker import DummyWallet
@@ -116,7 +116,7 @@ def test_verify_unsigned_tx_sw_valid(setup_env_nodeps):
     p2pkh_gen = address_p2pkh_generator()
 
     wallet = DummyWallet()
-    maker = OfflineMaker(wallet)
+    maker = OfflineMaker(WalletService(wallet))
 
     cj_addr, cj_script = next(p2sh_gen)
     changeaddr, cj_change_script = next(p2sh_gen)
@@ -149,7 +149,7 @@ def test_verify_unsigned_tx_nonsw_valid(setup_env_nodeps):
     p2pkh_gen = address_p2pkh_generator()
 
     wallet = DummyWallet()
-    maker = OfflineMaker(wallet)
+    maker = OfflineMaker(WalletService(wallet))
 
     cj_addr, cj_script = next(p2pkh_gen)
     changeaddr, cj_change_script = next(p2pkh_gen)

--- a/jmclient/test/test_podle.py
+++ b/jmclient/test/test_podle.py
@@ -196,14 +196,14 @@ def test_podle_error_string(setup_podle):
                              ('fakepriv2', 'fakeutxo2')]
     to = ['tooold1', 'tooold2']
     ts = ['toosmall1', 'toosmall2']
-    wallet = make_wallets(1, [[1, 0, 0, 0, 0]])[0]['wallet']
+    wallet_service = make_wallets(1, [[1, 0, 0, 0, 0]])[0]['wallet']
     cjamt = 100
     tua = "3"
     tuamtper = "20"
     errmgsheader, errmsg = generate_podle_error_string(priv_utxo_pairs,
                                                        to,
                                                        ts,
-                                                       wallet,
+                                                       wallet_service,
                                                        cjamt,
                                                        tua,
                                                        tuamtper)
@@ -212,7 +212,7 @@ def test_podle_error_string(setup_podle):
     y = [x[1] for x in priv_utxo_pairs]
     assert all([errmsg.find(x) != -1 for x in to + ts + y])
     #ensure OK with nothing
-    errmgsheader, errmsg = generate_podle_error_string([], [], [], wallet,
+    errmgsheader, errmsg = generate_podle_error_string([], [], [], wallet_service,
                                                        cjamt, tua, tuamtper)
 
 @pytest.fixture(scope="module")

--- a/jmclient/test/test_storage.py
+++ b/jmclient/test/test_storage.py
@@ -84,7 +84,6 @@ def test_storage_invalid():
         MockStorage(b'garbagefile', __file__, b'password')
         pytest.fail("Non-wallet file, encrypted")
 
-
 def test_storage_readonly():
     s = MockStorage(None, 'nonexistant', b'password', create=True)
     s = MockStorage(s.file_data, __file__, b'password', read_only=True)

--- a/jmclient/test/test_utxomanager.py
+++ b/jmclient/test/test_utxomanager.py
@@ -32,11 +32,11 @@ def test_utxomanager_persist(setup_env_nodeps):
     mixdepth = 0
     value = 500
 
-    um.add_utxo(txid, index, path, value, mixdepth)
-    um.add_utxo(txid, index+1, path, value, mixdepth+1)
+    um.add_utxo(txid, index, path, value, mixdepth, 1)
+    um.add_utxo(txid, index+1, path, value, mixdepth+1, 2)
     # the third utxo will be disabled and we'll check if
     # the disablement persists in the storage across UM instances
-    um.add_utxo(txid, index+2, path, value, mixdepth+1)
+    um.add_utxo(txid, index+2, path, value, mixdepth+1, 3)
     um.disable_utxo(txid, index+2)
     um.save()
 
@@ -103,19 +103,23 @@ def test_utxomanager_select(setup_env_nodeps):
     mixdepth = 0
     value = 500
 
-    um.add_utxo(txid, index, path, value, mixdepth)
+    um.add_utxo(txid, index, path, value, mixdepth, 100)
 
     assert len(um.select_utxos(mixdepth, value)) == 1
     assert len(um.select_utxos(mixdepth+1, value)) == 0
 
-    um.add_utxo(txid, index+1, path, value, mixdepth)
+    um.add_utxo(txid, index+1, path, value, mixdepth, None)
     assert len(um.select_utxos(mixdepth, value)) == 2
 
     # ensure that added utxos that are disabled do not
     # get used by the selector
-    um.add_utxo(txid, index+2, path, value, mixdepth)
+    um.add_utxo(txid, index+2, path, value, mixdepth, 101)
     um.disable_utxo(txid, index+2)
     assert len(um.select_utxos(mixdepth, value)) == 2
+
+    # ensure that unconfirmed coins are not selected if
+    # dis-requested:
+    assert len(um.select_utxos(mixdepth, value, maxheight=105)) == 1
 
 
 @pytest.fixture

--- a/scripts/cli_options.py
+++ b/scripts/cli_options.py
@@ -33,12 +33,12 @@ def add_common_options(parser):
         'for the total transaction fee, default=dynamically estimated, note that this is adjusted '
         'based on the estimated fee calculated after tx construction, based on '
         'policy set in joinmarket.cfg.')
-    parser.add_option('--fast',
+    parser.add_option('--recoversync',
                       action='store_true',
-                      dest='fastsync',
+                      dest='recoversync',
                       default=False,
-                      help=('choose to do fast wallet sync, only for Core and '
-                            'only for previously synced wallet'))
+                      help=('choose to do detailed wallet sync, '
+                            'used for recovering on new Core instance.'))
     parser.add_option(
         '-x',
         '--max-cj-fee-abs',
@@ -358,6 +358,18 @@ def get_tumbler_parser():
             default=9,
             help=
             'maximum amount of times to re-create a transaction before giving up, default 9')
+    # note that this is used slightly differently in tumbler from sendpayment,
+    # hence duplicated:
+    parser.add_option('-A',
+            '--amtmixdepths',
+            action='store',
+            type='int',
+            dest='amtmixdepths',
+            help='number of mixdepths ever used in wallet, '
+                 'only to be used if mixdepths higher than '
+                 'mixdepthsrc + number of mixdepths to tumble '
+                 'have been used.',
+            default=-1)
     add_common_options(parser)
     return parser
 

--- a/scripts/receive-payjoin.py
+++ b/scripts/receive-payjoin.py
@@ -20,12 +20,12 @@ def receive_payjoin_main(makerclass):
     parser.add_option('-g', '--gap-limit', action='store', type="int",
                       dest='gaplimit', default=6,
                       help='gap limit for wallet, default=6')
-    parser.add_option('--fast',
+    parser.add_option('--recoversync',
                       action='store_true',
-                      dest='fastsync',
+                      dest='recoversync',
                       default=False,
-                      help=('choose to do fast wallet sync, only for Core and '
-                            'only for previously synced wallet'))
+                      help=('choose to do detailed wallet sync, '
+                            'used for recovering on new Core instance.'))
     parser.add_option('-m', '--mixdepth', action='store', type='int',
                       dest='mixdepth', default=0,
                       help="mixdepth to source coins from")
@@ -68,7 +68,7 @@ def receive_payjoin_main(makerclass):
         jm_single().bc_interface.synctype = "with-script"
 
     while not jm_single().bc_interface.wallet_synced:
-        sync_wallet(wallet, fast=options.fastsync)
+        sync_wallet(wallet, fast=not options.recoversync)
 
     maker = makerclass(wallet, options.mixdepth, receiving_amount)
     

--- a/scripts/yg-privacyenhanced.py
+++ b/scripts/yg-privacyenhanced.py
@@ -34,8 +34,8 @@ jlog = get_log()
 
 class YieldGeneratorPrivacyEnhanced(YieldGeneratorBasic):
 
-    def __init__(self, wallet, offerconfig):
-        super(YieldGeneratorPrivacyEnhanced, self).__init__(wallet, offerconfig)
+    def __init__(self, wallet_service, offerconfig):
+        super(YieldGeneratorPrivacyEnhanced, self).__init__(wallet_service, offerconfig)
 
     def create_my_orders(self):
         mix_balance = self.get_available_mixdepths()

--- a/test/common.py
+++ b/test/common.py
@@ -15,27 +15,28 @@ sys.path.insert(0, os.path.join(data_dir))
 
 from jmbase import get_log
 from jmclient import open_test_wallet_maybe, BIP32Wallet, SegwitLegacyWallet, \
-    estimate_tx_fee, jm_single
+    estimate_tx_fee, jm_single, WalletService
 import jmbitcoin as btc
 from jmbase import chunks
 
 log = get_log()
 
 def make_sign_and_push(ins_full,
-                       wallet,
+                       wallet_service,
                        amount,
                        output_addr=None,
                        change_addr=None,
                        hashcode=btc.SIGHASH_ALL,
                        estimate_fee = False):
     """Utility function for easily building transactions
-    from wallets
+    from wallets.
     """
+    assert isinstance(wallet_service, WalletService)
     total = sum(x['value'] for x in ins_full.values())
     ins = ins_full.keys()
     #random output address and change addr
-    output_addr = wallet.get_new_addr(1, 1) if not output_addr else output_addr
-    change_addr = wallet.get_new_addr(1, 0) if not change_addr else change_addr
+    output_addr = wallet_service.get_new_addr(1, 1) if not output_addr else output_addr
+    change_addr = wallet_service.get_new_addr(0, 1) if not change_addr else change_addr
     fee_est = estimate_tx_fee(len(ins), 2) if estimate_fee else 10000
     outs = [{'value': amount,
              'address': output_addr}, {'value': total - amount - fee_est,
@@ -46,7 +47,7 @@ def make_sign_and_push(ins_full,
     for index, ins in enumerate(de_tx['ins']):
         utxo = ins['outpoint']['hash'] + ':' + str(ins['outpoint']['index'])
         addr = ins_full[utxo]['address']
-        priv = wallet.get_key_from_addr(addr)
+        priv = wallet_service.get_key_from_addr(addr)
         if index % 2:
             priv = binascii.unhexlify(priv)
         tx = btc.sign(tx, index, priv, hashcode=hashcode)
@@ -99,15 +100,16 @@ def make_wallets(n,
         w = open_test_wallet_maybe(seeds[i], seeds[i], mixdepths - 1,
                                    test_wallet_cls=walletclass)
 
+        wallet_service = WalletService(w)
         wallets[i + start_index] = {'seed': seeds[i].decode('ascii'),
-                                    'wallet': w}
+                                    'wallet': wallet_service}
         for j in range(mixdepths):
             for k in range(wallet_structures[i][j]):
                 deviation = sdev_amt * random.random()
                 amt = mean_amt - sdev_amt / 2.0 + deviation
                 if amt < 0: amt = 0.001
                 amt = float(Decimal(amt).quantize(Decimal(10)**-8))
-                jm_single().bc_interface.grab_coins(w.get_external_addr(j), amt)
+                jm_single().bc_interface.grab_coins(wallet_service.get_new_addr(j, 1), amt)
     return wallets
 
 

--- a/test/test_full_coinjoin.py
+++ b/test/test_full_coinjoin.py
@@ -57,7 +57,7 @@ def test_cj(setup_full_coinjoin, num_ygs, wallet_structures, mean_amt,
     wallet = wallets[num_ygs]['wallet']
     sync_wallet(wallet, fast=True)
     # grab a dest addr from the wallet
-    destaddr = wallet.get_new_addr(4, 0)
+    destaddr = wallet.get_external_addr(4)
     coinjoin_amt = 20000000
     schedule = [[1, coinjoin_amt, 2, destaddr,
                      0.0, False]]

--- a/test/ygrunner.py
+++ b/test/ygrunner.py
@@ -19,7 +19,7 @@ import pytest
 import random
 from jmbase import jmprint
 from jmclient import YieldGeneratorBasic, load_program_config, jm_single,\
-    sync_wallet, JMClientProtocolFactory, start_reactor, SegwitWallet,\
+    JMClientProtocolFactory, start_reactor, SegwitWallet,\
     SegwitLegacyWallet, cryptoengine
 
 
@@ -109,21 +109,21 @@ def test_start_ygs(setup_ygrunner, num_ygs, wallet_structures, mean_amt,
         # TODO add Legacy
         walletclass = SegwitLegacyWallet
 
-    wallets = make_wallets(num_ygs + 1,
+    wallet_services = make_wallets(num_ygs + 1,
                            wallet_structures=wallet_structures,
                            mean_amt=mean_amt,
                            walletclass=walletclass)
     #the sendpayment bot uses the last wallet in the list
-    wallet = wallets[num_ygs]['wallet']
-    jmprint("\n\nTaker wallet seed : " + wallets[num_ygs]['seed'])
+    wallet_service = wallet_services[num_ygs]['wallet']
+    jmprint("\n\nTaker wallet seed : " + wallet_services[num_ygs]['seed'])
     # for manual audit if necessary, show the maker's wallet seeds
     # also (note this audit should be automated in future, see
     # test_full_coinjoin.py in this directory)
     jmprint("\n\nMaker wallet seeds: ")
     for i in range(num_ygs):
-        jmprint("Maker seed: " + wallets[i]['seed'])
+        jmprint("Maker seed: " + wallet_services[i]['seed'])
     jmprint("\n")
-    sync_wallet(wallet, fast=True)
+    wallet_service.sync_wallet(fast=True)
     txfee = 1000
     cjfee_a = 4200
     cjfee_r = '0.001'
@@ -138,8 +138,9 @@ def test_start_ygs(setup_ygrunner, num_ygs, wallet_structures, mean_amt,
     for i in range(num_ygs):
         
         cfg = [txfee, cjfee_a, cjfee_r, ordertype, minsize]
-        sync_wallet(wallets[i]["wallet"], fast=True)
-        yg = ygclass(wallets[i]["wallet"], cfg)
+        wallet_service_yg = wallet_services[i]["wallet"]
+        wallet_service_yg.startService()
+        yg = ygclass(wallet_service_yg, cfg)
         if malicious:
             yg.set_maliciousness(malicious, mtype="tx")
         clientfactory = JMClientProtocolFactory(yg, proto_type="MAKER")


### PR DESCRIPTION
Idea of this PR was prompted by some related problems.

See #328 - there seems to be some flaw in full sync at least (and fast also perhaps) involving not recognising/registering new addresses to the wallet such that restarts almost always involve retrying the sync when that shouldn't be necessary.
Not obviously related, but #336 for example is a simple failure at UI level where wallet does not dynamically update the GUI; similar but more fundamental, a deposit into the wallet during operation is not recognized until restart.
I think all these should be fixed, and it makes sense to do it as one "project". I'd like to achieve these things:

* Make wallet sync *aggressive* and *optimistic* and *correct* - so iron out any bugs, go with the approach used in `--fast` sync of assuming "normal" conditions and make it *always* work, first time, then - for the restarting-on-new-Core-wallet case, we can still keep the more clunky fallback.
* Create a better/sharper interface between the client apps and the blockchain *via* the wallet. So that only the wallet will be affected by future changes (I'm thinking particularly of the possible future BIP157/8.
usage)
* Better asynchronous update. Let the clients (including the GUI as another type of client) subscribe to events, in particular changes to the wallet's utxo set. This can be made generic so the way it's done to solve the above mentioned "dynamic deposit" case works the same as for taker and makers watching for completions of coinjoins.


The first pushed commit here is something fairly minor, but part of the clean up: removed duplicated `import_new_addresses` functions and replaced them with an atomically in-wallet call, so that we can "guarantee" that all addresses used during JM operation have been imported.