### PR TITLE
simplified installation of joinmarket using a requirements file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,12 @@ matrix:
   include:
     - os: osx
       env: PIP_DOWNLOAD_CACHE=$HOME/Library/Caches/pip
+      addons:
+        homebrew:
+           packages:
+             - bitcoin
+             - libsodium
+           update: true
     - os: linux
       env: PIP_DOWNLOAD_CACHE=$HOME/.cache/pip
       addons:
@@ -13,6 +19,10 @@ matrix:
              key_url: 'http://keyserver.ubuntu.com:11371/pks/lookup?op=get&search=0xD46F45428842CE5E'
            packages:
              - bitcoind
+             - python3-dev
+             - python3-pip
+             - python-virtualenv
+             - libsodium18
     - os: linux
       services: docker
       env: DOCKER_IMG_JM=xenial-py2
@@ -44,26 +54,30 @@ before_install:
   - do_on(){ if [ "$TRAVIS_OS_NAME" = "$1" ]; then shift; "$@" ; fi; }
   - on_host(){ if [ -z "$DOCKER_IMG_JM" ]; then "$@" ; fi; }
   - should_run_dockers(){ if [ "$TRAVIS_EVENT_TYPE" = cron ] || [ -n "$TRAVIS_TAG" ] || echo "${TRAVIS_COMMIT_MESSAGE[@]}" | grep -q "TRAVIS_RUN_DOCKERS"; then return 0; else return 1; fi; }
-  - on_docker(){ if [ -n "$DOCKER_IMG_JM" ] && should_run_dockers; then "$@" ; fi; }
+  - on_docker(){ if [ -n "$DOCKER_IMG_JM" ]; then "$@" ; fi; }
   - do_on osx pip install virtualenv
 cache:
   directories:
    - $HOME/downloads
    - $HOME/.cache/pip
    - $HOME/Library/Caches/pip
+   - $HOME/Library/Caches/Homebrew
+before_cache:
+  - if [ "${TRAVIS_OS_NAME}" = "osx" ]; then brew cleanup; fi
 install:
   - mkdir -p "$HOME/downloads"
   - mkdir -p "$TRAVIS_BUILD_DIR/deps/cache/"
   - find "$HOME/downloads" -type f -exec cp -v {} "$TRAVIS_BUILD_DIR/deps/cache/" \;
-  - on_host ./install.sh --develop --python=python3 --with-qt
+  - on_host do_on linux ./install.sh --develop --python=python3 --with-qt
+  - on_host do_on osx virtualenv --python=python3 jmvenv
   - on_host find "$TRAVIS_BUILD_DIR/deps/cache/" -type f -exec cp -v {} "$HOME/downloads/" \;
 before_script:
   - on_host source jmvenv/bin/activate
 script:
-  - on_host do_on linux bitcoind --help | head -1
-  - on_host do_on linux ./test/run_tests.sh
+  - on_host bitcoind --help | head -1
+  - on_host ./test/run_tests.sh
   - on_host do_on linux flake8 jmbase jmbitcoin jmclient jmdaemon scripts test
   - on_docker ./test/Dockerfiles/build_docker.sh
 after_success:
   - on_docker echo "Success !"
-  - on_host do_on linux coveralls
+  - on_host coveralls

--- a/README.md
+++ b/README.md
@@ -68,8 +68,7 @@ If binaries are built, they will be gpg signed and announced on the Releases pag
 If you haven't chosen the Qt option during installation with `install.sh`, then to run the script `joinmarket-qt.py` from the command line you will need to install two more packages.  Use these 2 commands while the `jmvenv` virtual environment is activated:
 
 ```
-pip install PySide2
-pip install https://github.com/sunu/qt5reactor/archive/58410aaead2185e9917ae9cac9c50fe7b70e4a60.zip
+pip install -r requirements/gui.txt
 ```
 After this, the command `python joinmarket-qt.py` from within the `scripts` subdirectory should work.
 There is a [walkthrough](docs/JOINMARKET-QT-GUIDE.md) for what to do next.

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -26,7 +26,7 @@ is actually newer in version number, than what was there already.
 
 To install everything (client and server), install these packages:
 
-    sudo apt-get install python-dev python-pip git build-essential automake pkg-config libtool libffi-dev libssl-dev libgmp-dev
+    sudo apt-get install python3-dev python3-pip git build-essential automake pkg-config libtool libffi-dev libssl-dev libgmp-dev
 
 (+ `libsodium-dev` if you can find it, else build after)
 
@@ -49,7 +49,7 @@ Then install this repo:
 Then:
 
     sudo pip install virtualenv
-    virtualenv jmvenv
+    virtualenv --python=python3 jmvenv
     source jmvenv/bin/activate
 
 **At this point you should see `(jmvenv)` at the beginning of your command prompt.**
