### PR TITLE
Revert "Fix bug in detailed wallet sync relating to gap addrs."

### DIFF
--- a/jmclient/jmclient/blockchaininterface.py
+++ b/jmclient/jmclient/blockchaininterface.py
@@ -512,15 +512,7 @@ class BitcoinCoreInterface(BlockchainInterface):
         self.wallet_synced = True
 
     def sync_addresses(self, wallet, restart_cb=None):
-        # This more detailed version of wallet syncing must cover situations
-        # where the user has used the wallet on other Bitcoin Core instances
-        # and therefore the wallet label either does not have addresses
-        # imported, and/or, after the addresses are imported, they may not
-        # have the full history, since a rescan is required to discover
-        # the history of addresses before they were imported.
-
         log.debug("requesting detailed wallet history")
-
         wallet_name = self.get_wallet_name(wallet)
 
         addresses, saved_indices = self._collect_addresses_init(wallet)
@@ -542,6 +534,7 @@ class BitcoinCoreInterface(BlockchainInterface):
         used_addresses_gen = (tx['address']
                               for tx in self._yield_transactions(wallet_name)
                               if tx['category'] == 'receive')
+
         used_indices = self._get_used_indices(wallet, used_addresses_gen)
         log.debug("got used indices: {}".format(used_indices))
         gap_limit_used = not self._check_gap_indices(wallet, used_indices)


### PR DESCRIPTION
This reverts commit 4b4f8c97f40e232cf25315a3a2568a93d4f67456.

Due to a flawed assumption where sometimes importing addresses does
take a significant amount of time. For example on machines with HDD
importing 1-2 addresses can last a second or two, and importing 60
addresses lasts about 30 seconds. The commit makes running a maker
impossible on such a machine.

Following the discussion on IRC and issue #401. If we want to go via the route of just reverting that one commit then this PR does that.