### PR TITLE
Warn user if estimated tx fee is higher than 5%

### DIFF
--- a/scripts/sendpayment.py
+++ b/scripts/sendpayment.py
@@ -115,6 +115,17 @@ def main():
             options.txfee))
     assert (options.txfee >= 0)
 
+    # From the estimated tx fees, check if the expected amount is a
+    # significant value compared the the cj amount
+    exp_tx_fees_ratio = ((1 + options.makercount) * options.txfee) / amount
+    if exp_tx_fees_ratio > 0.05:
+        jmprint('WARNING: Expected bitcoin network miner fees for this coinjoin'
+            ' amount are roughly {:.1%}'.format(exp_tx_fees_ratio), "warning")
+    else:
+        log.info("Estimated miner/tx fees for this coinjoin amount: {:.1%}"
+            .format(exp_tx_fees_ratio))
+
+
     maxcjfee = (1, float('inf'))
     if not options.p2ep and not options.pickorders and options.makercount != 0:
         maxcjfee = get_max_cj_fee_values(jm_single().config, options)


### PR DESCRIPTION
Estimate tx fees for sendpayment or full tumbler run and warn the user if the tx fee estimation exceeds (bikesheddable) 5% of the funds to be coinjoined/tumbled.

Reasons:
We've recently had a user who accidently spent 20% of his whole coinjoin amount on tx fees.

This change warns a user in the command line tools tumbler.py (user must confirm) and sendpayment.py (the warning will be displayed right before the user enters his wallet password - no extra confirmation therefore).