@@ -57,10 +57,9 @@ Then:
 
 #### Installing packages to run everything in-one:
 
-> *NOTE*: It is very important to have activated virtualenv before running this step. Otherwise, `setupall.py` will fail, you may be tempted to re-run it with `sudo setupall.py` which will cause problems in the future.
+> *NOTE*: It is very important to have activated virtualenv before running this step. Otherwise, `pip install` will fail, you may be tempted to re-run it with `sudo pip install` which will cause problems in the future.
 
-    python setupall.py --daemon
-    python setupall.py --client-bitcoin
+    pip install -r requirements/base.txt
 
 If you have installed this "full" version of the client, you can use it with the
 command line scripts as explained in the [scripts README](https://github.com/AdamISZ/joinmarket-clientserver/tree/master/scripts).
@@ -94,10 +93,7 @@ command line scripts as explained in the [scripts README](https://github.com/Ada
     ```
 6) Setup joinmarket-qt
     ```
-    pip install PySide2
-    pip install qrcode[pil]
-    pip install https://github.com/sunu/qt5reactor/archive/58410aaead2185e9917ae9cac9c50fe7b70e4a60.zip
-    python setupall.py --all
+    pip install -r requirements/gui.txt
     ```
 7) Start joinmarket-qt
     ```

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -9,7 +9,7 @@ Make sure to have [bitcoind](https://bitcoin.org/en/full-node) 0.17 or newer ins
 
 Install the test requirements (still in your virtualenv as mentioned above):
 
-    pip install -r requirements-dev.txt
+    pip install -r requirements/testing.txt
 
 Running the test suite should be done something like (advisable to wipe ~/.bitcoin/regtest first):
 

--- a/jmclient/test/test_walletservice.py
+++ b/jmclient/test/test_walletservice.py
@@ -40,11 +40,10 @@ def test_address_reuse_freezing(setup_walletservice):
     called, and that the balance available in the mixdepth correctly
     reflects the usage pattern and freeze policy.
     """
-    cb_called = 0
+    context = {'cb_called': 0}
     def reuse_callback(utxostr):
-        nonlocal cb_called
         print("Address reuse freezing callback on utxo: ", utxostr)
-        cb_called += 1
+        context['cb_called'] += 1
     # we must fund after initial sync (for imports), hence
     # "populated" with no coins
     wallet = get_populated_wallet(num=0)
@@ -59,16 +58,16 @@ def test_address_reuse_freezing(setup_walletservice):
 
     # check that with default status any reuse is blocked:
     try_address_reuse(wallet_service, 0, 1, -1, 3 * 10**8)
-    assert cb_called == 1, "Failed to trigger freeze callback"
+    assert context['cb_called'] == 1, "Failed to trigger freeze callback"
 
     # check that above the threshold is allowed (1 sat less than funding)
     try_address_reuse(wallet_service, 1, 1, 99999999, 4 * 10**8)
-    assert cb_called == 1, "Incorrectly triggered freeze callback"
+    assert context['cb_called'] == 1, "Incorrectly triggered freeze callback"
 
     # check that below the threshold on the same address is not allowed:
     try_address_reuse(wallet_service, 1, 0.99999998, 99999999, 4 * 10**8)
     # note can be more than 1 extra call here, somewhat suboptimal:
-    assert cb_called > 1, "Failed to trigger freeze callback"
+    assert context['cb_called'] > 1, "Failed to trigger freeze callback"
 
 
 @pytest.fixture(scope='module')

--- a/jmdaemon/test/test_irc_messaging.py
+++ b/jmdaemon/test/test_irc_messaging.py
@@ -129,7 +129,7 @@ class TrialIRC(unittest.TestCase):
     def test_waiter(self):
         print("test_main()")
         #reactor.callLater(1.0, junk_messages, self.mcc)
-        return task.deferLater(reactor, 22, self._called_by_deffered)
+        return task.deferLater(reactor, 30, self._called_by_deffered)
 
     def _called_by_deffered(self):
         pass

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,0 +1,4 @@
+-e ./jmbase
+-e ./jmbitcoin
+-e ./jmclient
+-e ./jmdaemon

--- a/requirements/gui.txt
+++ b/requirements/gui.txt
@@ -1,0 +1,4 @@
+-r base.txt
+PySide2
+qrcode[pil]
+https://github.com/sunu/qt5reactor/archive/58410aaead2185e9917ae9cac9c50fe7b70e4a60.zip#egg=qt5reactor

--- a/requirements/testing.txt
+++ b/requirements/testing.txt
@@ -1,3 +1,4 @@
+-r base.txt
 # matplotlib
 # numpy
 pexpect

--- a/test/Dockerfiles/bionic-py2.Dockerfile
+++ b/test/Dockerfiles/bionic-py2.Dockerfile
@@ -3,11 +3,8 @@ SHELL ["/bin/bash", "-c"]
 
 # dependencies
 RUN apt-get update
-RUN apt-get install -y build-essential
 RUN apt-get install -y \
-    automake pkg-config libtool libgmp-dev
-RUN apt-get install -y \
-    python-dev python-pip python-virtualenv python-qt4 python-sip
+    python-dev python-pip python-virtualenv libsodium23
 
 # curl is a better tool
 RUN apt-get install -y curl
@@ -33,5 +30,5 @@ RUN bitcoind --version | head -1
 
 # install script
 WORKDIR ${repo_name}
-RUN ./install.sh --python=python2
+RUN virtualenv --python=python2 jmvenv
 RUN source jmvenv/bin/activate && ./test/run_tests.sh

--- a/test/Dockerfiles/bionic-py3.Dockerfile
+++ b/test/Dockerfiles/bionic-py3.Dockerfile
@@ -3,11 +3,8 @@ SHELL ["/bin/bash", "-c"]
 
 # dependencies
 RUN apt-get update
-RUN apt-get install -y build-essential
 RUN apt-get install -y \
-    automake pkg-config libtool libgmp-dev
-RUN apt-get install -y \
-    python3-dev python3-pip python-virtualenv python3-pyqt4 python3-sip
+    python3-dev python3-pip python-virtualenv libsodium23
 
 # curl is a better tool
 RUN apt-get install -y curl
@@ -33,5 +30,5 @@ RUN bitcoind --version | head -1
 
 # install script
 WORKDIR ${repo_name}
-RUN echo y | ./install.sh --python=python3
+RUN virtualenv --python=python3 jmvenv
 RUN source jmvenv/bin/activate && ./test/run_tests.sh

--- a/test/Dockerfiles/build_docker.sh
+++ b/test/Dockerfiles/build_docker.sh
@@ -15,14 +15,10 @@ build_docker ()
         return 0
     fi
 
-    core_version='0.17.1'
+    core_version='0.18.0'
     core_dist="bitcoin-${core_version}-x86_64-linux-gnu.tar.gz"
     core_url="https://bitcoincore.org/bin/bitcoin-core-${core_version}/${core_dist}"
-    libffi_lib_tar='v3.2.1.tar.gz'
-    libffi_url="https://github.com/libffi/libffi/archive/${libffi_lib_tar}"
-    sodium_lib_tar='libsodium-1.0.13.tar.gz'
-    sodium_url="https://download.libsodium.org/libsodium/releases/old/${sodium_lib_tar}"
-    declare -A deps=( [${core_dist}]="${core_url}" [${libffi_lib_tar}]="${libffi_url}" [${sodium_lib_tar}]="${sodium_url}" )
+    declare -A deps=( [${core_dist}]="${core_url}" )
     jm_root="${TRAVIS_BUILD_DIR}"
     owner_name="${TRAVIS_REPO_SLUG%\/*}"
     repo_name="${TRAVIS_REPO_SLUG#*\/}"

--- a/test/Dockerfiles/centos7-py2.Dockerfile
+++ b/test/Dockerfiles/centos7-py2.Dockerfile
@@ -6,7 +6,7 @@ RUN yum -y groups install 'Development tools'
 RUN yum -y install epel-release && \
     yum -y update
 RUN yum -y install \
-    python-devel python2-pip python-virtualenv gmp-devel
+    python-devel python2-pip python-virtualenv libsodium
 
 RUN useradd --home-dir /home/chaum --create-home --shell /bin/bash --skel /etc/skel/ chaum
 ARG core_version
@@ -29,5 +29,5 @@ RUN bitcoind --version | head -1
 
 # install script
 WORKDIR ${repo_name}
-RUN ./install.sh --python=python2
+RUN virtualenv --python=python2 jmvenv
 RUN source jmvenv/bin/activate && ./test/run_tests.sh

--- a/test/Dockerfiles/fedora27-py2.Dockerfile
+++ b/test/Dockerfiles/fedora27-py2.Dockerfile
@@ -4,8 +4,7 @@ SHELL ["/bin/bash", "-c"]
 # dependencies
 RUN dnf -y groups install 'Development tools'
 RUN dnf -y install \
-    autoconf libtool pkgconfig \
-    python-devel python-pip python2-virtualenv gmp-devel
+    python-devel python-pip python2-virtualenv libsodium
 
 # needed for build time
 # https://stackoverflow.com/questions/34624428/g-error-usr-lib-rpm-redhat-redhat-hardened-cc1-no-such-file-or-directory
@@ -32,5 +31,5 @@ RUN bitcoind --version | head -1
 
 # install script
 WORKDIR ${repo_name}
-RUN ./install.sh --python=python2
+RUN virtualenv --python=python2 jmvenv
 RUN source jmvenv/bin/activate && ./test/run_tests.sh

--- a/test/Dockerfiles/fedora27-py3.Dockerfile
+++ b/test/Dockerfiles/fedora27-py3.Dockerfile
@@ -4,8 +4,7 @@ SHELL ["/bin/bash", "-c"]
 # dependencies
 RUN dnf -y groups install 'Development tools'
 RUN dnf -y install \
-    autoconf libtool pkgconfig \
-    python3-devel python3-pip python-virtualenv gmp-devel
+    python3-devel python3-pip python-virtualenv libsodium
 
 # needed for build time
 # https://stackoverflow.com/questions/34624428/g-error-usr-lib-rpm-redhat-redhat-hardened-cc1-no-such-file-or-directory
@@ -32,5 +31,5 @@ RUN bitcoind --version | head -1
 
 # install script
 WORKDIR ${repo_name}
-RUN echo y | ./install.sh --python=python3
+RUN virtualenv --python=python3 jmvenv
 RUN source jmvenv/bin/activate && ./test/run_tests.sh

--- a/test/Dockerfiles/stretch-py3.Dockerfile
+++ b/test/Dockerfiles/stretch-py3.Dockerfile
@@ -33,5 +33,5 @@ RUN bitcoind --version | head -1
 
 # install script
 WORKDIR ${repo_name}
-RUN echo y | ./install.sh --python=python3
+RUN ./install.sh --python=python3 --with-qt
 RUN source jmvenv/bin/activate && ./test/run_tests.sh

--- a/test/Dockerfiles/xenial-py3.Dockerfile
+++ b/test/Dockerfiles/xenial-py3.Dockerfile
@@ -33,5 +33,5 @@ RUN bitcoind --version | head -1
 
 # install script
 WORKDIR ${repo_name}
-RUN echo y | ./install.sh --python=python3
+RUN ./install.sh --python=python3 --with-qt
 RUN source jmvenv/bin/activate && ./test/run_tests.sh

--- a/test/regtest_joinmarket.cfg
+++ b/test/regtest_joinmarket.cfg
@@ -14,15 +14,25 @@ rpc_user = bitcoinrpc
 rpc_password = 123456abcdef
 network = testnet
 
-[MESSAGING]
-host = localhost, localhost
-hostid = localhost1, localhost2
-channel = joinmarket-pit, joinmarket-pit
-port = 6667, 6668
-usessl = false, false
-socks5 = false, false
-socks5_host = localhost, localhost
-socks5_port = 9150, 9150
+[MESSAGING:server1]
+host = localhost
+hostid = localhost1
+channel = joinmarket-pit
+port = 6667
+usessl = false
+socks5 = false
+socks5_host = localhost
+socks5_port = 9150
+
+[MESSAGING:server2]
+host = localhost
+hostid = localhost2
+channel = joinmarket-pit
+port = 6668
+usessl = false
+socks5 = false
+socks5_host = localhost
+socks5_port = 9150
 
 [TIMEOUT]
 maker_timeout_sec = 15

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -19,6 +19,7 @@ run_jm_tests ()
         \`source ./jmvenv/bin/activate\`"
         return 1
     fi
+    jm_requirements="requirements/testing.txt"
     jm_source="${VIRTUAL_ENV}/.."
     export PKG_CONFIG_PATH="${PKG_CONFIG_PATH}:${VIRTUAL_ENV}/lib/pkgconfig"
     export LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:${VIRTUAL_ENV}/lib"
@@ -33,8 +34,8 @@ run_jm_tests ()
         mkdir -p miniircd
         tar -xzf miniircd.tar.gz -C ./miniircd --strip-components=1
     fi
-    if ! pip install -r ./requirements-dev.txt; then
-        echo "Packages in 'requirements-dev.txt' could not be installed. Exiting."
+    if ! pip install -r "${jm_requirements}"; then
+        echo "Packages in '${jm_requirements}' could not be installed. Exiting."
         return 1
     fi
     if [[ ! -L ./joinmarket.cfg && -e ./joinmarket.cfg ]]; then


### PR DESCRIPTION
I wrote this PR in an effort to simplify the installation of JoinMarket. As it turns out, it is possible to use the `pip` tool to install all the dependencies required to run JoinMarket. This installation method does not include system dependencies like `openssl` and `libsodium`. These would still need to be installed using whatever package manager is available on the target machine.

After installing these system dependencies, installing JoinMarket's dependencies is as simple as running:

```
pip install -r requirements/production.txt
```

To install the GUI dependencies:

```
pip install -r requirements/gui.txt
```

The `production` requirements file is currently locked to v0.5.5 and would need to be updated for every new release. If your goal is to install the development version:

```
pip install -r requirements/develop.txt
```

There's also a `testing` requirements file if your plan is to run the bundled integration tests:

```
pip install -r requirements/testing.txt
```