### PR TITLE
Improve error message in unknown wallettool method

### DIFF
--- a/jmclient/jmclient/wallet_utils.py
+++ b/jmclient/jmclient/wallet_utils.py
@@ -1228,6 +1228,9 @@ def wallet_tool_main(wallet_root_path):
         return wallet_signmessage(wallet, options.hd_path, args[2])
     elif method == "freeze":
         return wallet_freezeutxo(wallet, options.mixdepth)
+    else:
+        parser.error("Unknown wallet-tool method: " + method)
+        sys.exit(0)
 
 
 #Testing (can port to test modules, TODO)


### PR DESCRIPTION
The status quo gives an unhelpful error message

     (jmvenv) [andy@inner scripts]$ python wallet-tool.py wallet.jmdat listunspent
     Enter wallet decryption passphrase:
     Traceback (most recent call last):
       File "wallet-tool.py", line 13, in <module>
         jmprint(wallet_tool_main("wallets"), "success")
       File "/home/andy/joinmarket-clientserver-0.5.4/jmbase/jmbase/support.py", line 89, in jmprint
         msg = msg.replace('{', '{{')
     AttributeError: 'NoneType' object has no attribute 'replace'

Thanks to user zfk from the IRC channel for the bug report