### PR TITLE
Fix crash when pushing TX via "not-self"

### DIFF
--- a/jmclient/jmclient/taker.py
+++ b/jmclient/jmclient/taker.py
@@ -801,7 +801,7 @@ class Taker(object):
             if i == n:
                 pushed = jm_single().bc_interface.pushtx(tx)
             else:
-                nick_to_use = self.maker_utxo_data.keys()[i]
+                nick_to_use = list(self.maker_utxo_data.keys())[i]
                 pushed = True
         else:
             jlog.info("Only self, random-peer and not-self broadcast "


### PR DESCRIPTION
Ran into a crash with sendpayment today, when tx_broadcast in joinmarket.cfg is set to not-self.

Before the change, it crashed on the modified line because type dict_keys is returned here, which cannot be used with an index:

`
(Pdb) type(self.maker_utxo_data.keys())
`
`
<class 'dict_keys'>
`