### PR TITLE
Fixes #389 - wallet syncing in Qt

### DIFF
--- a/scripts/joinmarket-qt.py
+++ b/scripts/joinmarket-qt.py
@@ -1479,7 +1479,7 @@ class JMMainWindow(QMainWindow):
                                    title="Wallet created")
         self.initWallet(seed=self.walletname, restart_cb=self.restartWithMsg)
 
-    def selectWallet(self, testnet_seed=None):
+    def selectWallet(self, testnet_seed=None, restart_cb=None):
         if jm_single().config.get("BLOCKCHAIN", "blockchain_source") != "regtest":
             current_path = os.path.dirname(os.path.realpath(__file__))
             if os.path.isdir(os.path.join(current_path, 'wallets')):
@@ -1501,7 +1501,7 @@ class JMMainWindow(QMainWindow):
                 if not ok:
                     return
                 pwd = str(text).strip()
-                decrypted = self.loadWalletFromBlockchain(firstarg[0], pwd, restart_cb=self.restartWithMsg)
+                decrypted = self.loadWalletFromBlockchain(firstarg[0], pwd, restart_cb)
         else:
             if not testnet_seed:
                 testnet_seed, ok = QInputDialog.getText(self,


### PR DESCRIPTION
In commit 22467f4 a bug was introduced whereby detailed
sync was used instead of fast sync, but with only one
iteration, in Joinmarket-Qt, in certain circumstances,
leading to incorrect wallet reporting/display. This commit
reverts that change (except for function name change).
There may still be edge cases for large wallets doing
recovery in Qt but this will be dealt with later.