### PR TITLE
Redefine cli-option --txfee

### DIFF
--- a/scripts/cli_options.py
+++ b/scripts/cli_options.py
@@ -29,10 +29,12 @@ def add_common_options(parser):
         type='int',
         dest='txfee',
         default=-1,
-        help='number of satoshis per participant to use as the initial estimate '
-        'for the total transaction fee, default=dynamically estimated, note that this is adjusted '
-        'based on the estimated fee calculated after tx construction, based on '
-        'policy set in joinmarket.cfg.')
+        help='Bitcoin miner tx_fee to use for transaction(s). A number higher '
+        'than 1000 is used as "satoshi per KB" tx fee. A number lower than that '
+        'uses the dynamic fee estimation of your blockchain provider as '
+        'confirmation target. This temporarily overrides the "tx_fees" setting '
+        'in your joinmarket.cfg. Works the same way as described in it. Check '
+        'it for examples.')
     parser.add_option('--recoversync',
                       action='store_true',
                       dest='recoversync',

--- a/scripts/sendpayment.py
+++ b/scripts/sendpayment.py
@@ -105,6 +105,10 @@ def main():
     else:
         chooseOrdersFunc = options.order_choose_fn
 
+    # If tx_fees are set manually by CLI argument, override joinmarket.cfg:
+    if int(options.txfee) > 0:
+        jm_single().config.set("POLICY", "tx_fees", str(options.txfee))
+
     # Dynamically estimate a realistic fee if it currently is the default value.
     # At this point we do not know even the number of our own inputs, so
     # we guess conservatively with 2 inputs and 2 outputs each.

--- a/scripts/tumbler.py
+++ b/scripts/tumbler.py
@@ -114,6 +114,10 @@ def main():
     tumble_log.info("With this schedule: ")
     tumble_log.info(pprint.pformat(schedule))
 
+    # If tx_fees are set manually by CLI argument, override joinmarket.cfg:
+    if int(options['txfee']) > 0:
+        jm_single().config.set("POLICY", "tx_fees", str(options['txfee']))
+
     # Dynamically estimate an expected tx fee for the whole tumbling run.
     # This is very rough: we guess with 2 inputs and 2 outputs each.
     if options['txfee'] == -1:


### PR DESCRIPTION
Treat it as txfee to be used in the JM TX's instead of just for preliminary estimations.

With this PR, it is now a way to temporarily override the tx_fees setting in joinmarket.cfg and behaves exactly the same way as described in it:
N <= 1000: use blockchaininterface fee estimation with block target N
N > 1000: use this as fee in sat/KB