### PR TITLE
(doc) Update tx_broadcast explanation

### DIFF
--- a/jmclient/jmclient/configure.py
+++ b/jmclient/jmclient/configure.py
@@ -242,7 +242,7 @@ absurd_fee_per_kb = 350000
 # other counterparties are likely to reject unconfirmed inputs... don't do it.
 
 # options: self, random-peer, not-self (note: currently, ONLY 'self' works).
-# self = broadcast transaction with your bitcoin core's ip
+# self = broadcast transaction with your bitcoin node's ip
 # random-peer = everyone who took part in the coinjoin has a chance of broadcasting
 # not-self = never broadcast with your own ip
 tx_broadcast = self

--- a/jmclient/jmclient/configure.py
+++ b/jmclient/jmclient/configure.py
@@ -241,8 +241,8 @@ absurd_fee_per_kb = 350000
 # spends from unconfirmed inputs, which may then get malleated or double-spent!
 # other counterparties are likely to reject unconfirmed inputs... don't do it.
 
-#options: self, random-peer, not-self (note: random-maker is not currently supported).
-# self = broadcast transaction with your own ip
+# options: self, random-peer, not-self (note: currently, ONLY 'self' works).
+# self = broadcast transaction with your bitcoin core's ip
 # random-peer = everyone who took part in the coinjoin has a chance of broadcasting
 # not-self = never broadcast with your own ip
 tx_broadcast = self


### PR DESCRIPTION
Currently, only 'self' works until the other options for tx_broadcast are implemented. Update the docs accordingly, because there was someone wondering on IRC today why his transaction failed to broadcast; the reason was he changed this setting, which currently only works for 'self'.

If the other options are implemented (tagging #368 ), this documentation should be changed along with it.