### PR TITLE
Sendpayment/Tumbler: fix division by 0 error

### DIFF
--- a/scripts/sendpayment.py
+++ b/scripts/sendpayment.py
@@ -138,11 +138,12 @@ def main():
 
     # From the estimated tx fees, check if the expected amount is a
     # significant value compared the the cj amount
-    if amount == 0:
-        amount = wallet.get_balance_by_mixdepth()[options.mixdepth]
-        if amount == 0:
+    total_cj_amount = amount
+    if total_cj_amount == 0:
+        total_cj_amount = wallet.get_balance_by_mixdepth()[options.mixdepth]
+        if total_cj_amount == 0:
             raise ValueError("No confirmed coins in the selected mixdepth. Quitting")
-    exp_tx_fees_ratio = ((1 + options.makercount) * options.txfee) / amount
+    exp_tx_fees_ratio = ((1 + options.makercount) * options.txfee) / total_cj_amount
     if exp_tx_fees_ratio > 0.05:
         jmprint('WARNING: Expected bitcoin network miner fees for this coinjoin'
             ' amount are roughly {:.1%}'.format(exp_tx_fees_ratio), "warning")

--- a/scripts/tumbler.py
+++ b/scripts/tumbler.py
@@ -124,6 +124,8 @@ def main():
                             max_mix_depth)
     for i in range(options['mixdepthsrc'], max_mix_to_tumble):
         total_tumble_amount += wallet.get_balance_by_mixdepth()[i]
+        if total_tumble_amount == 0:
+            raise ValueError("No confirmed coins in the selected mixdepth(s). Quitting")
     exp_tx_fees_ratio = (involved_parties * options['txfee']) \
         / total_tumble_amount
     if exp_tx_fees_ratio > 0.05:


### PR DESCRIPTION
Important fix: otherwise sweeps crash when using sendpayment. This needs to be included in the upcoming release.

To be able to do this, needed to move the check in sendpayment to after the wallet is decrypted, otherwise there is no way to check if the selected mixdepth has coins in it (leading to another div by 0 in that case) or calculating the tx_fee_ratio.