### PR TITLE
Bugfix: ensure Taker sends coins out to destinations on tweaks

### DIFF
--- a/scripts/tumbler.py
+++ b/scripts/tumbler.py
@@ -68,6 +68,18 @@ def main():
             sys.exit(0)
         #This removes all entries that are marked as done
         schedule = [s for s in schedule if s[5] != 1]
+        # remaining destination addresses must be stored in Taker.tdestaddrs
+        # in case of tweaks; note we can't change, so any passed on command
+        # line must be ignored:
+        if len(destaddrs) > 0:
+            jmprint("For restarts, destinations are taken from schedule file,"
+                    " so passed destinations on the command line were ignored.",
+                    "important")
+            if input("OK? (y/n)") != "y":
+                sys.exit(0)
+        destaddrs = [s[3] for s in schedule if s[3] not in ["INTERNAL", "addrask"]]
+        jmprint("Remaining destination addresses in restart: " + ",".join(destaddrs),
+                "important")
         if isinstance(schedule[0][5], str) and len(schedule[0][5]) == 64:
             #ensure last transaction is confirmed before restart
             tumble_log.info("WAITING TO RESTART...")


### PR DESCRIPTION
after restarts, instead of sending coins back to wallet.

This is a fix for #363.
Prior to this commit, if a tumbler
run was restarted on command line with --restart, and a schedule
entry failed triggering a call of tweak_tumble_schedule, the
destination address was always reset with INTERNAL to another in-
wallet address, even if it was actually an outward destination
address, because the restart of the tumbler script created an
instance of Taker without any addresses stored in the variable
tdestaddrs. After this commit, the Taker instance is instantiated
with the remaining destination addresses in the post-restart
schedule.
The user is prompted with a warning if they use --restart in
combination with command line destination addresses; they are
warned that the latter will be ignored, since the contents of the
schedule file are respected, instead.