### PR TITLE
Restarting tumbler waits on gettransaction not gettxout

### DIFF
--- a/scripts/joinmarket-qt.py
+++ b/scripts/joinmarket-qt.py
@@ -582,7 +582,7 @@ class SpendTab(QWidget):
                 #since we already updated state to running, user cannot
                 #start another transactions while waiting. Also, use :0 because
                 #it always exists
-                self.waitingtxid=txid+":0"
+                self.waitingtxid=txid
                 self.restartTimer.timeout.connect(self.restartWaitWrap)
                 self.restartTimer.start(5000)
                 return

--- a/scripts/tumbler.py
+++ b/scripts/tumbler.py
@@ -72,7 +72,7 @@ def main():
             #ensure last transaction is confirmed before restart
             tumble_log.info("WAITING TO RESTART...")
             txid = schedule[0][5]
-            restart_waiter(txid + ":0") #add 0 index because all have it
+            restart_waiter(txid)
             #remove the already-done entry (this connects to the other TODO,
             #probably better *not* to truncate the done-already txs from file,
             #but simplest for now.


### PR DESCRIPTION
Fixes #362. Prior to this commit, if tumbler was invoked with
the --restart flag, it waited for the presence of the 0 index
output of the last seen tumbler transaction in the utxo set,
which was an unreliable indicator as that output could have,
in the meantime, been spent.
After this commit, we utilise the fact that the transaction
must be an in-wallet transaction, and use the rpc gettransaction
to check whether it has 1 or more confirmations, instead, which
should always work whether any outputs are spent or not.