### PR TITLE
SNICKER receiving function

### DIFF
--- a/jmbitcoin/jmbitcoin/__init__.py
+++ b/jmbitcoin/jmbitcoin/__init__.py
@@ -5,6 +5,9 @@ import coincurve as secp256k1
 from jmbitcoin.secp256k1_main import *
 from jmbitcoin.secp256k1_transaction import *
 from jmbitcoin.secp256k1_deterministic import *
+from jmbitcoin.secp256k1_ecdh import ecdh
 from jmbitcoin.btscript import *
 from jmbitcoin.bech32 import *
+from jmbitcoin.jm_psbt import *
+from jmbitcoin.snicker import *
 

--- a/jmbitcoin/jmbitcoin/jm_psbt.py
+++ b/jmbitcoin/jmbitcoin/jm_psbt.py
@@ -1,0 +1,90 @@
+from __future__ import (absolute_import, division,
+                        print_function, unicode_literals)
+from builtins import * # noqa: F401
+
+from binascii import unhexlify
+
+from .pythonpsbt import (Creator,
+                        Updater,
+                        Signer,
+                        Input_Finalizer,
+                        Transaction_Extractor
+                        )
+
+def convert_ins_format_for_creator(ins):
+    """ Takes transaction inputs as formatted in jmbitcoin
+    and converts them into required format for PSBT creation.
+    """
+
+    return [(unhexlify(x['outpoint']['hash']),
+             x['outpoint']['index']) for x in ins]
+
+def convert_outs_format_for_creator(outs):
+    """ Takes transaction outputs as formatted in jmbitcoin
+    and converts them into required format for PSBT creation.
+    """
+    return [(x["value"], unhexlify(x["script"])) for x in outs]
+
+def create_psbt(tx, ins_segwit_utxos):
+    """ Takes a deserialized bitcoin transaction(as formatted
+    in this jmbitcoin library), and creates the PSBT object initialized
+    with no signatures or data, and returns both the PSBT Updater object
+    and the network serialized bitcoin transaction, for convenience.
+    ins_segwit_utxos should be a list of (amount, scriptPubkey)
+    for each input, in order.
+    Currently supports segwit inputs only.
+    """
+    ins = convert_ins_format_for_creator(tx['ins'])
+    outs = convert_outs_format_for_creator(tx['outs'])
+    creator = Creator(ins, outs, tx_version=tx['version'],
+                      locktime=tx['locktime'])
+    updater = Updater(creator.serialized())
+    for i in range(len(ins)):
+        # note: we do not use the add_witness_utxo method
+        # of the Updater object, because it requires the full
+        # transaction containing the utxo, which rather misses
+        # the point: we can add just the single transaction output
+        # without knowing the full transaction.
+        updater.add_witness_utxo_from_txout(i, *ins_segwit_utxos[i])
+    return updater, get_tx_from_psbt(updater)
+
+def update_our_inputs(updater, ins, prevtxs, prevtxindices, indices, psbt_serialized):
+    """ Given a list of inputs `ins` as formatted deserialized
+    in jmbitcoin, at indices `indices` (list of ints), each of which came from a
+    tx as serialized in prevtxs, from output index in prevtxindices,
+    update the corresponding inputs in serialized psbt `psbt_serialized`,
+    to prepare for signing.
+    For simplicity we assume only one input type p2sh-p2wpkh as per JM default.
+    """
+    for i, j in enumerate(indices):
+        updater.add_witness_utxo(j, prevtxs[i], prevtxindices[i])
+        updater.add_input_redeem_script(j, ins[i]['script'])
+    return updater.psbt.serialize()
+
+def get_tx_from_psbt(psbt_tx):
+    """ Takes as argument an object of type psbt,
+    and retruns the network serialized transaction.
+    """
+    return psbt_tx.get_unsigned_tx()
+
+def sign_psbt(psbt_tx, input_index, sig, pub):
+    """ Takes a serialized PSBT, an index, signature
+    and pubkey and returns a new serialized PSBT
+    including the added signature.
+    """
+    updater = Updater(psbt_tx)
+    updater.add_sighash_type(input_index, sig[-1])
+    signer = Signer(updater.psbt.serialize())
+    signer.add_partial_signature(sig, pub, input_index=input_index)
+    return signer.psbt.serialize()
+
+def extract_final_tx_from_psbt(psbt_tx):
+    """ Takes a serialized PSBT and attempts to
+    finalize it, then extract a network serialized and
+    validly signed Bitcoin transaction. If the
+    finalization fails, None is returned.
+    """
+    # note the constructor performs finalization automatically.
+    finalizer = Input_Finalizer(psbt_tx)
+    extractor = Transaction_Extractor(finalizer.serialized())
+    return extractor.psbt, extractor.serialized()

--- a/jmbitcoin/jmbitcoin/pythonpsbt/README.md
+++ b/jmbitcoin/jmbitcoin/pythonpsbt/README.md
@@ -1,0 +1,3 @@
+# python-psbt
+
+Adapted and modified from https://github.com/bjarnemagnussen/python-psbt temporarily, please refer to there for credit/attribution and documentation.

--- a/jmbitcoin/jmbitcoin/pythonpsbt/__init__.py
+++ b/jmbitcoin/jmbitcoin/pythonpsbt/__init__.py
@@ -1,0 +1,14 @@
+from __future__ import (absolute_import, division,
+                        print_function, unicode_literals)
+from builtins import *
+
+from .psbt import (psbt,
+                   PSBT_IN_PARTIAL_SIG,
+    Creator,
+    Updater,
+    Signer,
+    Combiner,
+    Input_Finalizer,
+    Transaction_Extractor)
+
+

--- a/jmbitcoin/jmbitcoin/pythonpsbt/bitcoin_lib.py
+++ b/jmbitcoin/jmbitcoin/pythonpsbt/bitcoin_lib.py
@@ -1,0 +1,1429 @@
+'''
+Credit for this libary goes to Jimmy Song and the efforts of his Programming Blockchain course
+'''
+
+from binascii import hexlify, unhexlify
+from io import BytesIO
+
+import hmac
+import hashlib
+
+SIGHASH_ALL = 1
+SIGHASH_NONE = 2
+SIGHASH_SINGLE = 3
+BASE58_ALPHABET = b'123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz'
+
+
+def hash160(s):
+    return hashlib.new('ripemd160', hashlib.sha256(s).digest()).digest()
+
+
+def double_sha256(s):
+    return hashlib.sha256(hashlib.sha256(s).digest()).digest()
+
+
+def encode_base58(s):
+    # determine how many 0 bytes (b'\x00') s starts with
+    count = 0
+    for c in s:
+        if c == 0:
+            count += 1
+        else:
+            break
+    prefix = b'1' * count
+    # convert from binary to hex, then hex to integer
+    num = int.from_bytes(s, 'big')
+    result = bytearray()
+    while num > 0:
+        num, mod = divmod(num, 58)
+        result.insert(0, BASE58_ALPHABET[mod])
+
+    return prefix + bytes(result)
+
+
+def encode_base58_checksum(s):
+    return encode_base58(s + double_sha256(s)[:4]).decode('ascii')
+
+
+def decode_base58(s, num_bytes=25, strip_leading_zeros=False):
+    num = 0
+    for c in s.encode('ascii'):
+        num *= 58
+        num += BASE58_ALPHABET.index(c)
+    combined = num.to_bytes(num_bytes, byteorder='big')
+    if strip_leading_zeros:
+        while combined[0] == 0:
+            combined = combined[1:]
+    payload, checksum = combined[:-4], combined[-4:]
+    if double_sha256(payload)[:4] != checksum:
+        raise ValueError('bad address: {} {}'.format(
+            checksum, double_sha256(combined)[:4]))
+    return payload
+
+
+def p2pkh_script(h160):
+    '''Takes a hash160 and returns the scriptPubKey'''
+    return b'\x76\xa9\x14' + h160 + b'\x88\xac'
+
+
+def p2sh_script(h160):
+    '''Takes a hash160 and returns the scriptPubKey'''
+    return b'\xa9\x14' + h160 + b'\x87'
+
+
+def read_varint(s):
+    '''read_varint reads a variable integer from a stream'''
+    i = s.read(1)[0]
+    if i == 0xfd:
+        # 0xfd means the next two bytes are the number
+        return little_endian_to_int(s.read(2))
+    elif i == 0xfe:
+        # 0xfe means the next four bytes are the number
+        return little_endian_to_int(s.read(4))
+    elif i == 0xff:
+        # 0xff means the next eight bytes are the number
+        return little_endian_to_int(s.read(8))
+    else:
+        # anything else is just the integer
+        return i
+
+
+def encode_varint(i):
+    '''encodes an integer as a varint'''
+    if i < 0xfd:
+        return bytes([i])
+    elif i < 0x10000:
+        return b'\xfd' + int_to_little_endian(i, 2)
+    elif i < 0x100000000:
+        return b'\xfe' + int_to_little_endian(i, 4)
+    elif i < 0x10000000000000000:
+        return b'\xff' + int_to_little_endian(i, 8)
+    else:
+        raise ValueError('integer too large: {}'.format(i))
+
+
+def flip_endian(h):
+    '''flip_endian takes a hex string and flips the endianness
+    Returns a hexadecimal string
+    '''
+    # convert hex to binary (use unhexlify)
+    b = unhexlify(h)
+    # reverse the binary (use [::-1])
+    b_rev = b[::-1]
+    # convert binary to hex (use hexlify and then .decode('ascii'))
+    return hexlify(b_rev).decode('ascii')
+
+
+def little_endian_to_int(b):
+    '''little_endian_to_int takes byte sequence as a little-endian number.
+    Returns an integer'''
+    # use the from_bytes method of int
+    return int.from_bytes(b, 'little')
+
+
+def int_to_little_endian(n, length):
+    '''endian_to_little_endian takes an integer and returns the little-endian
+    byte sequence of length'''
+    # use the to_bytes method of n
+    return n.to_bytes(length, 'little')
+
+
+def h160_to_p2pkh_address(h160, prefix=b'\x00'):
+    '''Takes a byte sequence hash160 and returns a p2pkh address string'''
+    # p2pkh has a prefix of b'\x00' for mainnet, b'\x6f' for testnet
+    return encode_base58_checksum(prefix + h160)
+
+
+def h160_to_p2sh_address(h160, prefix=b'\x05'):
+    '''Takes a byte sequence hash160 and returns a p2sh address string'''
+    # p2sh has a prefix of b'\x05' for mainnet, b'\xc0' for testnet
+    return encode_base58_checksum(prefix + h160)
+
+class FieldElement:
+
+    def __init__(self, num, prime):
+        self.num = num
+        self.prime = prime
+        if self.num >= self.prime or self.num < 0:
+            error = 'Num {} not in field range 0 to {}'.format(
+                self.num, self.prime-1)
+            raise RuntimeError(error)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+        return self.num == other.num and self.prime == other.prime
+
+    def __ne__(self, other):
+        if other is None:
+            return True
+        return self.num != other.num or self.prime != other.prime
+
+    def __repr__(self):
+        return 'FieldElement_{}({})'.format(self.prime, self.num)
+
+    def __add__(self, other):
+        if self.prime != other.prime:
+            raise RuntimeError('Primes must be the same')
+        # self.num and other.num are the actual values
+        num = (self.num + other.num) % self.prime
+        # self.prime is what you'll need to mod against
+        prime = self.prime
+        # You need to return an element of the same class
+        # use: self.__class__(num, prime)
+        return self.__class__(num, prime)
+
+    def __sub__(self, other):
+        if self.prime != other.prime:
+            raise RuntimeError('Primes must be the same')
+        # self.num and other.num are the actual values
+        num = (self.num - other.num) % self.prime
+        # self.prime is what you'll need to mod against
+        prime = self.prime
+        # You need to return an element of the same class
+        # use: self.__class__(num, prime)
+        return self.__class__(num, prime)
+
+    def __mul__(self, other):
+        if self.prime != other.prime:
+            raise RuntimeError('Primes must be the same')
+        # self.num and other.num are the actual values
+        num = (self.num * other.num) % self.prime
+        # self.prime is what you'll need to mod against
+        prime = self.prime
+        # You need to return an element of the same class
+        # use: self.__class__(num, prime)
+        return self.__class__(num, prime)
+
+    def __rmul__(self, coefficient):
+        num = (self.num * coefficient) % self.prime
+        return self.__class__(num=num, prime=self.prime)
+
+    def __pow__(self, n):
+        # remember fermat's little theorem:
+        # self.num**(p-1) % p == 1
+        # you might want to use % operator on n
+        prime = self.prime
+        num = pow(self.num, n % (prime-1), prime)
+        return self.__class__(num, prime)
+
+    def __truediv__(self, other):
+        if self.prime != other.prime:
+            raise RuntimeError('Primes must be the same')
+        # self.num and other.num are the actual values
+        other_inv = pow(other.num, self.prime - 2, self.prime)
+        num = (self.num * other_inv) % self.prime
+        # self.prime is what you'll need to mod against
+        prime = self.prime
+        # use fermat's little theorem:
+        # self.num**(p-1) % p == 1
+        # this means:
+        # 1/n == pow(n, p-2, p)
+        # You need to return an element of the same class
+        # use: self.__class__(num, prime)
+        return self.__class__(num, prime)
+
+
+class Point:
+
+    def __init__(self, x, y, a, b):
+        self.a = a
+        self.b = b
+        self.x = x
+        self.y = y
+        # x being None and y being None represents the point at infinity
+        # Check for that here since the equation below won't make sense
+        # with None values for both.
+        if self.x is None and self.y is None:
+            return
+        # make sure that the elliptic curve equation is satisfied
+        # y**2 == x**3 + a*x + b
+        if self.y**2 != self.x**3 + a*x + b:
+            # if not, throw a RuntimeError
+            raise RuntimeError('({}, {}) is not on the curve'.format(
+                self.x, self.y))
+
+    def __eq__(self, other):
+        return self.x == other.x and self.y == other.y \
+            and self.a == other.a and self.b == other.b
+
+    def __ne__(self, other):
+        return self.x != other.x or self.y != other.y \
+            or self.a != other.a or self.b != other.b
+
+    def __repr__(self):
+        if self.x is None:
+            return 'Point(infinity)'
+        else:
+            return 'Point({},{})'.format(self.x, self.y)
+
+    def __add__(self, other):
+        if self.a != other.a or self.b != other.b:
+            raise RuntimeError(
+                'Points {}, {} are not on the same curve'.format(self, other))
+        # Case 0.0: self is the point at infinity, return other
+        if self.x is None:
+            return other
+        # Case 0.1: other is the point at infinity, return self
+        if other.x is None:
+            return self
+        # Case 1: self.x == other.x, self.y != other.y
+        # Result is point at infinity
+        if self.x == other.x and self.y != other.y:
+            # Remember to return an instance of this class:
+            # self.__class__(x, y, a, b)
+            return self.__class__(None, None, self.a, self.b)
+        # Case 2: self.x != other.x
+        if self.x != other.x:
+            # Formula (x3,y3)==(x1,y1)+(x2,y2)
+            # s=(y2-y1)/(x2-x1)
+            s = (other.y - self.y) / (other.x - self.x)
+            # x3=s**2-x1-x2
+            x = s**2 - self.x - other.x
+            # y3=s*(x1-x3)-y1
+            y = s*(self.x-x) - self.y
+            # Remember to return an instance of this class:
+            # self.__class__(x, y, a, b)
+            return self.__class__(x, y, self.a, self.b)
+        # Case 3: self.x == other.x, self.y == other.y
+        else:
+            # Formula (x3,y3)=(x1,y1)+(x1,y1)
+            # s=(3*x1**2+a)/(2*y1)
+            s = (3*self.x**2 + self.a) / (2*self.y)
+            # x3=s**2-2*x1
+            x = s**2 - 2*self.x
+            # y3=s*(x1-x3)-y1
+            y = s*(self.x-x) - self.y
+            # Remember to return an instance of this class:
+            # self.__class__(x, y, a, b)
+            return self.__class__(x, y, self.a, self.b)
+
+    def __rmul__(self, coefficient):
+        # rmul calculates coefficient * self
+        # implement the naive way:
+        # start product from 0 (point at infinity)
+        # use: self.__class__(None, None, a, b)
+        product = self.__class__(None, None, self.a, self.b)
+        # loop coefficient times
+        # use: for _ in range(coefficient):
+        for _ in range(coefficient):
+            # keep adding self over and over
+            product += self
+        # return the product
+        return product
+        # Extra Credit:
+        # a more advanced technique uses point doubling
+        # find the binary representation of coefficient
+        # keep doubling the point and if the bit is there for coefficient
+        # add the current.
+        # remember to return an instance of the class
+
+
+A = 0
+B = 7
+P = 2**256 - 2**32 - 977
+N = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141
+
+
+class S256Field(FieldElement):
+
+    def __init__(self, num, prime=None):
+        super().__init__(num=num, prime=P)
+
+    def hex(self):
+        return '{:x}'.format(self.num).zfill(64)
+
+    def __repr__(self):
+        return self.hex()
+
+    def sqrt(self):
+        return self**((P+1)//4)
+
+
+class S256Point(Point):
+    bits = 256
+
+    def __init__(self, x, y, a=None, b=None):
+        a, b = S256Field(A), S256Field(B)
+        if x is None:
+            super().__init__(x=None, y=None, a=a, b=b)
+        elif type(x) == int:
+            super().__init__(x=S256Field(x), y=S256Field(y), a=a, b=b)
+        else:
+            super().__init__(x=x, y=y, a=a, b=b)
+
+    def __repr__(self):
+        if self.x is None:
+            return 'Point(infinity)'
+        else:
+            return 'Point({},{})'.format(self.x, self.y)
+
+    def __rmul__(self, coefficient):
+        # current will undergo binary expansion
+        current = self
+        # result is what we return, starts at 0
+        result = S256Point(None, None)
+        # we double 256 times and add where there is a 1 in the binary
+        # representation of coefficient
+        for _ in range(self.bits):
+            if coefficient & 1:
+                result += current
+            current += current
+            # we shift the coefficient to the right
+            coefficient >>= 1
+        return result
+
+    def sec(self, compressed=True):
+        # returns the binary version of the sec format, NOT hex
+        # if compressed, starts with b'\x02' if self.y.num is even,
+        # b'\x03' if self.y is odd then self.x.num
+        # remember, you have to convert self.x.num/self.y.num to binary
+        # (some_integer.to_bytes(32, 'big'))
+        if compressed:
+            if self.y.num % 2 == 0:
+                return b'\x02' + self.x.num.to_bytes(32, 'big')
+            else:
+                return b'\x03' + self.x.num.to_bytes(32, 'big')
+        else:
+            # if non-compressed, starts with b'\x04' followod by self.x
+            # and then self.y
+            return b'\x04' + self.x.num.to_bytes(32, 'big') \
+                + self.y.num.to_bytes(32, 'big')
+
+    def h160(self, compressed=True):
+        return hash160(self.sec(compressed))
+
+    def p2pkh_script(self, compressed=True):
+        h160 = self.h160(compressed)
+        return p2pkh_script(h160)
+
+    def address(self, compressed=True, prefix=b'\x00'):
+        '''Returns the address string'''
+        h160 = self.h160(compressed)
+        return encode_base58_checksum(prefix + h160)
+
+    def segwit_redeem_script(self):
+        return b'\x16\x00\x14' + self.h160(True)
+
+    def segwit_address(self, prefix=b'\x05'):
+        address_bytes = hash160(self.segwit_redeem_script()[1:])
+        return encode_base58_checksum(prefix + address_bytes)
+
+    def verify(self, z, sig):
+        # remember sig.r and sig.s are the main things we're checking
+        # remember 1/s = pow(s, N-2, N)
+        s_inv = pow(sig.s, N-2, N)
+        # u = z / s
+        u = z * s_inv % N
+        # v = r / s
+        v = sig.r * s_inv % N
+        # u*G + v*P should have as the x coordinate, r
+        total = u*G + v*self
+        return total.x.num == sig.r
+
+    @classmethod
+    def parse(self, sec_bin):
+        '''returns a Point object from a compressed sec binary (not hex)
+        '''
+        if sec_bin[0] == 4:
+            x = int(hexlify(sec_bin[1:33]), 16)
+            y = int(hexlify(sec_bin[33:65]), 16)
+            return S256Point(x=x, y=y)
+        is_even = sec_bin[0] == 2
+        x = S256Field(int(hexlify(sec_bin[1:]), 16))
+        # right side of the equation y^2 = x^3 + 7
+        alpha = x**3 + S256Field(B)
+        # solve for left side
+        beta = alpha.sqrt()
+        if beta.num % 2 == 0:
+            even_beta = beta
+            odd_beta = S256Field(P - beta.num)
+        else:
+            even_beta = S256Field(P - beta.num)
+            odd_beta = beta
+        if is_even:
+            return S256Point(x, even_beta)
+        else:
+            return S256Point(x, odd_beta)
+
+
+G = S256Point(
+    0x79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798,
+    0x483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b8)
+
+
+class Signature:
+
+    def __init__(self, r, s):
+        self.r = r
+        self.s = s
+
+    def __repr__(self):
+        return 'Signature({:x},{:x})'.format(self.r, self.s)
+
+    def der(self):
+        rbin = self.r.to_bytes(32, byteorder='big')
+        # remove all null bytes at the beginning
+        rbin = rbin.lstrip(b'\x00')
+        # if rbin has a high bit, add a 00
+        if rbin[0] & 0x80:
+            rbin = b'\x00' + rbin
+        result = bytes([2, len(rbin)]) + rbin
+        sbin = self.s.to_bytes(32, byteorder='big')
+        # remove all null bytes at the beginning
+        sbin = sbin.lstrip(b'\x00')
+        # if sbin has a high bit, add a 00
+        if sbin[0] & 0x80:
+            sbin = b'\x00' + sbin
+        result += bytes([2, len(sbin)]) + sbin
+        return bytes([0x30, len(result)]) + result
+
+    @classmethod
+    def parse(cls, signature_bin):
+        s = BytesIO(signature_bin)
+        compound = s.read(1)[0]
+        if compound != 0x30:
+            raise RuntimeError("Bad Signature")
+        length = s.read(1)[0]
+        if length + 2 != len(signature_bin):
+            raise RuntimeError("Bad Signature Length")
+        marker = s.read(1)[0]
+        if marker != 0x02:
+            raise RuntimeError("Bad Signature")
+        rlength = s.read(1)[0]
+        r = int(hexlify(s.read(rlength)), 16)
+        marker = s.read(1)[0]
+        if marker != 0x02:
+            raise RuntimeError("Bad Signature")
+        slength = s.read(1)[0]
+        s = int(hexlify(s.read(slength)), 16)
+        if len(signature_bin) != 6 + rlength + slength:
+            raise RuntimeError("Signature too long")
+        return cls(r, s)
+
+
+class PrivateKey:
+
+    def __init__(self, secret, compressed=False, testnet=False):
+        self.secret = secret
+        self.point = secret*G
+        self.compressed = compressed
+        self.testnet = testnet
+
+    def hex(self):
+        return '{:x}'.format(self.secret).zfill(64)
+
+    def deterministic_k(self, z):
+        # RFC6979, optimized for secp256k1
+        k = b'\x00' * 32
+        v = b'\x01' * 32
+        if z > N:
+            z -= N
+        z_bytes = z.to_bytes(32, 'big')
+        secret_bytes = self.secret.to_bytes(32, 'big')
+        s256 = hashlib.sha256
+        k = hmac.new(k, v + b'\x00' + secret_bytes + z_bytes, s256).digest()
+        v = hmac.new(k, v, s256).digest()
+        k = hmac.new(k, v + b'\x01' + secret_bytes + z_bytes, s256).digest()
+        v = hmac.new(k, v, s256).digest()
+        while 1:
+            v = hmac.new(k, v, s256).digest()
+            candidate = int.from_bytes(v, 'big')
+            if candidate >= 1 and candidate < N:
+                return candidate
+            k = hmac.new(k, v + b'\x00', s256).digest()
+            v = hmac.new(k, v, s256).digest()
+
+    def sign(self, z):
+        # use deterministic signatures
+        k = self.deterministic_k(z)
+        # r is the x coordinate of the resulting point k*G
+        r = (k*G).x.num
+        # remember 1/k = pow(k, N-2, N)
+        k_inv = pow(k, N-2, N)
+        # s = (z+r*secret) / k
+        s = (z + r*self.secret) * k_inv % N
+        if s > N/2:
+            s = N - s
+        # return an instance of Signature:
+        # Signature(r, s)
+        return Signature(r, s)
+
+    def wif(self, prefix=None):
+        if prefix is None:
+            if self.testnet:
+                prefix = b'\xef'
+            else:
+                prefix = b'\x80'
+        # convert the secret from integer to a 32-bytes in big endian using
+        # num.to_bytes(32, 'big')
+        secret_bytes = self.secret.to_bytes(32, 'big')
+        # append b'\x01' if compressed
+        if self.compressed:
+            suffix = b'\x01'
+        else:
+            suffix = b''
+        # encode_base58_checksum the whole thing
+        return encode_base58_checksum(prefix + secret_bytes + suffix)
+
+    def h160(self):
+        return self.point.h160(compressed=self.compressed)
+
+    def address(self, prefix=None):
+        if prefix is None:
+            if self.testnet:
+                prefix = b'\x6f'
+            else:
+                prefix = b'\x00'
+        return self.point.address(compressed=self.compressed, prefix=prefix)
+
+    def segwit_redeem_script(self):
+        return self.point.segwit_redeem_script()
+
+    def segwit_address(self, prefix=None):
+        if prefix is None:
+            if self.testnet:
+                prefix = b'\xc4'
+            else:
+                prefix = b'\x05'
+        return self.point.segwit_address(prefix=prefix)
+
+    @classmethod
+    def parse(cls, wif):
+        secret_bytes = decode_base58(
+            wif,
+            num_bytes=40,
+            strip_leading_zeros=True,
+        )
+        # remove the first and last if we have 34, only the first if we have 33
+        testnet = secret_bytes[0] == 0xef
+        if len(secret_bytes) == 34:
+            secret_bytes = secret_bytes[1:-1]
+            compressed = True
+        elif len(secret_bytes) == 33:
+            secret_bytes = secret_bytes[1:]
+            compressed = False
+        else:
+            raise RuntimeError('not valid WIF')
+        secret = int.from_bytes(secret_bytes, 'big')
+        return cls(secret, compressed=compressed, testnet=testnet)
+
+
+class Script:
+
+    def __init__(self, elements):
+        self.elements = elements
+
+    def __repr__(self):
+        result = ''
+        for element in self.elements:
+            if type(element) == int:
+                result += '{} '.format(OP_CODES[element])
+            else:
+                result += '{} '.format(hexlify(element))
+        return result
+
+    @classmethod
+    def parse(cls, binary):
+        s = BytesIO(binary)
+        elements = []
+        current = s.read(1)
+        while current != b'':
+            op_code = current[0]
+            if op_code > 0 and op_code <= 75:
+                # we have an element
+                elements.append(s.read(op_code))
+            else:
+                elements.append(op_code)
+            current = s.read(1)
+        return cls(elements)
+
+    def type(self):
+        '''Some standard pay-to type scripts.'''
+        if len(self.elements) == 0:
+            return 'blank'
+        elif self.elements[0] == 0x76 \
+            and self.elements[1] == 0xa9 \
+            and type(self.elements[2]) == bytes \
+            and len(self.elements[2]) == 0x14 \
+            and self.elements[3] == 0x88 \
+            and self.elements[4] == 0xac:
+            # p2pkh:
+            # OP_DUP OP_HASH160 <20-byte hash> <OP_EQUALVERIFY> <OP_CHECKSIG>
+            return 'p2pkh'
+        elif self.elements[0] == 0xa9 \
+            and type(self.elements[1]) == bytes \
+            and len(self.elements[1]) == 0x14 \
+            and self.elements[-1] == 0x87:
+            # p2sh:
+            # OP_HASH160 <20-byte hash> <OP_EQUAL>
+            return 'p2sh'
+        elif type(self.elements[0]) == bytes \
+            and len(self.elements[0]) in range(0x40, 0x50) \
+            and type(self.elements[1]) == bytes \
+            and len(self.elements[1]) in (0x21, 0x41):
+            # p2pkh scriptSig:
+            # <signature> <pubkey>
+            return 'p2pkh sig'
+        elif len(self.elements) == 2 \
+            and self.elements[0] == 0 \
+            and len(self.elements[-1]) == 20 \
+            and type(self.elements[-1]) == bytes :
+            return 'p2wpkh'
+        elif len(self.elements) == 2 \
+            and self.elements[0] == 0 \
+            and len(self.elements[-1]) == 32 \
+            and type(self.elements[-1]) == bytes :
+            return 'p2wsh'   
+        elif len(self.elements) > 1 \
+            and type(self.elements[1]) == bytes \
+            and len(self.elements[1]) in range(0x40, 0x50) \
+            and type(self.elements[-1]) == bytes \
+            and self.elements[-1][-1] == 0xae:
+            # HACK: assumes p2sh is a multisig
+            # p2sh multisig:
+            # <x> <sig1> ... <sigm> <redeemscript ends with OP_CHECKMULTISIG>
+            return 'p2sh sig'
+        elif len(self.elements) == 1 \
+            and type(self.elements[0]) == bytes \
+            and len(self.elements[0]) == 0x16:
+            # HACK: assumes p2sh can be p2sh-p2pkh
+            return 'p2sh sig'
+        elif len(self.elements) > 1 \
+            and type(self.elements[1]) == bytes \
+            and len(self.elements[1]) == 0x21 \
+            and self.elements[-1] == 0xae:
+            # HACK: Assumes script with 2nd element length of a SEC compressed pubkey
+            # and ending with OP_CHECKMULTISG is a multisig redeemScript
+            return 'multisig redeem'
+        else:
+            return 'unknown: {}'.format(self)
+
+    def serialize(self):
+        result = b''
+        for element in self.elements:
+            if type(element) == int:
+                result += bytes([element])
+            else:
+                result += bytes([len(element)]) + element
+        return result
+
+    def hash160(self):
+        return hash160(self.serialize())
+
+    def der_signature(self, index=0):
+        '''index isn't used for p2pkh, for p2sh, means one of m sigs'''
+        sig_type = self.type()
+        if sig_type == 'p2pkh sig':
+            return self.elements[0]
+        elif sig_type == 'p2sh sig':
+            return self.elements[index+1]
+        else:
+            raise RuntimeError('script type needs to be p2pkh sig or p2sh sig')
+
+    def sec_pubkey(self, index=0):
+        '''index isn't used for p2pkh, for p2sh, means one of n pubkeys'''
+        sig_type = self.type()
+        if sig_type == 'p2pkh sig':
+            return self.elements[1]
+        elif sig_type == 'p2sh sig':
+            if len(self.elements) > 2:
+                # HACK: assumes p2sh is a multisig
+                redeem_script = Script.parse(self.elements[-1])
+                return redeem_script.elements[index+1]
+            else:
+                return None
+        # Understand multisg redeem scripts
+        elif sig_type == 'multisig redeem':
+            return self.elements[index+1]
+
+    def num_sigs_required(self):
+        '''Returns the number of sigs required. For p2pkh, it's always 1,
+        For p2sh multisig, it's the m in the m of n'''
+        sig_type = self.type()
+        if sig_type == 'p2pkh sig':
+            return 1
+        elif sig_type == 'p2sh sig':
+            if len(self.elements) > 2:
+                op_code = OP_CODES[self.elements[-1][0]]
+                return int(op_code[3:])
+            else:
+                return 1
+        else:
+            raise RuntimeError('script type needs to be p2pkh sig or p2sh sig')
+
+    def redeem_script(self):
+        sig_type = self.type()
+        if sig_type == 'p2sh sig':
+            return self.elements[-1]
+        else:
+            return
+
+    def address(self, prefix=b'\x00'):
+        '''Returns the address corresponding to the script'''
+        sig_type = self.type()
+        if sig_type == 'p2pkh':
+            # hash160 is the 3rd element
+            h160 = self.elements[2]
+            # convert to p2pkh address using h160_to_p2pkh_address
+            # (remember testnet)
+            return h160_to_p2pkh_address(h160, prefix)
+        elif sig_type == 'p2sh':
+            # hash160 is the 2nd element
+            h160 = self.elements[1]
+            # convert to p2sh address using h160_to_p2sh_address
+            # (remember testnet)
+            return h160_to_p2sh_address(h160, prefix)
+        elif sig_type == 'multisig redeem':
+            # Convert multisig redeemscript to p2sh address
+            return h160_to_p2sh_address(hash160(self.serialize()), prefix)
+            
+
+
+OP_CODES = {
+  0: 'OP_0',
+  76: 'OP_PUSHDATA1',
+  77: 'OP_PUSHDATA2',
+  78: 'OP_PUSHDATA4',
+  79: 'OP_1NEGATE',
+  80: 'OP_RESERVED',
+  81: 'OP_1',
+  82: 'OP_2',
+  83: 'OP_3',
+  84: 'OP_4',
+  85: 'OP_5',
+  86: 'OP_6',
+  87: 'OP_7',
+  88: 'OP_8',
+  89: 'OP_9',
+  90: 'OP_10',
+  91: 'OP_11',
+  92: 'OP_12',
+  93: 'OP_13',
+  94: 'OP_14',
+  95: 'OP_15',
+  96: 'OP_16',
+  97: 'OP_NOP',
+  98: 'OP_VER',
+  99: 'OP_IF',
+  100: 'OP_NOTIF',
+  101: 'OP_VERIF',
+  102: 'OP_VERNOTIF',
+  103: 'OP_ELSE',
+  104: 'OP_ENDIF',
+  105: 'OP_VERIFY',
+  106: 'OP_RETURN',
+  107: 'OP_TOALTSTACK',
+  108: 'OP_FROMALTSTACK',
+  109: 'OP_2DROP',
+  110: 'OP_2DUP',
+  111: 'OP_3DUP',
+  112: 'OP_2OVER',
+  113: 'OP_2ROT',
+  114: 'OP_2SWAP',
+  115: 'OP_IFDUP',
+  116: 'OP_DEPTH',
+  117: 'OP_DROP',
+  118: 'OP_DUP',
+  119: 'OP_NIP',
+  120: 'OP_OVER',
+  121: 'OP_PICK',
+  122: 'OP_ROLL',
+  123: 'OP_ROT',
+  124: 'OP_SWAP',
+  125: 'OP_TUCK',
+  126: 'OP_CAT',
+  127: 'OP_SUBSTR',
+  128: 'OP_LEFT',
+  129: 'OP_RIGHT',
+  130: 'OP_SIZE',
+  131: 'OP_INVERT',
+  132: 'OP_AND',
+  133: 'OP_OR',
+  134: 'OP_XOR',
+  135: 'OP_EQUAL',
+  136: 'OP_EQUALVERIFY',
+  137: 'OP_RESERVED1',
+  138: 'OP_RESERVED2',
+  139: 'OP_1ADD',
+  140: 'OP_1SUB',
+  141: 'OP_2MUL',
+  142: 'OP_2DIV',
+  143: 'OP_NEGATE',
+  144: 'OP_ABS',
+  145: 'OP_NOT',
+  146: 'OP_0NOTEQUAL',
+  147: 'OP_ADD',
+  148: 'OP_SUB',
+  149: 'OP_MUL',
+  150: 'OP_DIV',
+  151: 'OP_MOD',
+  152: 'OP_LSHIFT',
+  153: 'OP_RSHIFT',
+  154: 'OP_BOOLAND',
+  155: 'OP_BOOLOR',
+  156: 'OP_NUMEQUAL',
+  157: 'OP_NUMEQUALVERIFY',
+  158: 'OP_NUMNOTEQUAL',
+  159: 'OP_LESSTHAN',
+  160: 'OP_GREATERTHAN',
+  161: 'OP_LESSTHANOREQUAL',
+  162: 'OP_GREATERTHANOREQUAL',
+  163: 'OP_MIN',
+  164: 'OP_MAX',
+  165: 'OP_WITHIN',
+  166: 'OP_RIPEMD160',
+  167: 'OP_SHA1',
+  168: 'OP_SHA256',
+  169: 'OP_HASH160',
+  170: 'OP_HASH256',
+  171: 'OP_CODESEPARATOR',
+  172: 'OP_CHECKSIG',
+  173: 'OP_CHECKSIGVERIFY',
+  174: 'OP_CHECKMULTISIG',
+  175: 'OP_CHECKMULTISIGVERIFY',
+  176: 'OP_NOP1',
+  177: 'OP_CHECKLOCKTIMEVERIFY',
+  178: 'OP_CHECKSEQUENCEVERIFY',
+  179: 'OP_NOP4',
+  180: 'OP_NOP5',
+  181: 'OP_NOP6',
+  182: 'OP_NOP7',
+  183: 'OP_NOP8',
+  184: 'OP_NOP9',
+  185: 'OP_NOP10',
+  252: 'OP_NULLDATA',
+  253: 'OP_PUBKEYHASH',
+  254: 'OP_PUBKEY',
+  255: 'OP_INVALIDOPCODE',
+}
+
+
+class Tx():
+
+    default_version = 1
+    default_hash_type = 1
+    cache = {}
+    p2pkh_prefixes = (b'\x00', b'\x6f')
+    p2sh_prefixes = (b'\x05', b'\xc4')
+    testnet_prefixes = (b'\x6f', b'\xc4')
+    scale = 100000000
+    num_bytes = 25
+    fee = 2500
+    insight = 'https://btc-bitcore6.trezor.io/api'
+    seeds = None
+
+    def __init__(self, version, tx_ins, tx_outs, locktime, testnet=False):
+        self.version = version
+        self.tx_ins = tx_ins
+        self.tx_outs = tx_outs
+        self.locktime = locktime
+        self.testnet = testnet
+        self._hash_prevouts = None
+        self._hash_sequence = None
+        self._hash_outputs = None
+
+    def __repr__(self):
+        tx_ins = ''
+        for tx_in in self.tx_ins:
+            tx_ins += tx_in.__repr__() + '\n'
+        tx_outs = ''
+        for tx_out in self.tx_outs:
+            tx_outs += tx_out.__repr__() + '\n'
+        return '{}\nversion: {}\ntx_ins:\n{}\ntx_outs:\n{}\nlocktime: {}\n'.format(
+            self.hash().hex(),
+            self.version,
+            tx_ins,
+            tx_outs,
+            self.locktime,
+        )
+
+    def hash(self):
+        if self.is_segwit():
+            result = int_to_little_endian(self.version, 4)
+            # encode_varint on the number of inputs
+            result += encode_varint(len(self.tx_ins))
+            # iterate inputs
+            for tx_in in self.tx_ins:
+                # serialize each input
+                result += tx_in.serialize()
+            # encode_varint on the number of inputs
+            result += encode_varint(len(self.tx_outs))
+            # iterate outputs
+            for tx_out in self.tx_outs:
+                # serialize each output
+                result += tx_out.serialize()
+            # serialize locktime (4 bytes, little endian)
+            result += int_to_little_endian(self.locktime, 4)
+            return double_sha256(result)[::-1]
+        else:
+            return double_sha256(self.serialize())[::-1]
+
+    def id(self):
+        return self.hash().hex()
+
+    @classmethod
+    def get_address_data(cls, addr):
+        b58 = decode_base58(addr, num_bytes=cls.num_bytes)
+        prefix = b58[:-20]
+        h160 = b58[-20:]
+        testnet = prefix in cls.testnet_prefixes
+        if prefix in cls.p2pkh_prefixes:
+            script_pubkey = Script.parse(p2pkh_script(h160))
+        elif prefix in cls.p2sh_prefixes:
+            script_pubkey = Script.parse(p2sh_script(h160))
+        else:
+            raise RuntimeError('unknown type of address {} {}'.format(addr, prefix))
+        return {
+            'testnet': testnet,
+            'h160': h160,
+            'script_pubkey': script_pubkey,
+        }
+
+    @classmethod
+    def parse(cls, s):
+        '''Takes a byte stream and parses the transaction at the start
+        return a Tx object
+        '''
+        # s.read(n) will return n bytes
+        # version has 4 bytes, little-endian, interpret as int
+        version = little_endian_to_int(s.read(4))
+        # num_inputs is a varint, use read_varint(s)
+        num_inputs = read_varint(s)
+        # if we have a segwit marker, we need to parse in another way
+        if num_inputs == 0:
+            return cls.parse_segwit(s, version)
+        # each input needs parsing
+        inputs = []
+        for _ in range(num_inputs):
+            inputs.append(TxIn.parse(s))
+        # num_outputs is a varint, use read_varint(s)
+        num_outputs = read_varint(s)
+        # each output needs parsing
+        outputs = []
+        for _ in range(num_outputs):
+            outputs.append(TxOut.parse(s))
+        # locktime is 4 bytes, little-endian
+        locktime = little_endian_to_int(s.read(4))
+        # return an instance of the class (cls(...))
+        return cls(version, inputs, outputs, locktime)
+
+    @classmethod
+    def parse_segwit(cls, s, version):
+        '''Takes a byte stream and parses the segwit transaction in middle
+        return a Tx object
+        '''
+        flag = s.read(1)
+        if flag != b'\x01':
+            raise RuntimeError('Not a segwit transaction {}'.format(flag))
+        # num_inputs is a varint, use read_varint(s)
+        num_inputs = read_varint(s)
+        # each input needs parsing
+        tx_ins = []
+        for _ in range(num_inputs):
+            tx_ins.append(TxIn.parse(s))
+        # num_outputs is a varint, use read_varint(s)
+        num_outputs = read_varint(s)
+        # each output needs parsing
+        tx_outs = []
+        for _ in range(num_outputs):
+            tx_outs.append(TxOut.parse(s))
+        # now parse the witness program
+        for tx_in in tx_ins:
+            num_elements = read_varint(s)
+            elements = [num_elements]
+            for _ in range(num_elements):
+                element_len = read_varint(s)
+                elements.append(s.read(element_len))
+            tx_in.witness_program = Script(elements).serialize()
+        # locktime is 4 bytes, little-endian
+        locktime = little_endian_to_int(s.read(4))
+        # return an instance of the class (cls(...))
+        return cls(version, tx_ins, tx_outs, locktime)
+
+    def is_segwit(self):
+        for tx_in in self.tx_ins:
+            if tx_in.is_segwit():
+                return True
+        return False
+
+    def serialize(self):
+        '''Returns the byte serialization of the transaction'''
+        if self.is_segwit():
+            return self.serialize_segwit()
+        # serialize version (4 bytes, little endian)
+        result = int_to_little_endian(self.version, 4)
+        # encode_varint on the number of inputs
+        result += encode_varint(len(self.tx_ins))
+        # iterate inputs
+        for tx_in in self.tx_ins:
+            # serialize each input
+            result += tx_in.serialize()
+        # encode_varint on the number of inputs
+        result += encode_varint(len(self.tx_outs))
+        # iterate outputs
+        for tx_out in self.tx_outs:
+            # serialize each output
+            result += tx_out.serialize()
+        # serialize locktime (4 bytes, little endian)
+        result += int_to_little_endian(self.locktime, 4)
+        return result
+
+    def serialize_segwit(self):
+        '''Returns the byte serialization of the transaction'''
+        # serialize version (4 bytes, little endian)
+        result = int_to_little_endian(self.version, 4)
+        # segwit marker '0001'
+        result += b'\x00\x01'
+        # encode_varint on the number of inputs
+        result += encode_varint(len(self.tx_ins))
+        # iterate inputs
+        for tx_in in self.tx_ins:
+            # serialize each input
+            result += tx_in.serialize()
+        # encode_varint on the number of inputs
+        result += encode_varint(len(self.tx_outs))
+        # iterate outputs
+        for tx_out in self.tx_outs:
+            # serialize each output
+            result += tx_out.serialize()
+        # add the witness data
+        for tx_in in self.tx_ins:
+            result += tx_in.witness_program
+        # serialize locktime (4 bytes, little endian)
+        result += int_to_little_endian(self.locktime, 4)
+        return result
+
+    def fee(self):
+        '''Returns the fee of this transaction in satoshi'''
+        # initialize input sum and output sum
+        input_sum, output_sum = 0, 0
+        # iterate through inputs
+        for tx_in in self.tx_ins:
+            # for each input get the value and add to input sum
+            input_sum += tx_in.value()
+        # iterate through outputs
+        for tx_out in self.tx_outs:
+            # for each output get the amount and add to output sum
+            output_sum += tx_out.amount
+        # return input sum - output sum
+        return input_sum - output_sum
+
+    def hash_prevouts(self):
+        if self._hash_prevouts is None:
+            all_prevouts = b''
+            all_sequence = b''
+            for tx_in in self.tx_ins:
+                all_prevouts += tx_in.prev_tx[::-1] + int_to_little_endian(tx_in.prev_index, 4)
+                all_sequence += int_to_little_endian(tx_in.sequence, 4)
+            self._hash_prevouts = double_sha256(all_prevouts)
+            self._hash_sequence = double_sha256(all_sequence)
+        return self._hash_prevouts
+
+    def hash_sequence(self):
+        if self._hash_sequence is None:
+            self.hash_prevouts()  # this should calculate self._hash_prevouts
+        return self._hash_sequence
+
+    def hash_outputs(self):
+        if self._hash_outputs is None:
+            all_outputs = b''
+            for tx_out in self.tx_outs:
+                all_outputs += tx_out.serialize()
+            self._hash_outputs = double_sha256(all_outputs)
+        return self._hash_outputs
+
+    def sig_hash_preimage_bip143(self, input_index, hash_type, redeem_script=None):
+        '''Returns the integer representation of the hash that needs to get
+        signed for index input_index'''
+        tx_in = self.tx_ins[input_index]
+        # per BIP143 spec
+        s = int_to_little_endian(self.version, 4)
+        s += self.hash_prevouts() + self.hash_sequence()
+        s += tx_in.prev_tx[::-1] + int_to_little_endian(tx_in.prev_index, 4)
+        if tx_in.is_segwit() or redeem_script:
+            if redeem_script:
+                h160 = redeem_script[-20:]
+            else:
+                h160 = tx_in.redeem_script()[-20:]
+            ser = p2pkh_script(h160)
+        else:
+            ser = tx_in.script_pubkey().serialize()
+        s += bytes([len(ser)]) + ser  # script pubkey
+        s += int_to_little_endian(tx_in.value(), 8)
+        s += int_to_little_endian(tx_in.sequence, 4)
+        s += self.hash_outputs()
+        s += int_to_little_endian(self.locktime, 4)
+        s += int_to_little_endian(hash_type, 4)
+        return s
+
+    def sig_hash_bip143(self, input_index, hash_type, redeem_script=None):
+        s = self.sig_hash_preimage_bip143(input_index, hash_type, redeem_script=redeem_script)
+        return int.from_bytes(double_sha256(s), 'big')
+
+    def sig_hash(self, input_index, hash_type):
+        '''Returns the integer representation of the hash that needs to get
+        signed for index input_index'''
+        # create a transaction serialization where
+        # all the input script_sigs are blanked out
+        alt_tx_ins = []
+        for tx_in in self.tx_ins:
+            alt_tx_ins.append(TxIn(
+                prev_tx=tx_in.prev_tx,
+                prev_index=tx_in.prev_index,
+                script_sig=b'',
+                sequence=tx_in.sequence,
+                value=tx_in.value(),
+                script_pubkey=tx_in.script_pubkey().serialize(),
+            ))
+        # replace the input's scriptSig with the scriptPubKey
+        signing_input = alt_tx_ins[input_index]
+        script_pubkey = signing_input.script_pubkey(self.testnet)
+        sig_type = script_pubkey.type()
+        if sig_type == 'p2pkh':
+            signing_input.script_sig = script_pubkey
+        elif sig_type == 'p2sh':
+            current_input = self.tx_ins[input_index]
+            signing_input.script_sig = Script.parse(
+                current_input.redeem_script())
+        else:
+            raise RuntimeError('not a valid sig_type: {}'.format(sig_type))
+        alt_tx = self.__class__(
+            version=self.version,
+            tx_ins=alt_tx_ins,
+            tx_outs=self.tx_outs,
+            locktime=self.locktime,
+        )
+        # add the hash_type
+        result = alt_tx.serialize()
+        result += int_to_little_endian(hash_type, 4)
+        return int.from_bytes(double_sha256(result), 'big')
+
+    def verify_input(self, input_index):
+        '''Returns whether the input has a valid signature'''
+        # get the relevant input
+        tx_in = self.tx_ins[input_index]
+        # get the number of signatures required. This is available in tx_in.script_sig.num_sigs_required()
+        sigs_required = tx_in.script_sig.num_sigs_required()
+        # iterate over the sigs required and check each signature
+        for sig_num in range(sigs_required):
+            # get the point from the sec format
+            sec = tx_in.sec_pubkey(index=sig_num)
+            # get the sec_pubkey at current signature index
+            point = S256Point.parse(sec)
+            # get the der sig and hash_type from input
+            # get the der_signature at current signature index
+            der, hash_type = tx_in.der_signature(index=sig_num)
+            # get the signature from der format
+            signature = Signature.parse(der)
+            # get the hash to sign
+            if tx_in.is_segwit():
+                h160 = hash160(tx_in.script_sig.redeem_script())
+                if h160 != tx_in.script_pubkey(self.testnet).elements[1]:
+                    return False
+                pubkey_h160 = tx_in.script_sig.redeem_script()[-20:]
+                if pubkey_h160 != point.h160():
+                    return False
+                z = self.sig_hash_bip143(input_index, hash_type)
+            else:
+                z = self.sig_hash(input_index, hash_type)
+            # use point.verify on the hash to sign and signature
+            if not point.verify(z, signature):
+                return False
+        return True
+
+    def sign_input(self, input_index, private_key, hash_type, compressed=True, redeem_script=None):
+        '''Signs the input using the private key'''
+        # get the hash to sign
+        tx_in = self.tx_ins[input_index]
+        if redeem_script:
+            z = self.sig_hash_bip143(input_index, hash_type, redeem_script=redeem_script)
+        else:
+            z = self.sig_hash(input_index, hash_type)
+        # get der signature of z from private key
+        der = private_key.sign(z).der()
+        # append the hash_type to der (use bytes([hash_type]))
+        sig = der + bytes([hash_type])
+        # calculate the sec
+        sec = private_key.point.sec(compressed=compressed)
+        if redeem_script:
+            # witness program 0
+            tx_in.script_sig = Script([redeem_script])
+            tx_in.witness_program = Script([2, sig, sec]).serialize()
+        else:
+            # initialize a new script with [sig, sec] as the elements
+            # change input's script_sig to new script
+            tx_in.script_sig = Script([sig, sec])
+        # return whether sig is valid using self.verify_input
+        return self.verify_input(input_index)
+
+    def is_coinbase(self):
+        '''Returns whether this transaction is a coinbase transaction or not'''
+        # check that there is exactly 1 input
+        if len(self.tx_ins) != 1:
+            return False
+        # grab the first input
+        first_input = self.tx_ins[0]
+        # check that first input prev_tx is b'\x00' * 32 bytes
+        if first_input.prev_tx != b'\x00' * 32:
+            return False
+        # check that first input prev_index is 0xffffffff
+        if first_input.prev_index != 0xffffffff:
+            return False
+        return True
+
+    def coinbase_height(self):
+        '''Returns the height of the block this coinbase transaction is in
+        Returns None if this transaction is not a coinbase transaction
+        '''
+        # if this is NOT a coinbase transaction, return None
+        if not self.is_coinbase():
+            return None
+        # grab the first input
+        first_input = self.tx_ins[0]
+        # grab the first element of the script_sig (.script_sig.elements[0])
+        first_element = first_input.script_sig.elements[0]
+        # convert the first element from little endian to int
+        return little_endian_to_int(first_element)
+
+    def verify(self):
+        for i in range(len(self.tx_ins)):
+            if not self.verify_input(i):
+                return False
+        return True
+
+class TxIn():
+
+    def __init__(self, prev_tx, prev_index, script_sig, sequence, witness_program=b'\x00', value=None, script_pubkey=None):
+        self.prev_tx = prev_tx
+        self.prev_index = prev_index
+        self.script_sig = Script.parse(script_sig)
+        self.sequence = sequence
+        self.witness_program = witness_program
+        self._value = value
+        if script_pubkey is None:
+            self._script_pubkey = None
+        else:
+            self._script_pubkey = Script.parse(script_pubkey)
+
+    def __repr__(self):
+        return '{}:{}'.format(self.prev_tx.hex(), self.prev_index)
+
+    @classmethod
+    def parse(cls, s):
+        '''Takes a byte stream and parses the tx_input at the start
+        return a TxIn object
+        '''
+        # s.read(n) will return n bytes
+        # prev_tx is 32 bytes, little endian
+        prev_tx = s.read(32)[::-1]
+        # prev_index is 4 bytes, little endian, interpret as int
+        prev_index = little_endian_to_int(s.read(4))
+        # script_sig is a variable field (length followed by the data)
+        # get the length by using read_varint(s)
+        script_sig_length = read_varint(s)
+        script_sig = s.read(script_sig_length)
+        # sequence is 4 bytes, little-endian, interpret as int
+        sequence = little_endian_to_int(s.read(4))
+        # return an instance of the class (cls(...))
+        return cls(prev_tx, prev_index, script_sig, sequence)
+
+    def serialize(self):
+        '''Returns the byte serialization of the transaction input'''
+        # serialize prev_tx, little endian
+        result = self.prev_tx[::-1]
+        # serialize prev_index, 4 bytes, little endian
+        result += int_to_little_endian(self.prev_index, 4)
+        # get the scriptSig ready (use self.script_sig.serialize())
+        raw_script_sig = self.script_sig.serialize()
+        # encode_varint on the length of the scriptSig
+        result += encode_varint(len(raw_script_sig))
+        # add the scriptSig
+        result += raw_script_sig
+        # serialize sequence, 4 bytes, little endian
+        result += int_to_little_endian(self.sequence, 4)
+        return result
+
+    def script_pubkey(self, testnet=False):
+        '''Get the scriptPubKey by looking up the tx hash on libbitcoin server
+        Returns the binary scriptpubkey
+        '''
+        if self._script_pubkey is None:
+            # use self.fetch_tx to get the transaction
+            tx = self.fetch_tx(testnet=testnet)
+            # get the output at self.prev_index
+            # get the script_pubkey property
+            self._script_pubkey = tx.tx_outs[self.prev_index].script_pubkey
+        return self._script_pubkey
+
+    def der_signature(self, index=0):
+        '''returns a DER format signature and hash_type if the script_sig
+        has a signature'''
+        if self.is_segwit():
+            signature = self.witness_program[2:-34]
+        else:
+            signature = self.script_sig.der_signature(index=index)
+        # last byte is the hash_type, rest is the signature
+        return signature[:-1], signature[-1]
+
+    def sec_pubkey(self, index=0):
+        '''returns the SEC format public if the script_sig has one'''
+        if self.is_segwit():
+            return self.witness_program[-33:]
+        else:
+            return self.script_sig.sec_pubkey(index=index)
+
+    def redeem_script(self):
+        '''return the Redeem Script if there is one'''
+        return self.script_sig.redeem_script()
+
+    def is_segwit(self):
+        # Updated so if TxIn has a witness program present, then it is a segwit input
+        if len(self.witness_program) > 1:
+            return True
+        if self.script_sig.type() != 'p2sh sig':
+            return False
+        redeem_script_raw = self.script_sig.redeem_script()
+        if not redeem_script_raw:
+            return False
+        redeem_script = Script.parse(redeem_script_raw)
+        return redeem_script.elements[0] == 0 and \
+            type(redeem_script.elements[1]) == bytes and \
+            len(redeem_script.elements[1]) == 20
+
+
+class TxOut:
+
+    def __init__(self, amount, script_pubkey):
+        self.amount = amount
+        self.script_pubkey = Script.parse(script_pubkey)
+
+    def __repr__(self):
+        return '{}:{}'.format(self.amount, self.script_pubkey.address())
+
+    @classmethod
+    def parse(cls, s):
+        '''Takes a byte stream and parses the tx_output at the start
+        return a TxOut object
+        '''
+        # s.read(n) will return n bytes
+        # amount is 8 bytes, little endian, interpret as int
+        amount = little_endian_to_int(s.read(8))
+        # script_pubkey is a variable field (length followed by the data)
+        # get the length by using read_varint(s)
+        script_pubkey_length = read_varint(s)
+        script_pubkey = s.read(script_pubkey_length)
+        # return an instance of the class (cls(...))
+        return cls(amount, script_pubkey)
+
+    def serialize(self):
+        '''Returns the byte serialization of the transaction output'''
+        # serialize amount, 8 bytes, little endian
+        result = int_to_little_endian(self.amount, 8)
+        # get the scriptPubkey ready (use self.script_pubkey.serialize())
+        raw_script_pubkey = self.script_pubkey.serialize()
+        # encode_varint on the length of the scriptPubkey
+        result += encode_varint(len(raw_script_pubkey))
+        # add the scriptPubKey
+        result += raw_script_pubkey
+        return result

--- a/jmbitcoin/jmbitcoin/pythonpsbt/psbt.py
+++ b/jmbitcoin/jmbitcoin/pythonpsbt/psbt.py
@@ -1,0 +1,879 @@
+'''
+python-psbt
+
+Implementation of BIP 174 - Partially Signed Bitcoin Transaction format as defined 
+here: https://github.com/bitcoin/bips/blob/master/bip-0174.mediawiki
+
+Usage:
+
+Instantiate either a Creator, Updater, Signer, Combiner, Input Finalizer or Transaction Extractor 
+object depending on the responsibility of the entity
+
+Different psbt roles have different requirements and scopes and should stick only to those. 
+
+At this time, most functions expect data arguments to be raw bytes. Any PSBT role that has a constructor
+that expects a PSBT as an argument, expects it to be in bytes
+
+You can parse a base64 encoded PSBT and get the base64 representation of one as well.
+
+Index arguments are expected to be ints and at this time getting/adding sighash types is expected 
+to be of type int
+
+Author: Jason Les
+@heyitscheet
+'''
+from io import BytesIO
+from base64 import b64encode, b64decode
+from hashlib import sha256
+from .bitcoin_lib import (
+    hash160,
+    read_varint, 
+    encode_varint,
+    int_to_little_endian,
+    little_endian_to_int,
+    double_sha256,
+    Tx,
+    TxIn,
+    TxOut,
+    Script,
+    OP_CODES
+) 
+
+# Magic bytes and separator constants for serialization
+MAGIC_BYTES = b'psbt' 
+HEAD_SEPARATOR = b'\xff'
+DATA_SEPARATOR = b'\x00'
+
+# Global key types
+PSBT_GLOBAL_UNSIGNED_TX = b'\x00'
+
+# Per-input key types
+PSBT_IN_NON_WITNESS_UTXO = b'\x00'
+PSBT_IN_WITNESS_UTXO = b'\x01'
+PSBT_IN_PARTIAL_SIG = b'\x02'
+PSBT_IN_SIGHASH_TYPE = b'\x03'
+PSBT_IN_REDEEM_SCRIPT = b'\x04'
+PSBT_IN_WITNESS_SCRIPT = b'\x05'
+PSBT_IN_BIP32_DERIVATION = b'\x06'
+PSBT_IN_FINAL_SCRIPTSIG = b'\x07'
+PSBT_IN_FINAL_SCRIPTWITNESS = b'\x08'
+
+# Per-output key types
+PSBT_OUT_REDEEM_SCRIPT = b'\x00'
+PSBT_OUT_WITNESS_SCRIPT = b'\x01'
+PSBT_OUT_BIP32_DERIVATION = b'\x02'
+
+         
+class psbt:
+    '''A partially signed bitcoin transaction as described in BIP 174'''
+    
+    def __init__(self, dict_of_maps=None):
+        ''' A Partially Signed Bitcoin Transaction (psbt) object
+        
+        Argument dict_of_maps is a dictionary of all maps (global, inputs, outputs). 
+         '''
+        # Dict of map is organized by having three base keys: 'global', 'inputs', and 'outputs'
+        # The value for key 'global' is a dictionary of all key-value pairs of global data
+        # The value for key 'inputs' is an array of input maps. 
+        # An input map is a dictionary of key-value pairs for that input map
+        # The value for key 'outputs' is an array of input maps. 
+        # An output map is a dictionary of key-value pairs for that input map
+        self.maps = dict_of_maps
+        # Ensure PSBT is valid
+        self._validity_checking()
+        
+        
+    def __repr__(self):
+        # Representation of psbt (in hex):
+        result = ''
+        for g in sorted(self.maps['global'].keys()):
+            result += '{}:{} '.format(g.hex(), self.maps['global'][g].hex())
+        result += DATA_SEPARATOR.hex() + ' '
+        for i in self.maps['inputs']:
+            for k in sorted(i):
+                result += ('{}:{} '.format(k.hex(), i[k].hex()))
+            result += DATA_SEPARATOR.hex() + ' '
+        for o in self.maps['outputs']:
+            for k in sorted(o):
+                result += '{}:{} '.format(k.hex(), o[k].hex())
+            result += DATA_SEPARATOR.hex() + ' '
+        return result
+        
+        
+    def __str__(self):
+        # String version of psbt (in hex) for debugging
+        result = ('Globals\n===========\n')
+        for g in sorted(self.maps['global'].keys()):
+            result += '\t{} : {}\n'.format(g.hex(), self.maps['global'][g].hex())
+        result += 'Inputs\n===========\n'  
+        for i in self.maps['inputs']:
+            for k in sorted(i):
+                result += ('\t{} : {}\n'.format(k.hex(), i[k].hex()))
+        result += 'Outputs\n===========\n'         
+        for o in self.maps['outputs']:
+            for k in sorted(o):
+                result += '\t{} : {}\n'.format(k.hex(), o[k].hex())   
+        return result
+    
+    
+    def _validity_checking(self):
+        '''A variety of tests to ensure this PSBT is valid'''
+        # Check to make sure unsigned transaction is present
+        if PSBT_GLOBAL_UNSIGNED_TX not in self.maps['global']:
+            raise ValueError('Invalid PSBT, missing unsigned transaction')
+        else:
+            # Parse global unsigned tx for future checks
+            tx_obj = Tx.parse(BytesIO(self.maps['global'][PSBT_GLOBAL_UNSIGNED_TX]))
+        # If a scriptSig or scriptWitness is present, this is an signed transaction and is invalid
+        for i in tx_obj.tx_ins:
+            if len(i.script_sig.elements) >  0 or len(i.witness_program) > 1:
+                raise ValueError('Invalid PSBT, transaction in global map has scriptSig or scriptWitness present, not unsigned')
+        # Get number of inputs in unsigned tx and psbt maps
+        global_ins_cnt = len(tx_obj.tx_ins)
+        psbt_ins_cnt = len(self.maps['inputs'])
+        # If unsigned tx has no inputs, invalid
+        if global_ins_cnt == 0:
+            raise ValueError('Invalid PSBT, unsigned transaction missing inputs')
+        # If the psbt has no inputs, invalid
+        elif psbt_ins_cnt == 0:
+            raise ValueError('Invalid PSBT, no inputs')
+        # If the counts do not match, invalid
+        elif global_ins_cnt != psbt_ins_cnt:
+            raise ValueError('Invalid PSBT, number of inputs in unsigned transaction and PSBT do not match')
+        # Repeat for outputs
+        global_outs_cnt = len(tx_obj.tx_outs)
+        psbt_outs_cnt = len(self.maps['outputs'])
+        if global_outs_cnt == 0:
+            raise ValueError('Invalid PSBT, unsigned transaction missing outputs')
+        elif psbt_outs_cnt == 0:
+            raise ValueError('Invalid PSBT, no outputs')
+        elif global_outs_cnt != psbt_outs_cnt:
+            raise ValueError('Invalid PSBT, number of outputs in unsigned transaction and PSBT do not match')
+    
+    
+    @staticmethod
+    def serialize_map(key, value):
+        '''Serializes a key+value map. Expects arguments to be of type bytes'''
+        # In psbt serialization, each key and value is preceded by its length.
+        return encode_varint(len(key)) + key + encode_varint(len(value)) + value  
+
+
+    @staticmethod
+    def parse_key(s):
+        '''Reads byte stream and returns a key-value pair. 
+        
+        Returns None for both if key length is 0 (data separator)'''
+        key_length = read_varint(s)
+        if key_length == 0:
+            return None, None
+        key = s.read(key_length)
+        val_length = read_varint(s)
+        val = s.read(val_length)
+        return key, val
+
+
+    def serialize(self):
+        '''Returns a serialization representation of the PSBT'''
+        # First add magic bytes and separator
+        result = MAGIC_BYTES + HEAD_SEPARATOR
+        # Begin with global types. Iterate through and add all key+value pairs
+        for g in sorted(self.maps['global'].keys()):
+            result += self.serialize_map(key=g, value=self.maps['global'][g])
+        # Add separator to mark end of globals
+        result += DATA_SEPARATOR 
+        # Next is input types. Iterate through list of inputs, each of which is its own dict 
+        for i in self.maps['inputs']:
+            for k in sorted(i):
+                result += self.serialize_map(key=k, value=i[k])
+            # Insert a separator to mark the end of each input
+            result += DATA_SEPARATOR     
+        # Finally, do output types. Iterate through list of outputs, each of which is its own dict 
+        for o in self.maps['outputs']:
+            for k in sorted(o):
+                result += self.serialize_map(key=k, value=o[k])
+            # Insert a separator to mark the end of each output
+            result += DATA_SEPARATOR     
+        return result
+    
+    
+    @classmethod
+    def parse(cls, s):
+        '''Takes byte stream of a serialized psbt and returns a psbt object.'''
+        # Check that serialization begins with the magic bytes
+        if s.read(4) != MAGIC_BYTES:
+            raise RuntimeError('Missing magic bytes')
+        # Check that that magic bytes are followed by the separator
+        if s.read(1) != HEAD_SEPARATOR :
+            raise RuntimeError('Missing head separator')
+        # Begin parsing global types, which is required to start with an unsigned transaction
+        new_map = {
+            'global' : {},
+            'inputs' : [],
+            'outputs' : []
+            }
+        expect_globals = True
+        num_inputs = 0
+        num_outputs = 0
+        while expect_globals or num_inputs > 0 or num_outputs > 0:
+            try:
+                new_key, new_value = psbt.parse_key(s)
+            except IndexError:
+                raise RuntimeError('Unexpected serialization encountered, possible missing input/output maps')
+            if expect_globals:
+                # If a separator has been reached, the new_key will be None 
+                # So it's time to continue on
+                if new_key == None:
+                    expect_globals = False
+                    continue
+                # Add new key-value pair to global maps
+                new_map['global'][new_key] = new_value
+                # If adding the unsigned_tx, parse it as a Tx object from bitcoin_lib 
+                # and count the number of inputs and outputs
+                if new_key == PSBT_GLOBAL_UNSIGNED_TX:
+                    unsigned_tx_obj = Tx.parse(BytesIO(new_value))
+                    num_inputs = len(unsigned_tx_obj.tx_ins)
+                    num_outputs = len(unsigned_tx_obj.tx_outs)
+                    # Set the amount of input and output maps that are expected
+                    [new_map['inputs'].append({}) for _ in range(num_inputs)]
+                    [new_map['outputs'].append({}) for _ in range(num_outputs)]
+            # Parse each input key-value map
+            elif num_inputs > 0:
+                # If a separator has been reached, the new_key will be None 
+                # thus marking the end of that input
+                if new_key == None:
+                    num_inputs -= 1
+                    continue
+                # curr_index is the position of the current input being parsed in the 
+                # list of inputs in new_map['inputs']
+                # Determined by the absolute value of the total number of inputs left 
+                # to parse - the total number of inputs
+                curr_index = abs(num_inputs - len(new_map['inputs']))
+                new_map['inputs'][curr_index][new_key] = new_value       
+            # Parse each output key-value map
+            elif num_outputs > 0:
+                # If a separator has been reached, the new_key will be None marking 
+                # the end of that output
+                if new_key == None:
+                    num_outputs -= 1
+                    continue
+                # curr_index is the position of the current output being parsed 
+                # in the list of inputs in new_map['outputs']
+                # Determined by the absolute value of the total number of inputs left 
+                # to parse - the total number of inputs
+                curr_index = abs(num_outputs - len(new_map['outputs']))
+                new_map['outputs'][curr_index][new_key] = new_value     
+        return cls(dict_of_maps=new_map)
+    
+    
+    @classmethod
+    def parse_b64(cls, b64_psbt):
+        return psbt.parse(BytesIO(b64decode(b64_psbt)))
+            
+            
+    def get_as_b64(self):
+        '''Returns a string Base64 encoding of the PSBT'''
+        return b64encode(self.serialize()).decode("utf-8") 
+    
+    
+class PSBT_Role:
+    
+    
+    def __init__(self, serialized_psbt):
+        self.psbt=psbt.parse(BytesIO(serialized_psbt))
+        
+        
+    def serialized(self):
+        return self.psbt.serialize()
+    
+    
+    def make_file(self, filename=None):
+        '''Returns a binary representation of psbt in the form of a 
+        file with .psbt extension.
+        
+        Optional argument of the desired file name (without extension)
+        '''
+        extension = 'psbt'
+        # Current idea: hex of double-sha256 of unsigned tx, first 8 characters + role name + 
+        # hex of double-sha256 of entire psbt, last 8 characters 
+        # Ex: 7b61d191-Signer-93d87e3c
+        if filename == None:
+            filename = double_sha256(self.psbt.maps['global'][PSBT_GLOBAL_UNSIGNED_TX]).hex()[:8] + \
+            '-{}-'.format(self.role) + double_sha256(self.serialized()).hex()[-8:]
+        with open('{}.{}'.format(filename, extension), 'wb') as f:
+            f.write(self.serialized())
+        return
+
+
+    def _get_input_index(self, pubkey):
+        '''Returns the input index (integer) of the input that can be signed by 
+        the private key corresponding to the provided public key (in bytes)
+        
+        Note that this requires the public key be added to the PSBT with key 
+        PSBT_IN_BIP32_DERIVATION
+        '''
+        # Iterate through all inputs and check to see if there is an index 
+        # containing this public key
+        for i in self.psbt.maps['inputs']:
+            if (PSBT_IN_BIP32_DERIVATION+pubkey) in i:
+                # Returns int
+                return self.psbt.maps['inputs'].index(i)
+        return None
+    
+    
+    def _is_witness_input(self, an_input):
+        '''Iterate through an input's key-value pairs and determine if it has a witness or
+        non-witness UTXO'''
+        for k in an_input.keys():
+                if k[:1] == PSBT_IN_WITNESS_UTXO: 
+                    return True
+        return False
+    
+    
+    def get_unsigned_tx(self):
+        '''Returns the unsigned transaction for this psbt (in bytes)'''
+        return self.psbt.maps['global'][PSBT_GLOBAL_UNSIGNED_TX]
+    
+    
+    def get_utxo(self, input_index):
+        '''Returns the UTXO at the provided input index in the PSBT'''
+        return self.psbt.maps['inputs'][input_index].get(PSBT_IN_NON_WITNESS_UTXO, 
+            self.psbt.maps['inputs'][input_index].get(PSBT_IN_WITNESS_UTXO))
+    
+    
+    def b64_psbt(self):
+        '''Returns a string Base64 encoding of the PSBT'''
+        return b64encode(self.serialized_psbt()).decode("utf-8") 
+        
+        
+    def get_output_redeem_script(self, output_index):
+        try:
+            return self.psbt.maps['outputs'][output_index][PSBT_OUT_REDEEM_SCRIPT]
+        except KeyError:
+            raise RuntimeError('Either this output index is out of bounds or there is no redeemScript for it')
+        
+        
+    def get_output_witness_script(self, output_index):
+        try:
+            return self.psbt.maps['outputs'][output_index][PSBT_OUT_WITNESS_SCRIPT]
+        except KeyError:
+            raise RuntimeError('Either this output index is out of bounds or there is no witnessScript for it')
+        
+
+class Creator(PSBT_Role):
+    '''The Creator creates a new psbt. It must create an unsigned transaction 
+        and place it in the psbt. The Creator must create empty input fields.'''
+    
+    def __init__(self, inputs, outputs, tx_version=2, input_sequence=0xffffffff, locktime=0):
+        '''Inputs should be a list of tuples in the form of (prev tx, prev index)
+        Outputs should be a list of tuples in the form of (amount, scriptPubKey)'''
+        # Specify current role as string for default file name in make_file()
+        self.role = 'Creator'
+        self.tx_inputs = []
+        # outputs should be a list of tuples in the form of (amount, scriptPubKey), amount in satoshi
+        self.tx_outputs = []
+        # Initialize list of TxIn objects (Inputs)
+        for i in inputs:
+            self.tx_inputs.append(TxIn(prev_tx=i[0], prev_index=i[1], script_sig=b'', sequence=input_sequence))
+        # Initialize list of TxOut objects (Outputs)
+        for i in outputs:
+            self.tx_outputs.append(TxOut(amount=i[0], script_pubkey=i[1]))
+        self.tx_obj = Tx(version=tx_version, tx_ins=self.tx_inputs, tx_outs=self.tx_outputs, locktime=locktime)
+        # Get a serialized version of the unsigned tx for the psbt
+        serialized_tx = self.tx_obj.serialize()
+        # Construct a serialized psbt manually
+        new_psbt_serialized = MAGIC_BYTES + HEAD_SEPARATOR + psbt.serialize_map(key=PSBT_GLOBAL_UNSIGNED_TX, \
+        value=serialized_tx)  + DATA_SEPARATOR + (DATA_SEPARATOR*len(self.tx_inputs)) + \
+        (DATA_SEPARATOR*len(self.tx_outputs))
+        # Create the psbt object using the serialized psbt
+        self.psbt = psbt.parse(BytesIO(new_psbt_serialized))
+
+    
+    def get_utxo(self, input_index):
+        raise RuntimeError('Function out of scope for this role')
+    
+    
+    def _get_input_index(self, pubkey):
+        raise RuntimeError('Function out of scope for this role')
+    
+    
+    def _is_witness_input(self, an_input):
+        raise RuntimeError('Function out of scope for this role')
+    
+    
+    def get_output_redeem_script(self, output_index):
+        raise RuntimeError('Function out of scope for this role')
+        
+        
+    def get_output_witness_script(self, output_index):
+        raise RuntimeError('Function out of scope for this role')
+
+
+class Updater(PSBT_Role):
+    '''The Updater must only accept a PSBT. The Updater adds information to the PSBT that it has access to.'''
+    
+    def __init__(self, serialized_psbt):
+        super().__init__(serialized_psbt)
+        # Specify current role as string for default file name in make_file()
+        self.role = 'Updater'
+           
+           
+    def add_nonwitness_utxo(self, input_index, utxo):
+        '''Add a non-witness UTXO to it's corresponding input
+        
+        input_index - (int) index of the input being updated
+        utxo - raw bytes of utxo being added
+        '''
+        self.psbt.maps['inputs'][input_index][PSBT_IN_NON_WITNESS_UTXO] = utxo
+    
+    
+    def add_witness_utxo(self, input_index, utxo, utxo_index):
+        '''Add a non-witness UTXO to it's corresponding input
+        
+        input_index - (int) index of the input being updated
+        utxo - raw bytes of utxo being added
+        '''
+        tx_obj = Tx.parse(BytesIO(utxo))
+        value = tx_obj.tx_outs[utxo_index].serialize()
+        self.psbt.maps['inputs'][input_index][PSBT_IN_WITNESS_UTXO] = value
+        
+    def add_witness_utxo_from_txout(self, input_index, amount, scriptPubKey):
+        value = TxOut(amount, scriptPubKey).serialize()
+        self.psbt.maps['inputs'][input_index][PSBT_IN_WITNESS_UTXO] = value
+
+    def add_sighash_type(self, input_index, sighash):
+        '''Adds a sighash type to an input
+        
+        Signatures for this input must use the sighash type
+        
+        input_index - (int) index of the input being updated
+        sighash - int of the sighash type
+        '''
+        # Converts into to 32-bit unsigned LE integer of the sighash type
+        self.psbt.maps['inputs'][input_index][PSBT_IN_SIGHASH_TYPE] = \
+        int_to_little_endian(n=sighash, length=4)
+    
+    
+    def add_input_redeem_script(self, input_index, script):
+        '''Adds a redeem script to an input
+        
+        input_index - (int) index of the input being updated
+        script 0 raw bytes of witness script being added
+        '''
+        self.psbt.maps['inputs'][input_index][PSBT_IN_REDEEM_SCRIPT] = script
+
+        
+    def add_input_witness_script(self, input_index, script):
+        '''Adds a witness script to an input
+        
+        input_index - (int) index of the input being updated
+        script 0 raw bytes of witness script being added
+        '''
+        self.psbt.maps['inputs'][input_index][PSBT_IN_WITNESS_SCRIPT] = script  
+        
+        
+    def add_input_pubkey(self, input_index, pubkey, masterkey_fingerprint, bip32_path):
+        '''Adds a public key and the master key fingerprint + bip32 path it maps to 
+        an input. 
+        
+        The bip32 derivation path is represented as 32-bit unsigned integer indexes 
+        concatenated with each other.
+        
+        input_index - (int) index of the input being updated
+        All other arguments should be raw bytes'''
+        self.psbt.maps['inputs'][input_index][PSBT_IN_BIP32_DERIVATION+pubkey] = masterkey_fingerprint + bip32_path  
+    
+    
+    def add_output_redeem_script(self, output_index, script):
+        '''Adds a redeem script to an output
+        
+        output_index - (int) index of the output being updated
+        script 0 raw bytes of witness script being added
+        '''
+        self.psbt.maps['outputs'][output_index][PSBT_OUT_REDEEM_SCRIPT] = script
+
+        
+    def add_output_witness_script(self, output_index, script):
+        '''Adds a witness script to an output
+        
+        output_index - (int) index of the output being updated
+        script = raw bytes of witness script being added
+        '''
+        self.psbt.maps['outputs'][output_index][PSBT_OUT_WITNESS_SCRIPT] = script  
+        
+        
+    def add_output_pubkey(self, output_index, pubkey, masterkey_fingerprint, bip32_path):
+        '''Adds a public key and the master key fingerprint + bip32 path it maps to to 
+        an output. 
+        
+        The bip32 derivation path is represented as 32-bit unsigned integer indexes 
+        concatenated with each other.
+        
+        input_index - (int) index of the output being updated
+        All other arguments should be raw bytes'''
+        self.psbt.maps['outputs'][output_index][PSBT_OUT_BIP32_DERIVATION+pubkey] \
+        = masterkey_fingerprint + bip32_path   
+    
+
+class Signer(PSBT_Role):
+    '''The Signer must only accept a PSBT. The Signer must only use the UTXOs provided in 
+    the PSBT to produce signatures for inputs. '''
+    def __init__(self, serialized_psbt):
+        # Specify current role as string for default file name in make_file()
+        self.role = 'Signer'
+        self.psbt=psbt.parse(BytesIO(serialized_psbt))
+        # Iterate through all of the inputs for this PSBT and check to make sure a 
+        # UTXO has been filled in
+        for i in range(len(self.psbt.maps['inputs'])):
+            if self.get_utxo(i) is None:
+                raise ValueError('Not all the UTXOs have been filled in for this PSBTs inputs')
+            
+            
+    def get_path(self, pubkey):
+        '''Returns the masterkey fingerprint concatenated with the bip32 path of the 
+        provided public key (in bytes)'''
+        return self.psbt.maps['inputs'][PSBT_IN_BIP32_DERIVATION+pubkey]
+    
+    
+    def get_sighash_type(self, input_index):
+        '''Returns the int of the sighash type for the input at input_index'''
+        found = self.psbt.maps['inputs'][input_index].get(PSBT_IN_SIGHASH_TYPE)
+        if found is None:
+            raise RuntimeWarning('No sighash key for input at index {}'.format(input_index))
+            return None
+        else:
+            return little_endian_to_int(found)
+        
+        
+    def check_sighash(self, input_index, sighash):
+        '''Takes the bytes representation of a sighash type and checks if it matches the
+        sighash for the input at int input_index
+        '''
+        return sighash == self.get_sighash_type(input_index)
+    
+    
+    def add_partial_signature(self, new_sig, compressed_sec, input_index=None):
+        '''Adds signature to input of PSBT. Signature and public key should be of type bytes
+        
+        If the public key has been added to an input in the PSBT, the input index will be found
+        '''
+        # TODO: Add more ways to find an input that matches the provided public key
+        # If an input index is not specified in arguments, find it based on matching public key
+        if input_index == None:
+            input_index = self._get_input_index(compressed_sec)
+        # Note that the below assumes that the sighash type is only the last byte of sig. 
+        # This may be problematic
+        # Note: Assumes inputs in psbt and indexed the same as in unsigned tx
+        # TODO: Check on this
+        this_sighash = little_endian_to_int(new_sig[-1:])
+        if input_index is not None:
+            # Check to make sure signature's sighash type correctly matches the type specified 
+            # for this input
+            if not self.check_sighash(input_index=input_index, sighash=this_sighash):
+                raise ValueError('Sighash type {} on this signature does not match specified \
+                sighash type {} for this input'.format(little_endian_to_int(this_sighash), 
+                                                       self.get_sighash_type(input_index)))     
+            curr_input = self.psbt.maps['inputs'][input_index]
+            # Verify that if UTXO for witness or non-witness is present, it matches TXID of global unsigned tx
+            if PSBT_IN_NON_WITNESS_UTXO in curr_input:
+                global_txid = Tx.parse(BytesIO(self.psbt.maps['global'][PSBT_GLOBAL_UNSIGNED_TX])).tx_ins[input_index].prev_tx 
+                utxo_txid = double_sha256(curr_input[PSBT_IN_NON_WITNESS_UTXO])[::-1]
+                # Verify that txids match
+                if utxo_txid != global_txid:
+                    raise RuntimeError('UTXO of this input does not match with that in global unsigned tx') 
+            # If witness UTXO, verify that hashes match there
+            elif PSBT_IN_WITNESS_UTXO in curr_input:
+                # TODO: Do more testing for native segwit utxos
+                # Get the hash of witness program in scriptPubKey of the witness UTXO
+                scriptPubKey = Script.parse(curr_input[PSBT_IN_WITNESS_UTXO][9:]) 
+                # Determine script type of scriptPubKey
+                if scriptPubKey.type() == 'p2wpkh':
+                    # If scriptPubKey is p2wpkh, keyhash is last element
+                    keyhash = scriptPubKey.elements[-1]
+                    # Check to make sure hash160 of compressed pubkey of signature matches that in UTXO scriptPubKey
+                    if hash160(compressed_sec) != keyhash:
+                        raise RuntimeError('Hash of compressed pubkey in partial signature does not match \
+                        that of hash in witness UTXOs scriptPubKey')     
+                elif scriptPubKey.type() == 'p2wsh':
+                    # If scriptPubKey is p2wsh, scripthash is last element
+                    scripthash = scriptPubKey.elements[-1]
+                    # Check to make sure single SHA256 of witnessScript (if provided) matches that in UTXO scriptPubKey
+                    if PSBT_IN_WITNESS_SCRIPT in curr_input:
+                        if sha256(curr_input[PSBT_IN_WITNESS_SCRIPT]).digest != scripthash:
+                                raise RuntimeError('Hash of witnessScript does not match that of hash in witness UTXOs \
+                                scriptPubKey')            
+                # Otherwise check if P2SH (including P2SH wrapped segwit)   
+                elif scriptPubKey.type() == 'p2sh':
+                    # If scriptPubKey is p2sh, scripthash is 2nd to last element
+                    scripthash = scriptPubKey.elements[-2]
+                    # If redeemScript is present for this input, its hash160 should match scripthash in scriptPubKey
+                    if PSBT_IN_REDEEM_SCRIPT in curr_input:
+                        if hash160(curr_input[PSBT_IN_REDEEM_SCRIPT]) != scripthash:
+                            raise RuntimeError('Hash of redeemScript does not match that of hash in witness UTXOs \
+                            scriptPubKey')
+                        # If witness script is also present, verify the hash of this input's witnessScript matches the hash
+                        # inside the redeemScript
+                        if PSBT_IN_WITNESS_SCRIPT in curr_input:
+                            # Parse redeemScript to get hash of witnessScript inside it
+                            redeemScript = Script.parse(curr_input[PSBT_IN_REDEEM_SCRIPT])
+                            # The last item in a P2SH-segwit redeemScript is the hash of the witness program
+                            redeem_wit_hash = redeemScript.elements[-1]
+                            if redeemScript.type() == 'p2wsh':
+                                if sha256(curr_input[PSBT_IN_WITNESS_SCRIPT]).digest() != redeem_wit_hash:
+                                    raise RuntimeError('Hash of witnessScript does not match that of hash in redeemScript')                
+            # If this point has been reached without any errors, add partial signature
+            self.psbt.maps['inputs'][input_index][PSBT_IN_PARTIAL_SIG+compressed_sec] = new_sig      
+        # If input_index is still None, partial signature cannot be added
+        else:
+            raise RuntimeError('If the public key for this signature has not been added to the PSBT \
+            and an input_index has not been provided then partial signature cannot be added')
+        return
+        
+    
+class Combiner(PSBT_Role):
+    '''Takes any number of serialized PSBTs and combines them. All additional PSBTs 
+    will be checked against the initializing (first) PSBT's 0x00 global unsigned transaction 
+    key-value'''
+    
+    def __init__(self, *args):
+        # Specify current role as string for default file name in make_file()
+        self.role = 'Combiner'
+        # Initialize the new PSBT using the first one passed as an argument as the base
+        self.psbt=psbt.parse(BytesIO(args[0]))
+        # Count number of inputs in the base PSBT. All future PSBTs will be checked 
+        # to make sure the count matches
+        self.base_num_inputs = len(self.psbt.maps['inputs'])
+        # Same for outputs
+        self.base_num_outputs = len(self.psbt.maps['outputs'])
+        # Run combine function on the rest of the PSBTs passed as arguments
+        [self.combine_serialized(a) for a in args]
+    
+    
+    def matching_psbt(self, check_psbt):
+        return self.psbt.maps['global'][PSBT_GLOBAL_UNSIGNED_TX] == \
+        check_psbt.maps['global'][PSBT_GLOBAL_UNSIGNED_TX]
+
+                  
+    def combine_serialized(self, *args):
+        '''Takes one or more PSBTs in bytes and combines them into one PSBT which contains 
+        all of the key-value pairs from each of the PSBTs and removes any duplicate key-value pairs.'''
+        for p in args:
+            curr = psbt.parse(BytesIO(p))
+            # First check to make sure all PSBTs being passed are the same PSBT, 
+            # identified by the global transaction value
+            if self.matching_psbt(curr) is True:    
+                # Combine the global keys 
+                self.psbt.maps['global'].update(curr.maps['global'])
+                # Go through each input for this PSBT and combine it with its matching input 
+                # in the base PSBT
+                # Note this assumes that every PSBT has inputs indexed in the same order they 
+                # appear in the unsigned tx
+                # TODO: Review and revise this process if necessary
+                curr_num_inputs = len(curr.maps['inputs'])
+                # Check to make sure the number of inputs on the current PSBT matches up with 
+                # the base PSBT
+                if curr_num_inputs != self.base_num_inputs:
+                    raise ValueError('Number of input maps in the following PSBT does not match that of base: \
+                    {}'.format(curr.get_as_b64))
+                for i in range(curr_num_inputs):
+                    self.psbt.maps['inputs'][i].update(curr.maps['inputs'][i]) 
+                # Go through each output for this current PSBT and combine it with its matching 
+                # output in the base PSBT
+                curr_num_outputs = len(curr.maps['outputs'])
+                # Check to make sure the number of inputs on the current PSBT matches up with 
+                # the base PSBT
+                if curr_num_outputs != self.base_num_outputs:
+                    raise ValueError('Number of output maps in the following PSBT does not match that \
+                    of base: {}'.format(curr.get_as_b64))
+                for o in range(len(curr.maps['outputs'])):
+                    self.psbt.maps['outputs'][o].update(curr.maps['outputs'][o])        
+            else:
+                # If the current PSBT being passed does not match global tx of base PSBT, skip it 
+                # and raise warning
+                raise RuntimeWarning('A PSBT being combined does not have matching a unsigned \
+                transaction value and was not added')
+        # Return that combination was successful
+        return True
+        
+        
+        
+class Input_Finalizer(PSBT_Role):
+    '''Input_Finalizer accepts a single PSBT, validates and finalizes the inputs'''
+    
+    def __init__(self, serialized_psbt):
+        # Specify current role as string for default file name in make_file()
+        self.role = 'Input_Finalizer'
+        self.psbt=psbt.parse(BytesIO(serialized_psbt))
+        # For each input, check to see if it has enough data to pass validation
+        # If it does, construct the scriptSig and scriptWitness and place them in map
+        # All other data except the UTXO and unknown fields in the input key-value map
+        # should be cleared
+        # Iterate through each input
+        for i in self.psbt.maps['inputs']:
+            # Step 1: check to make sure at least 1 signature is present
+            if not self._check_for_sig(i):
+                continue
+            # Step 2: check to make sure a sighash type is specified
+            if PSBT_IN_SIGHASH_TYPE not in i.keys():
+                continue
+            # Step 3: check if witness or non-witness utxo
+            if self._is_witness_input(i):
+                # Currently assumes a multisig witness input,
+                # or a p2sh-p2wpkh input. TODO: handle all cases
+                if PSBT_IN_REDEEM_SCRIPT in i.keys() and PSBT_IN_WITNESS_SCRIPT not in i.keys():
+                    i[PSBT_IN_FINAL_SCRIPTSIG] = encode_varint(len(i[PSBT_IN_REDEEM_SCRIPT])) + i[PSBT_IN_REDEEM_SCRIPT]
+                    # insert the added signature; since we are assuming p2sh-p2wpkh, there
+                    # must be only 1.
+                    found = 0
+                    for k in i.keys():
+                        if k[:1] == PSBT_IN_PARTIAL_SIG:
+                            found += 1
+                            pub = k[1:]
+                            sig = i[k]
+                    if found != 1:
+                        print("FAILED to find 1 signature in input, cannot be finalized.")
+                        continue
+                    i[PSBT_IN_FINAL_SCRIPTWITNESS] = Script([sig, pub]).serialize()
+                    continue
+                # Step 3a: If witness, check to make sure witnessScript is present
+                if PSBT_IN_WITNESS_SCRIPT not in i.keys():
+                    continue
+                # Step 3b: Then create scriptWitness
+                new_scriptWitness = self._make_multisig_script(inp=i, witness=True)
+                # Complete scriptWitness by adding the number of witness items to the beginning 
+                new_scriptWitness.insert(0, len(new_scriptWitness))
+                # Add key-type PSBT_IN_FINAL_SCRIPTWITNESS to PSBT with the finalized scriptWitness as its value     
+                i[PSBT_IN_FINAL_SCRIPTWITNESS] = Script(new_scriptWitness).serialize()
+                # Add key-type PSBT_IN_FINAL_SCRIPTSIG to PSBT with the finalized scriptSig as its value
+                # For witness inputs, this is the redeemScript preceded by its length
+                i[PSBT_IN_FINAL_SCRIPTSIG] = encode_varint(len(i[PSBT_IN_REDEEM_SCRIPT])) + i[PSBT_IN_REDEEM_SCRIPT]
+            # Step 4: If not witness, check for a lone redeemScript
+            elif PSBT_IN_REDEEM_SCRIPT in i.keys():
+                # Step 4a: since redeem script is present, create the scriptSig for this input
+                # Add key-type PSBT_IN_FINAL_SCRIPTSIG to PSBT with the finalized scriptSig as its value       
+                i[PSBT_IN_FINAL_SCRIPTSIG] = Script(self._make_multisig_script(i)).serialize()
+            # Final case is this input is P2PKH, so create its scriptSig
+            # TODO: Test case for this
+            else: 
+                found_sec = False
+                for k in i.keys():
+                    if k[:1] == PSBT_IN_PARTIAL_SIG:
+                        if found_sec:
+                            # More than one partial sig should not be found without a redeemScript or
+                            # witnessScript. Must be missing a script
+                            continue
+                            sec = k[1:]
+                            sig = i[k]
+                            found_sec = True
+                # Take the SEC and sig and construct the scriptSig
+                # Add key-type PSBT_IN_FINAL_SCRIPTSIG to PSBT with the finalized scriptSig as its value 
+                i[PSBT_IN_FINAL_SCRIPTSIG] = Script([sig, sec]).serialize()
+            # If this point is reached, all neccessary data must be present
+            # Clear all data except UTXO and unknown fields
+            self._clear_keyvalues(i)
+    
+    
+    def _clear_keyvalues(self, inp):
+        '''Clears all of an input's key-value fields besides the UTXO, finalized scriptSig, 
+        scriptWitness and any unknown fields'''
+        to_delete = []
+        for k in inp.keys():
+            if k[:1] in [PSBT_IN_PARTIAL_SIG, PSBT_IN_SIGHASH_TYPE, PSBT_IN_REDEEM_SCRIPT, 
+                         PSBT_IN_WITNESS_SCRIPT, PSBT_IN_BIP32_DERIVATION]:
+                to_delete.append(k)
+        for k in to_delete:
+            del inp[k]
+        return 
+                
+                
+    def _make_multisig_script(self, inp, witness=False):
+        '''Takes a PSBT input and constructs a finalized scriptSig or scriptWitness for that input'''
+        new_script = []
+        # Start with OP_0
+        new_script.append(0)
+        # Create redeemScript object and get number of sigs required for the redeemScript
+        if witness:
+            redeemScript = Script.parse(inp[PSBT_IN_WITNESS_SCRIPT])
+        else:
+            redeemScript = Script.parse(inp[PSBT_IN_REDEEM_SCRIPT])
+        # Make sure this is a multisig redeemScript by checking for OP_CODE 174, OP_CHECKMULTISIG
+        if redeemScript.elements[-1] != 174 :
+            raise ValueError('Present redeemScript is not multisig and not understood')
+        # Assumes this is multisig redeemScript which has m and n # of sigs in usual position
+        sigs_required = int(OP_CODES[redeemScript.elements[0]][3:])
+        total_sigs = int(OP_CODES[redeemScript.elements[-2]][3:])
+        found_sigs = 0
+        # Iterate through redeemScript. Go through its public keys and check if there is a
+        # partial sig present matching that public key.
+        for pk_i in range(total_sigs):
+            if found_sigs >= sigs_required :
+                # If the required number of sigs have been found, stop searching
+                break
+            # Look for partial signature matching a redeemScript public key in our
+            # current input's partial signatures
+            try_key = PSBT_IN_PARTIAL_SIG + redeemScript.sec_pubkey(pk_i)
+            if try_key in inp:
+                # If key is found, add its signature to scriptSig and increment counter
+                new_script.append(inp[try_key])
+                found_sigs += 1
+        # Check if a sufficient number of signatures are present to satisfy redeemScript
+        if found_sigs < sigs_required:
+            raise ValueError("Insufficient sigs present to satisfy this PSBT input's redeemScript")
+        # Complete the scriptSig by adding the redeemScript to the end
+        new_script.append(redeemScript.serialize())
+        return new_script
+    
+    
+    def _check_for_sig(self, an_input):
+        '''Iterate through an input's key-value pairs and determine if it has a parial sig present'''
+        for k in an_input.keys():
+                if k[:1] == PSBT_IN_PARTIAL_SIG: 
+                    return True
+        return False
+    
+                 
+class Transaction_Extractor(PSBT_Role):
+    '''Transaction Extractor accepts a single PSBT and determines if the necessary finalized
+    scriptSig and scriptWitness are present and constructors a network serialized transaction'''
+    
+    def __init__(self, serialized_psbt):
+        # Specify current role as string for default file name in make_file()
+        self.role = 'Transaction_Extractor'
+        self.psbt=psbt.parse(BytesIO(serialized_psbt))
+        # Take the finalized scriptSig and scriptWitness data and complete the unsigned tx
+        self.tx_obj = Tx.parse(BytesIO(self.psbt.maps['global'][PSBT_GLOBAL_UNSIGNED_TX]))
+        # Iterate through psbt input key-value fields and input their finalized data into 
+        # the transaction. Note this assumes PSBT inputs are ordered the same as they are
+        # in the unsigned TX
+        # TODO: Reconsider that assumption
+        for i in range(len(self.psbt.maps['inputs'])):
+            curr_input = self.psbt.maps['inputs'][i]
+            if self._is_witness_input(curr_input):
+                try:
+                    # Insert final scriptWitness as witness program for this input
+                    self.tx_obj.tx_ins[i].witness_program = curr_input[PSBT_IN_FINAL_SCRIPTWITNESS]
+                except KeyError:
+                    print("No scriptWitness was present, this is correct for *p2wpkh inputs")
+                # If a final scriptSig is present, must be P2SH-wrapped segwit so scriptSig is required
+                if PSBT_IN_FINAL_SCRIPTSIG in curr_input:
+                    self.tx_obj.tx_ins[i].script_sig = Script.parse(curr_input[PSBT_IN_FINAL_SCRIPTSIG])
+                    self.tx_obj.tx_ins[i].witness_program = curr_input[PSBT_IN_FINAL_SCRIPTWITNESS]
+            # Else, this is a non-witness input
+            else:
+                try:
+                    # Insert final scriptSig into input
+                    self.tx_obj.tx_ins[i].script_sig = Script.parse(curr_input[PSBT_IN_FINAL_SCRIPTSIG])
+                except KeyError:
+                    # If not a witness input, final scriptSig should be present
+                    raise ValueError('PSBT input is missing finalized scriptSig')  
+            # TODO: Verify each input                        
+        
+        
+    def serialized(self):
+        return self.tx_obj.serialize()
+    
+
+    def input_index_in_ustx(self, inp):
+        '''Take a PSBT input and determine its index in the unsigned tx'''
+        raise NotImplementedError
+        
+    

--- a/jmbitcoin/jmbitcoin/secp256k1_ecdh.py
+++ b/jmbitcoin/jmbitcoin/secp256k1_ecdh.py
@@ -1,0 +1,18 @@
+#!/usr/bin/python
+from __future__ import (absolute_import, division,
+                        print_function, unicode_literals)
+from builtins import * # noqa: F401
+import coincurve as secp256k1
+
+def ecdh(privkey, pubkey):
+    """ Take a privkey in raw byte serialization,
+    and a pubkey serialized in compressed, binary format (33 bytes),
+    and output the shared secret as a 32 byte hash digest output.
+    The exact calculation is:
+    shared_secret = SHA256(privkey * pubkey)
+    .. where * is elliptic curve scalar multiplication.
+    See https://github.com/bitcoin/bitcoin/blob/master/src/secp256k1/src/modules/ecdh/main_impl.h
+    for implementation details.
+    """
+    secp_privkey = secp256k1.PrivateKey(privkey)
+    return secp_privkey.ecdh(pubkey)

--- a/jmbitcoin/jmbitcoin/secp256k1_ecies.py
+++ b/jmbitcoin/jmbitcoin/secp256k1_ecies.py
@@ -1,0 +1,91 @@
+#!/usr/bin/python
+from __future__ import (absolute_import, division,
+                        print_function, unicode_literals)
+from builtins import * # noqa: F401
+from future.utils import native
+import coincurve as secp256k1
+import base64
+import hmac
+import hashlib
+import pyaes
+import os
+import jmbitcoin as btc
+
+ECIES_MAGIC_BYTES = b'BIE1'
+
+class ECIESDecryptionError(Exception):
+    pass
+
+# AES primitives. See BIP-SNICKER for specification.
+def aes_encrypt(key, data, iv):
+    encrypter = pyaes.Encrypter(
+        pyaes.AESModeOfOperationCBC(key, iv=native(iv)))
+    enc_data = encrypter.feed(data)
+    enc_data += encrypter.feed()
+
+    return enc_data
+
+def aes_decrypt(key, data, iv):
+        decrypter = pyaes.Decrypter(
+            pyaes.AESModeOfOperationCBC(key, iv=native(iv)))
+        try:
+            dec_data = decrypter.feed(data)
+            dec_data += decrypter.feed()
+        except ValueError:
+            # note decryption errors can come from PKCS7 padding errors
+            raise ECIESDecryptionError()
+        return dec_data
+
+def ecies_encrypt(message, pubkey):
+    """ Take a privkey in raw byte serialization,
+    and a pubkey serialized in compressed, binary format (33 bytes),
+    and output the shared secret as a 32 byte hash digest output.
+    The exact calculation is:
+    shared_secret = SHA256(privkey * pubkey)
+    .. where * is elliptic curve scalar multiplication.
+    See https://github.com/bitcoin/bitcoin/blob/master/src/secp256k1/src/modules/ecdh/main_impl.h
+    for implementation details.
+    """
+    # create an ephemeral pubkey for this encryption:
+    while True:
+        r = os.urandom(32)
+        # use compressed serialization of the pubkey R:
+        try:
+            R = btc.privkey_to_pubkey(r + b'\x01', False)
+            break
+        except:
+            # accounts for improbable overflow:
+            continue
+    # note that this is *not* ECDH as in the secp256k1_ecdh module,
+    # since it uses sha512:
+    ecdh_key = btc.multiply(r, pubkey, False)
+    key = hashlib.sha512(ecdh_key).digest()
+    iv, key_e, key_m = key[0:16], key[16:32], key[32:]
+    ciphertext = aes_encrypt(key_e, message, iv=iv)
+    encrypted = ECIES_MAGIC_BYTES + R + ciphertext
+    mac = hmac.new(key_m, encrypted, hashlib.sha256).digest()
+    return base64.b64encode(encrypted + mac)    
+    
+def ecies_decrypt(privkey, encrypted):
+    if len(privkey) == 33 and privkey[-1] == 1:
+        privkey = privkey[:32]
+    encrypted = base64.b64decode(encrypted)
+    if len(encrypted) < 85:
+        raise Exception('invalid ciphertext: length')
+    magic = encrypted[:4]
+    if magic != ECIES_MAGIC_BYTES:
+        raise ECIESDecryptionError()
+    ephemeral_pubkey = encrypted[4:37]
+    try:
+        testR = secp256k1.PublicKey(ephemeral_pubkey)
+    except:
+        raise ECIESDecryptionError()
+    ciphertext = encrypted[37:-32]
+    mac = encrypted[-32:]
+    ecdh_key = btc.multiply(privkey, ephemeral_pubkey, False)
+    key = hashlib.sha512(ecdh_key).digest()
+    iv, key_e, key_m = key[0:16], key[16:32], key[32:]
+    if mac != hmac.new(key_m, encrypted[:-32], hashlib.sha256).digest():
+        raise ECIESDecryptionError()
+    return aes_decrypt(key_e, ciphertext, iv=iv)    
+

--- a/jmbitcoin/jmbitcoin/snicker.py
+++ b/jmbitcoin/jmbitcoin/snicker.py
@@ -1,0 +1,287 @@
+from __future__ import (absolute_import, division,
+                        print_function, unicode_literals)
+from builtins import * # noqa: F401
+
+# Implementation of proposal as per
+# https://gist.github.com/AdamISZ/2c13fb5819bd469ca318156e2cf25d79
+# (BIP SNICKER)
+
+from jmbitcoin.secp256k1_ecdh import *
+from jmbitcoin.secp256k1_ecies import *
+from jmbitcoin.secp256k1_main import *
+from jmbitcoin.secp256k1_transaction import *
+from jmbitcoin.jm_psbt import *
+from .pythonpsbt import PSBT_IN_PARTIAL_SIG
+
+SNICKER_MAGIC_BYTES = b'SNICKER'
+
+# Flags may be added in future versions
+SNICKER_FLAG_NONE = 0
+
+def snicker_pubkey_tweak(pub, tweak):
+    """ use secp256k1 library to perform tweak.
+    Both `pub` and `tweak` are expected as byte strings
+    (33 and 32 bytes respectively).
+    Return value is also a 33 byte string serialization
+    of the resulting pubkey (compressed).
+    """
+    base_pub = secp256k1.PublicKey(pub)
+    return base_pub.add(tweak).format()
+
+def snicker_privkey_tweak(priv, tweak):
+    """ use secp256k1 library to perform tweak.
+    Both `priv` and `tweak` are expected as byte strings
+    (32 or 33 and 32 bytes respectively).
+    Return value isa 33 byte string serialization
+    of the resulting private key/secret (with compression flag).
+    """
+    if len(priv) == 33 and priv[-1] == 1:
+        priv = priv[:-1]
+    base_priv = secp256k1.PrivateKey(priv)
+    return base_priv.add(tweak).secret + b'\x01'
+
+def verify_output(tx, pub, tweak, spk_type='p2sh-p2wpkh'):
+    """ A convenience function to check that one output address in a transaction
+    is a SNICKER-type tweak of an existing key. Returns the index of the output
+    for which this is True (and there must be only 1), and the derived spk,
+    or -1 and None if it is not found exactly once.
+    TODO Add support for other scriptPubKey types.
+    """
+    expected_destination_pub = snicker_pubkey_tweak(pub, tweak)
+    expected_destination_spk = pubkey_to_p2sh_p2wpkh_script(expected_destination_pub)
+    found = 0
+    for i, o in enumerate(tx['outs']):
+        if o['script'] == expected_destination_spk:
+            found += 1
+            found_index = i
+    if found != 1:
+        return -1, None
+    return found_index, expected_destination_spk
+
+def create_proposal(our_input, their_input, our_input_utxo, their_input_utxo,
+                    net_transfer, network_fee, our_priv, their_pub,
+                    our_spk, change_spk, encrypted=True, version_byte=1):
+    """ Creates a SNICKER proposal from the given transaction data.
+    This only applies to existing specification, i.e. SNICKER v 00 or 01.
+    This is only to be used for Joinmarket as currently restricted to p2sh-p2wpkh.
+    `our_input`, `their_input` - in format of deserialized inputs in jmbitcoin
+    `our_input_utxo`, `their..` - in format (amount, scriptPubkey)
+    net_transfer - amount, after bitcoin transaction fee, transferred from
+    Proposer (our) to Receiver (their). May be negative.
+    network_fee - total bitcoin network transaction fee to be paid (so estimates
+    must occur before this function).
+    `our_priv`, `their_pub` - these are the keys to be used in ECDH to derive
+    the tweak as per the BIP. Note `their_pub` may or may not be associated with
+    the input of the receiver, so is specified here separately. Note also that
+    according to the BIP the privkey we use *must* be the one corresponding to
+    the input we provided, else (properly coded) Receivers will reject our
+    proposal.
+    `our_spk` - a scriptPubKey for the Proposer coinjoin output
+    `change_spk` - a change scriptPubkey for the proposer as per BIP
+    `encrypted` - whether or not to return the ECIES encrypted version of the
+    proposal.
+    `version_byte` - which of currently specified Snicker versions is being
+    used, (0 for reused address, 1 for inferred key).
+    """
+    # before constructing the bitcoin transaction we must calculate the output
+    # amounts
+    # TODO investigate arithmetic for negative transfer
+    if our_input_utxo[0] - their_input_utxo[0] - network_fee <= 0:
+        raise Exception(
+            "Cannot create SNICKER proposal, Proposer input too small")
+    total_input_amount = our_input_utxo[0] + their_input_utxo[0]
+    total_output_amount = total_input_amount - network_fee
+    receiver_output_amount = their_input_utxo[0] + net_transfer
+    proposer_output_amount = total_output_amount - receiver_output_amount
+
+    # we must also use ecdh to calculate the output scriptpubkey for the
+    # receiver
+    # TODO: add check here that `our_priv` corresponds to scriptPubKey in
+    # `our_input_utxo` to prevent callers from making useless proposals.
+    tweak_bytes = ecdh(our_priv[:-1], their_pub)
+    tweaked_pub = snicker_pubkey_tweak(their_pub, tweak_bytes)
+    # TODO: remove restriction to one scriptpubkey type
+    tweaked_spk = pubkey_to_p2sh_p2wpkh_script(tweaked_pub)
+
+    # now we must construct the three outputs with correct output amounts.
+    outputs = [{"script": tweaked_spk, "value": receiver_output_amount}]
+    outputs.append({"script": our_spk, "value": receiver_output_amount})
+    outputs.append({"script": change_spk,
+                    "value": total_output_amount - 2 * receiver_output_amount})
+    assert all([x["value"] > 0 for x in outputs])
+
+    # version and locktime as currently specified in the BIP
+    # for 0/1 version SNICKER.
+    tx = mktx([our_input, their_input], outputs, version=2, locktime=0)
+
+    # Apply lexicographic ordering BIP 69:
+    desertx = btc.deserialize(tx)
+    bip69tx = bip69_sort(desertx)
+
+    # input utxo data must be attached to the right input, according to
+    # BIP69 ordering. Since v0/1 only use 2 inputs, this is fairly simple:
+    if bip69tx["ins"] == desertx["ins"]:
+        utxoargs = (our_input_utxo, their_input_utxo)
+        signing_index = 0
+    else:
+        utxoargs = (their_input_utxo, our_input_utxo)
+        signing_index = 1
+    updater, nserialized = create_psbt(bip69tx, utxoargs)
+
+    # having created the PSBT, sign our input
+    updater.add_input_redeem_script(signing_index, pubkey_to_p2wpkh_script(
+        privkey_to_pubkey(our_priv, False)))
+    updater.add_sighash_type(signing_index, 1)
+
+    signer = Signer(updater.psbt.serialize())
+    signed_serialized = sign(nserialized, signing_index, our_priv,
+                             amount=our_input_utxo[0])
+    signed_deserialized = deserialize(signed_serialized)
+    sig, pub = [binascii.unhexlify(x) for x in signed_deserialized['ins']
+                [signing_index]['txinwitness']]
+    partially_signed_psbt = sign_psbt(signer.psbt.serialize(),
+                                      signing_index, sig, pub)
+
+    snicker_serialized_message = SNICKER_MAGIC_BYTES + bytes([version_byte]) + \
+        b'\x00' + tweak_bytes + partially_signed_psbt
+
+    if not encrypted:
+        return snicker_serialized_message
+
+    # encryption has been requested; we apply ECIES in the form given by the BIP.
+    return ecies_encrypt(snicker_serialized_message, their_pub)
+
+def parse_proposal_to_signed_tx(privkey, proposal, acceptance_callback):
+    """ Given a candidate privkey (binary and compressed format),
+    and a candidate encrypted SNICKER proposal, attempt to decrypt
+    and validate it in all aspects. If validation fails the first
+    return value is None and the second is the reason as a string.
+
+    If all validation checks pass, the next step is checking
+    acceptance according to financial rules: the acceptance
+    callback must be a function that accepts four arguments:
+    (our_ins, their_ins, our_outs, their_outs), where each of those
+    arguments are dicts of the format used in jmbitcoin transaction
+    deserialization) and must return only True/False where True
+    means that the transaction should be signed.
+
+    If True is returned from the callback, the following are returned
+    from this function:
+    (raw transaction for signing [deserialized, with other signature
+    attached], tweak value as bytes, unsigned_index,
+    derived output spk belonging to receiver, version, flags), "Valid"
+    Note: flags is currently always None as version is only 0 or 1.
+    """
+
+    our_pub = privkey_to_pubkey(privkey, usehex=False)
+
+    if len(proposal) < 5:
+        return None, "Invalid proposal, too short."
+
+    if base64.b64decode(proposal)[:4] == ECIES_MAGIC_BYTES:
+        # attempt decryption and reject if fails:
+        try:
+            snicker_message = ecies_decrypt(privkey, proposal)
+        except Exception as e:
+            return None, "Failed to decrypt." + repr(e)
+    else:
+        snicker_message = proposal
+
+    # magic + version,flag + tweak + psbt:
+    # TODO replace '20' with the minimum feasible PSBT.
+    if len(snicker_message) < 7 + 2 + 32 + 20:
+        return None, "Invalid proposal, too short."
+
+    if snicker_message[:7] != SNICKER_MAGIC_BYTES:
+        return None, "Invalid SNICKER magic bytes."
+
+    version_byte = snicker_message[7]
+    flag_byte = snicker_message[8]
+    if version_byte not in [0,1]:
+        return None, "Unrecognized SNICKER version: " + version_byte
+    if flag_byte != 0:
+        return None, "Invalid flag byte for version 0,1: " + flag_byte
+
+    tweak_bytes = snicker_message[9:41]
+    candidate_psbt = snicker_message[41:]
+    # attempt to validate the PSBT's format:
+    try:
+        updater = Updater(candidate_psbt)
+    except:
+        return None, "Invalid PSBT format."
+
+    # validate that it contains one signature,
+    # else the proposal is invalid:
+    # TODO this code should be encapsulated in the PSBT
+    # implementation, but the current one is rudimentary.
+    ins = updater.psbt.maps['inputs']
+    if len(ins) != 2:
+        return None, "Invalid number of transaction inputs, must be 2."
+    sig_found = 0
+    for j, i in enumerate(ins):
+        for k, v in i.items():
+            if k[0] == ord(PSBT_IN_PARTIAL_SIG):
+                # TODO actually validate here?
+                if k[1] not in [2, 3]:
+                    return None, "Invalid public key."
+                if v[0] != 48 or len(v) < 8:
+                    return None, "Invalid ECDSA signature"
+                sig_found += 1
+                their_index = j
+                break
+    if sig_found != 1:
+        return None, "There must be exactly one signed input."
+
+    # TODO Ver 0/1 has only 2 inputs, change for other versions.
+    unsigned_index = 0 if their_index == 1 else 1
+
+    raw_transaction = deserialize(updater.get_unsigned_tx())
+
+    # check that BIP 69 was applied
+    check_raw_tx = bip69_sort(raw_transaction)
+    if not check_raw_tx == raw_transaction:
+        return None, "The proposed transaction is not BIP69 sorted."
+
+    # Validate that we own one SNICKER style output:
+    spk = verify_output(raw_transaction, our_pub, tweak_bytes)
+
+    if spk[0] == -1:
+        return None, "Correct tweaked destination not found exactly once in outputs."
+    our_output_index = spk[0]
+    our_output_amount = raw_transaction['outs'][our_output_index]['value']
+
+    # At least one other output must have an amount equal to that at
+    # `our_output_index`, according to the spec.
+    found = 0
+    for i, o in enumerate(raw_transaction['outs']):
+        if i == our_output_index:
+            continue
+        if o['value'] == our_output_amount:
+            found += 1
+    if found != 1:
+        return None, "Invalid coinjoin, there are not two equal outputs."
+
+    # All validation checks passed. We now check whether the
+    #transaction is acceptable according to the caller:
+    if not acceptance_callback([raw_transaction['ins'][unsigned_index]],
+                               [raw_transaction['ins'][their_index]],
+                               [raw_transaction['outs'][our_output_index]],
+                               [x for i, x in enumerate(raw_transaction['outs']) if i != our_output_index]):
+        return None, "Caller rejected transaction for signing."
+
+    # Acceptance passed, prepare the deserialized tx for signing by us:
+    # TODO This is p2sh-p2wpkh specific
+    # TODO consider how to generalize this *without* requiring jmclient
+    # to do PSBT processing itself.
+    m = updater.psbt.maps['inputs'][their_index]
+    for k,v in m.items():
+        if k[0] == ord(PSBT_IN_PARTIAL_SIG):
+            pub = k[1:]
+            sig = v #check that
+    raw_transaction['ins'][their_index]['script'] = b'\x16' + pubkey_to_p2wpkh_script(pub)
+    raw_transaction['ins'][their_index]['txinwitness'] = [sig, pub]
+
+    # Return the data in detail to
+    # the caller (see docstring):
+    return (raw_transaction, tweak_bytes, unsigned_index,
+            spk[1], version_byte, flag_byte)

--- a/jmbitcoin/test/test_bip32.py
+++ b/jmbitcoin/test/test_bip32.py
@@ -109,7 +109,3 @@ def test_bip32_descend():
     assert end_key=="6856ef965940a1a7b1311dc041050ac0013e326c7ff4e2c677a7694b4f0405c901"
     end_key = btc.bip32_descend(master, 2, 5, 4, 5)
     assert end_key=="d2d816b6485103c0d7ff95482788f0e8e73fa11817079e006d47979d8196c4b101"
-
-    
-
-    

--- a/jmbitcoin/test/test_bip69.py
+++ b/jmbitcoin/test/test_bip69.py
@@ -1,0 +1,53 @@
+from __future__ import (absolute_import, division,
+                        print_function, unicode_literals)
+from builtins import * # noqa: F401
+import pytest
+import jmbitcoin as btc
+import random
+import copy
+
+# TODO Several more vectors should be added here:
+
+@pytest.mark.parametrize(
+    "vector",
+    # 2
+    [
+      ("28204cad1d7fc1d199e8ef4fa22f182de6258a3eaafe1bbe56ebdcacd3069a5f",
+     [("35288d269cee1941eaebb2ea85e32b42cdb2b04284a56d8b14dcc3f5c65d6055", 0),
+      ("35288d269cee1941eaebb2ea85e32b42cdb2b04284a56d8b14dcc3f5c65d6055", 1)],
+     [(100000000, "41046a0765b5865641ce08dd39690aade26dfbf5511430ca428a3089261361cef170e3929a68aee3d8d4848b0c5111b0a37b82b86ad559fd2a745b44d8e8d9dfdc0cac"),
+      (2400000000, "41044a656f065871a353f216ca26cef8dde2f03e8c16202d2e8ad769f02032cb86a5eb5e56842e92e19141d60a01928f8dd2c875a390f67c1f6c94cfc617c0ea45afac")]),
+# 1
+ ("0a6a357e2f7796444e02638749d9611c008b253fb55f5dc88b739b230ed0c4c3",
+[("0e53ec5dfb2cb8a71fec32dc9a634a35b7e24799295ddd5278217822e0b31f57", 0),
+ ("26aa6e6d8b9e49bb0630aac301db6757c02e3619feb4ee0eea81eb1672947024", 1),
+ ("28e0fdd185542f2c6ea19030b0796051e7772b6026dd5ddccd7a2f93b73e6fc2", 0),
+ ("381de9b9ae1a94d9c17f6a08ef9d341a5ce29e2e60c36a52d333ff6203e58d5d", 1),
+ ("3b8b2f8efceb60ba78ca8bba206a137f14cb5ea4035e761ee204302d46b98de2", 0),
+ ("402b2c02411720bf409eff60d05adad684f135838962823f3614cc657dd7bc0a", 1),
+ ("54ffff182965ed0957dba1239c27164ace5a73c9b62a660c74b7b7f15ff61e7a", 1),
+ ("643e5f4e66373a57251fb173151e838ccd27d279aca882997e005016bb53d5aa", 0),
+ ("6c1d56f31b2de4bfc6aaea28396b333102b1f600da9c6d6149e96ca43f1102b1", 1),
+ ("7a1de137cbafb5c70405455c49c5104ca3057a1f1243e6563bb9245c9c88c191", 0),
+ ("7d037ceb2ee0dc03e82f17be7935d238b35d1deabf953a892a4507bfbeeb3ba4", 1),
+ ("a5e899dddb28776ea9ddac0a502316d53a4a3fca607c72f66c470e0412e34086", 0),
+ ("b4112b8f900a7ca0c8b0e7c4dfad35c6be5f6be46b3458974988e1cdb2fa61b8", 0),
+ ("bafd65e3c7f3f9fdfdc1ddb026131b278c3be1af90a4a6ffa78c4658f9ec0c85", 0),
+ ("de0411a1e97484a2804ff1dbde260ac19de841bebad1880c782941aca883b4e9", 1),
+ ("f0a130a84912d03c1d284974f563c5949ac13f8342b8112edff52971599e6a45", 0),
+ ("f320832a9d2e2452af63154bc687493484a0e7745ebd3aaf9ca19eb80834ad60", 0)],
+  [(400057456, "76a9144a5fba237213a062f6f57978f796390bdcf8d01588ac"),
+ (40000000000, "76a9145be32612930b8323add2212a4ec03c1562084f8488ac")])
+])
+def test_bip69_vector(vector):
+    # strategy: create deserialized tx, shuffle ins and outs, apply bip69 and see if it returns to the original
+    txid, vins, vouts = vector
+    ins = [i[0] + ":" + str(i[1]) for i in vins]
+    outs = [{"value": o[0], "script": o[1]} for o in vouts]
+    tx1 = btc.deserialize(btc.mktx(ins, outs))
+    tx2 = copy.deepcopy(tx1)
+    # shuffle the new copy
+    random.shuffle(tx2["ins"])
+    random.shuffle(tx2["outs"])
+    bip69tx = btc.bip69_sort(tx2)
+    assert bip69tx == tx1

--- a/jmbitcoin/test/test_ecdh.py
+++ b/jmbitcoin/test/test_ecdh.py
@@ -1,0 +1,60 @@
+#! /usr/bin/env python
+from __future__ import (absolute_import, division,
+                        print_function, unicode_literals)
+from builtins import * # noqa: F401
+'''Tests coincurve binding to libsecp256k1 ecdh module code'''
+
+import jmbitcoin as btc
+import binascii
+import pytest
+import os
+import json
+testdir = os.path.dirname(os.path.realpath(__file__))
+    
+def test_ecdh():
+    """Using private key test vectors from Bitcoin Core.
+    1. Import a set of private keys from the json file.
+    2. Calculate the corresponding public keys.
+    3. Do ECDH on the cartesian product (x, Y), with x private
+    and Y public keys, for all combinations.
+    4. Compare the result from CoinCurve with the manual
+    multiplication xY following by hash (sha256). Note that
+    sha256(xY) is the default hashing function used for ECDH
+    in libsecp256k1.
+
+    Since there are about 20 private keys in the json file, this
+    creates around 400 test cases (note xX is still valid).
+    """
+    with open(os.path.join(testdir,"base58_keys_valid.json"), "r") as f:
+        json_data = f.read()
+        valid_keys_list = json.loads(json_data)
+        extracted_privkeys = []
+        for a in valid_keys_list:
+            key, hex_key, prop_dict = a
+            if prop_dict["isPrivkey"]:
+                c, k = btc.read_privkey(binascii.unhexlify(hex_key))
+                extracted_privkeys.append(k)
+    extracted_pubkeys = [btc.privkey_to_pubkey(x,
+                                usehex=False) for x in extracted_privkeys]
+    for p in extracted_privkeys:
+        for P in extracted_pubkeys:
+            c, k = btc.read_privkey(p)
+            shared_secret = btc.ecdh(k, P)
+            assert len(shared_secret) == 32
+            # try recreating the shared secret manually:
+            pre_secret = btc.multiply(p, P, False)
+            derived_secret = btc.bin_sha256(pre_secret)
+            assert derived_secret == shared_secret
+
+    # test some important failure cases; null key, overflow case
+    privkeys_invalid = [b'\x00'*32, binascii.unhexlify(
+        'fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141')]
+    for p in privkeys_invalid:
+        with pytest.raises(Exception) as e_info:
+            shared_secret = btc.ecdh(p, extracted_pubkeys[0])
+    pubkeys_invalid = [b'0xff' + extracted_pubkeys[0][1:], b'0x00'*12]
+    for p in extracted_privkeys:
+        with pytest.raises(Exception) as e_info:
+            shared_secret = btc.ecdh(p, pubkeys_invalid[0])
+        with pytest.raises(Exception) as e_info:
+            shared_secret = btc.ecdh(p, pubkeys_invalid[1])

--- a/jmbitcoin/test/test_ecies.py
+++ b/jmbitcoin/test/test_ecies.py
@@ -1,0 +1,43 @@
+#! /usr/bin/env python
+from __future__ import (absolute_import, division,
+                        print_function, unicode_literals)
+from builtins import * # noqa: F401
+'''Tests ECIES implementation as defined in BIP-SNICKER
+(and will be updated if that is).'''
+
+import jmbitcoin as btc
+import binascii
+import base64
+import os
+import json
+testdir = os.path.dirname(os.path.realpath(__file__))
+    
+def test_ecies():
+    """Using private key test vectors from Bitcoin Core.
+    1. Import a set of private keys from the json file.
+    2. Calculate the corresponding public keys.
+    3. Do ECDH on the cartesian product (x, Y), with x private
+    and Y public keys, for all combinations.
+    4. Compare the result from CoinCurve with the manual
+    multiplication xY following by hash (sha256). Note that
+    sha256(xY) is the default hashing function used for ECDH
+    in libsecp256k1.
+
+    Since there are about 20 private keys in the json file, this
+    creates around 400 test cases (note xX is still valid).
+    """
+    with open(os.path.join(testdir,"base58_keys_valid.json"), "r") as f:
+        json_data = f.read()
+        valid_keys_list = json.loads(json_data)
+        extracted_privkeys = []
+        for a in valid_keys_list:
+            key, hex_key, prop_dict = a
+            if prop_dict["isPrivkey"]:
+                c, k = btc.read_privkey(binascii.unhexlify(hex_key))
+                extracted_privkeys.append(k)
+    extracted_pubkeys = [btc.privkey_to_pubkey(x,
+                                usehex=False) for x in extracted_privkeys]
+    for (priv, pub) in zip(extracted_privkeys, extracted_pubkeys):
+        test_message = base64.b64encode(os.urandom(15)*20)
+        assert btc.ecies_decrypt(priv, btc.ecies_encrypt(test_message, pub)) == test_message
+

--- a/jmclient/jmclient/__init__.py
+++ b/jmclient/jmclient/__init__.py
@@ -48,6 +48,7 @@ from .wallet_utils import (
     wallet_display, get_utxos_enabled_disabled)
 from .maker import Maker, P2EPMaker
 from .yieldgenerator import YieldGenerator, YieldGeneratorBasic, ygmain
+from .snicker_receiver import SNICKERError, SNICKERReceiver
 # Set default logging handler to avoid "No handler found" warnings.
 
 try:

--- a/jmclient/jmclient/snicker_receiver.py
+++ b/jmclient/jmclient/snicker_receiver.py
@@ -1,0 +1,233 @@
+#! /usr/bin/env python
+from __future__ import (absolute_import, division,
+                        print_function, unicode_literals)
+from builtins import * # noqa: F401
+
+import sys
+import binascii
+
+import jmbitcoin as btc
+from jmclient.configure import get_p2pk_vbyte, jm_single
+from jmbase.support import get_log
+
+jlog = get_log()
+
+class SNICKERError(Exception):
+    pass
+
+class SNICKERReceiver(object):
+    versions = [0, 1]
+    supported_flags = []
+    import_branch = 0
+    # TODO implement http api or similar
+    # for polling, here just a file:
+    proposals_source = "proposals.txt"
+
+    def __init__(self, wallet, income_threshold=0, acceptance_callback=None):
+        """
+        Class to manage processing of SNICKER proposals and
+        co-signs and broadcasts in case the application level
+        configuration permits.
+
+        `acceptance_callback`, if specified, must have arguments
+        and return type as for the default_acceptance_callback
+        in this class.
+        """
+
+        # This is a Joinmarket wallet object.
+        # TODO support native segwit BIP84, currently
+        # library only supports p2sh-p2wpkh so it must
+        # be the BIP49 type.
+        self.wallet = wallet
+
+        # The simplest filter on accepting SNICKER joins:
+        # that they pay a minimum of this value in satoshis,
+        # which can be negative (to account for fees).
+        # TODO this will be a config variable.
+        self.income_threshold = income_threshold
+
+        # The acceptance callback which defines if we accept
+        # a valid proposal and sign it, or not.
+        if acceptance_callback is None:
+            self.acceptance_callback = self.default_acceptance_callback
+        else:
+            self.acceptance_callback - acceptance_callback
+
+        # A list of currently viable key candidates; these must
+        # all be (pub)keys for which the privkey is accessible,
+        # i.e. they must be in-wallet keys.
+        # This list will be continuously updated by polling the
+        # wallet.
+        self.candidate_keys = []
+
+        # A list of already processed proposals
+        self.processed_proposals = []
+
+    def poll_for_proposals(self):
+        """ Intended to be invoked in a LoopingCall or other
+        event loop.
+        Retrieves any entries in the proposals_source, then
+        compares with existing,
+        and invokes parse_proposal on all new entries.
+        # TODO considerable thought should go into how to store
+        proposals cross-runs, and also handling of keys, which
+        must be optional.
+        """
+        new_proposals = []
+        with open(self.proposals_source, "rb") as f:
+            current_entries = f.readlines()
+        for entry in current_entries:
+            if entry in self.processed_proposals:
+                continue
+            new_proposals.append(entry)
+        if not self.process_proposals(new_proposals):
+            jlog.error("Critical logic error, shutting down.")
+            sys.exit(1)
+        self.processed_proposals.extend(new_proposals)
+
+    def default_acceptance_callback(self, our_ins, their_ins,
+                                    our_outs, their_outs):
+        """ Accepts lists of inputs as per deserialized tx inputs,
+        a single output (belonging to us) as per deserialized tx outputs,
+        and a list of other outputs (belonging not to us) in same
+        format, and must return only True or False representing acceptance.
+
+        Note that this code is relying on the calling function to give
+        accurate information about the outputs.
+        """
+        # we must find the utxo in our wallet to get its amount.
+        # this serves as a sanity check that the input is indeed
+        # ours.
+        # we use get_all* because for these purposes mixdepth
+        # is irrelevant.
+        utxos = self.wallet.get_all_utxos()
+        our_in_amts = []
+        our_out_amts = []
+        for i in our_ins:
+            txid = i["outpoint"]["hash"]
+            idx = i["outpoint"]["index"]
+            if (txid, idx) not in utxos.keys():
+                jlog.debug("The input utxo was not found: " + btc.safe_hexlify(
+                    txid) + ":" + str(idx))
+                return False
+            our_in_amts.append(utxos[(txid, idx)]["value"])
+        for o in our_outs:
+            our_out_amts.append(o["value"])
+        if sum(our_out_amts) - sum(our_in_amts) < self.income_threshold:
+            return False
+        return True
+
+    def process_proposals(self, proposals):
+        """ Each entry in `proposals` is of form:
+        encrypted_proposal - base64 string
+        key - hex encoded compressed pubkey, or ''
+        if the key is not null, we attempt to decrypt and
+        process according to that key, else cycles over all keys.
+    
+        If all SNICKER validations succeed, the decision to spend is
+        entirely dependent on self.acceptance_callback.
+        If the callback returns True, we co-sign and broadcast the
+        transaction and also update the wallet with the new
+        imported key (TODO: future versions will enable searching
+        for these keys using history + HD tree; note the jmbitcoin
+        snicker.py module DOES insist on ECDH being correctly used,
+        so this will always be possible for transactions created here.
+
+        Returned is a list of txids of any transactions which
+        were broadcast, unless a critical error occurs, in which case
+        False is returned (to minimize this function's trust in other
+        parts of the code being executed, if something appears to be
+        inconsistent, we trigger immediate halt with this return).
+        """
+
+        for kp in proposals:
+            try:
+                p, k = kp.split(b',')
+            except:
+                jlog.error("Invalid proposal string, ignoring: " + kp)
+            if k is not None:
+                # note that this operation will succeed as long as
+                # the key is in the wallet._script_map, which will
+                # be true if the key is at an HD index lower than
+                # the current wallet.index_cache
+                k = binascii.unhexlify(k)
+                addr = btc.pubkey_to_p2sh_p2wpkh_address(k)
+                # TODO this section can be refactored to not extract the
+                # privkey from the wallet.
+                try:
+                    priv = binascii.unhexlify(self.wallet.get_key_from_addr(addr))
+                except AssertionError:
+                    jlog.debug("Key not recognized as part of our "
+                               "wallet, ignoring.")
+                    continue
+                result = btc.parse_proposal_to_signed_tx(priv, p,
+                                            self.acceptance_callback)
+                if result[0] is not None:
+                    tx, tweak, unsigned_index, out_spk, vb, fb = result
+                    if vb not in self.versions:
+                        jlog.debug("Unrecognized SNICKER version, ignoring (" + \
+                                   str(vb) + ")")
+                        continue
+                    # We will: rederive the key as a sanity check,
+                    # and see if it matches the claimed spk.
+                    # Then, we import the key into the wallet
+                    # (even though it's re-derivable from history, this
+                    # is the easiest for a first implementation).
+                    # Finally, we co-sign, then push.
+                    # (Again, simplest function: checks already passed,
+                    # so do it automatically).
+                    # TODO: the more sophisticated actions.
+                    tweaked_key = btc.snicker_pubkey_tweak(k, tweak)
+                    tweaked_spk = btc.pubkey_to_p2sh_p2wpkh_script(tweaked_key)
+                    if not tweaked_spk == out_spk:
+                        jlog.error("The spk derived from the pubkey does "
+                                   "not match the scriptPubkey returned from "
+                                   "the snicker module - code error.")
+                        return False
+                    # before import, we should derive the tweaked *private* key
+                    # from the tweak, also:
+                    tweaked_privkey = btc.snicker_privkey_tweak(priv, tweak)
+                    if not btc.privkey_to_pubkey(tweaked_privkey, False) == tweaked_key:
+                        jlog.error("Was not able to recover tweaked pubkey "
+                        "from tweaked privkey - code error.")
+                        jlog.error("Expected: " + btc.safe_hexlify(tweaked_key))
+                        jlog.error("Got: " + binascii.hexlify(btc.privkey_to_pubkey(
+                            tweaked_privkey, False)))
+                        return False
+                    # the recreated private key matches, so we import to the wallet,
+                    # note that type = None here is because we use the same
+                    # scriptPubKey type as the wallet, this has been implicitly
+                    # checked above by deriving the scriptPubKey.
+                    self.wallet.import_private_key(self.import_branch,
+                        btc.wif_compressed_privkey(btc.safe_hexlify(
+                            tweaked_privkey),vbyte=get_p2pk_vbyte()))
+
+                    # we are ready to sign and broadcast
+                    final_tx, txid = self.wallet.sign_tx_at_index(tx,
+                                                                  unsigned_index)
+                    if not final_tx:
+                        jlog.error("Unable to sign SNICKER transaction even though "
+                                   "it passed validity checks. Code error.")
+                        return False
+                    jlog.info("Produced valid transaction for signing: ")
+                    jlog.info(final_tx)
+                        # TODO condition on automatic brdcst or not
+                    if not jm_single().bc_interface.pushtx(final_tx):
+                        jlog.error("Failed to broadcast SNICKER CJ.")
+                        return False
+                    self.wallet.remove_old_utxos(btc.deserialize(final_tx))
+                    self.wallet.add_new_utxos(btc.deserialize(final_tx), txid)
+                    return True
+                else:
+                    jlog.debug('Failed to parse proposal: ' + result[1])
+                    continue
+            else:
+                # Some extra work to implement checking all possible
+                # keys.
+                raise NotImplementedError()
+
+        # Completed processing all proposals without any logic
+        # errors (whether the proposals were valid or accepted
+        # or not).
+        return True
+

--- a/jmclient/test/commontest.py
+++ b/jmclient/test/commontest.py
@@ -124,6 +124,11 @@ def binarize_tx(tx):
         o['script'] = binascii.unhexlify(o['script'])
     for i in tx['ins']:
         i['outpoint']['hash'] = binascii.unhexlify(i['outpoint']['hash'])
+        if 'script' in i:
+            i['script'] = binascii.unhexlify(i['script'])
+        if 'txinwitness' in i:
+            for x, y in enumerate(i['txinwitness']):
+                i['txinwitness'][x] = binascii.unhexlify(i['txinwitness'][x])
 
 
 def make_sign_and_push(ins_full,

--- a/jmclient/test/test_snicker.py
+++ b/jmclient/test/test_snicker.py
@@ -1,0 +1,125 @@
+#! /usr/bin/env python
+from __future__ import (absolute_import, division,
+                        print_function, unicode_literals)
+from builtins import * # noqa: F401
+'''Test of unusual transaction types creation and push to
+network to check validity.'''
+
+import binascii
+from commontest import make_wallets, binarize_tx
+
+import jmbitcoin as btc
+import pytest
+from jmbase import get_log
+from jmclient import load_program_config, jm_single, sync_wallet,\
+     estimate_tx_fee, SNICKERReceiver
+
+log = get_log()
+   
+@pytest.mark.parametrize(
+    "nw, wallet_structures, mean_amt, sdev_amt, amt, net_transfer", [
+        (2, [[1, 0, 0, 0, 0]] * 2, 4, 1.4, 20000000, 1000),
+    ])
+def test_snicker_e2e(setup_snicker, nw, wallet_structures,
+                               mean_amt, sdev_amt, amt, net_transfer):
+    """ Test strategy:
+    1. create two wallets.
+    2. with wallet 1 (Receiver), create a single transaction
+    tx1, from mixdepth 0 to 1.
+    3. with wallet 2 (Proposer), take pubkey of all inputs from tx1, and use
+    them to create snicker proposals to the non-change out of tx1,
+    in base64 and place in proposals.txt.
+    4. Receiver polls for proposals in the file manually (instead of twisted
+    LoopingCall) and processes them.
+    5. Check for valid final transaction with broadcast.
+    """
+    wallets = make_wallets(nw, wallet_structures, mean_amt, sdev_amt)
+    for w in wallets.values():
+        sync_wallet(w['wallet'], fast=True)
+    print(wallets)
+    wallet_r = wallets[0]['wallet']
+    wallet_p = wallets[1]['wallet']
+    # next, create a tx from the receiver wallet
+    tx1_ins = wallet_r.select_utxos(0, amt)
+    #as normal for a coinjoin from m 0:
+    output_addr = wallet_r.get_new_addr(1, 1)
+    change_addr = wallet_r.get_new_addr(0, 1)
+    total = sum(x['value'] for x in tx1_ins.values())
+    ins = list(tx1_ins.keys())    
+    fee_est = estimate_tx_fee(len(ins), 2)
+    outs = [{'value': amt,
+             'address': output_addr}, {'value': total - amt - fee_est,
+                                       'address': change_addr}]
+    de_tx = btc.deserialize(btc.mktx(ins, outs))
+    scripts = {}
+    for index, ins in enumerate(de_tx['ins']):
+        utxo = ins['outpoint']['hash'] + ':' + str(ins['outpoint']['index'])
+        script = wallet_r.addr_to_script(tx1_ins[utxo]['address'])
+        scripts[index] = (script, tx1_ins[utxo]['value'])
+    binarize_tx(de_tx)
+    de_tx = wallet_r.sign_tx(de_tx, scripts)
+    #pushtx returns False on any error
+    push_succeed = jm_single().bc_interface.pushtx(btc.serialize(de_tx))
+    assert push_succeed
+    print("Parent transaction OK. It was: ")
+    print(de_tx)
+    removed = wallet_r.remove_old_utxos(de_tx)
+    txid1 = btc.txhash(btc.serialize(de_tx))
+    added = wallet_r.add_new_utxos(de_tx, txid1)
+    txid1_index = 0
+
+    receiver_start_bal = sum([x['value'] for x in wallet_r.get_all_utxos().values()])
+
+    # Now create a proposal for every input index in tx1
+    # (version 1 proposals mean we source keys from the/an
+    # ancestor transaction)
+    binarize_tx(de_tx) # all processing from here must be binary
+    propose_keys = []
+    for i in de_tx['ins']:
+        propose_keys.append(i['txinwitness'][1])
+    # the proposer wallet needs to choose a single
+    # utxo that is bigger than the output amount of tx1
+    prop_m_utxos = wallet_p.get_utxos_by_mixdepth_()[0]
+    prop_utxo = prop_m_utxos[list(prop_m_utxos)[0]]
+    # get the private key for that utxo
+    priv = binascii.unhexlify(wallet_p.get_key_from_addr(
+        wallet_p.script_to_addr(prop_utxo['script'])))
+    prop_input_amt = prop_utxo['value']
+    # construct the arguments for the snicker proposal:
+    our_input = list(prop_m_utxos)[0] # should be (txid, index)
+    our_input = btc.safe_hexlify(our_input[0])+":"+str(our_input[1])
+    their_input = txid1+":"+str(txid1_index)
+    our_input_utxo = (prop_input_amt, prop_utxo['script'])
+    fee_est = estimate_tx_fee(len(ins), 2)
+    net_transfer = 1000 # something non zero to test arithmetic
+    change_spk = wallet_p.get_new_script(0, 1)
+
+    encrypted_proposals = []
+
+    for i, p in enumerate(propose_keys):
+        their_input_utxo = (de_tx['outs'][i]['value'],
+                            de_tx['outs'][i]['script'])
+        encrypted_proposals.append(btc.create_proposal(
+            our_input, their_input,
+            our_input_utxo,
+            their_input_utxo,
+            net_transfer,
+            fee_est,
+            priv,
+            p,
+            prop_utxo['script'],
+            change_spk,
+            version_byte=1)+b","+binascii.hexlify(p))
+    with open("test_proposals.txt", "wb") as f:
+        f.write(b"\n".join(encrypted_proposals))
+    sR = SNICKERReceiver(wallet_r)
+    sR.proposals_source = "test_proposals.txt" # avoid clashing with mainnet
+    sR.poll_for_proposals()
+    end_utxos = wallet_r.get_all_utxos()
+    print("At end the receiver has these utxos: ", end_utxos)
+    receiver_end_bal = sum([x['value'] for x in end_utxos.values()])
+    assert receiver_end_bal == receiver_start_bal + net_transfer
+
+@pytest.fixture(scope="module")
+def setup_snicker():
+    load_program_config()

--- a/scripts/cli_options.py
+++ b/scripts/cli_options.py
@@ -20,8 +20,18 @@ order_choose_algorithms = {
     'weighted_order_choose': '-W'
 }
 
+def add_common_wallet_options(parser):
+    parser.add_option('--fast',
+                      action='store_true',
+                      dest='fastsync',
+                      default=False,
+                      help=('choose to do fast wallet sync, only for Core and '
+                            'only for previously synced wallet'))
 
 def add_common_options(parser):
+
+    add_common_wallet_options(parser)
+
     parser.add_option(
         '-f',
         '--txfee',
@@ -33,12 +43,6 @@ def add_common_options(parser):
         'for the total transaction fee, default=dynamically estimated, note that this is adjusted '
         'based on the estimated fee calculated after tx construction, based on '
         'policy set in joinmarket.cfg.')
-    parser.add_option('--fast',
-                      action='store_true',
-                      dest='fastsync',
-                      default=False,
-                      help=('choose to do fast wallet sync, only for Core and '
-                            'only for previously synced wallet'))
     parser.add_option(
         '-x',
         '--max-cj-fee-abs',
@@ -70,6 +74,7 @@ def add_common_options(parser):
              .format('random_under_max_order_choose',
                      ', '.join(order_choose_algorithms.keys())),
         dest='order_choose_fn')
+
     add_order_choose_short_options(parser)
 
 

--- a/scripts/snicker-receiver.py
+++ b/scripts/snicker-receiver.py
@@ -1,0 +1,69 @@
+#! /usr/bin/env python
+from __future__ import (absolute_import, division,
+                        print_function, unicode_literals)
+from builtins import * # noqa: F401
+
+import sys
+from twisted.internet import reactor
+from twisted.internet.task import LoopingCall
+from twisted.python.log import startLogging
+from optparse import OptionParser
+
+from jmbase import get_log, jmprint
+from cli_options import add_common_wallet_options
+from jmclient import SNICKERReceiver, load_program_config, \
+     get_wallet_path, open_test_wallet_maybe, jm_single, sync_wallet
+
+""" This script allows the user to run SNICKER as a receiver
+using a Joinmarket wallet, standalone (i.e. not used for
+Joinmarket coinjoins or any other function).
+Funds for joins can be sourced from any mixdepth, and coinjoin
+outputs are placed in the imported section of mixdepth 0 (private
+keys are imported into the wallet file).
+"""
+
+jlog = get_log()
+
+def snicker_receive():
+    parser = OptionParser(usage='usage: %prog [options] [wallet file]')
+    add_common_wallet_options(parser)
+    parser.add_option('-i', '--income-threshold', action='store', type='int',
+                      dest='income', default=0,
+                      help='Minimum net income for a coinjoin, in satoshis. '
+                      'Can be negative.')
+    parser.add_option('-m', '--mixdepth', action='store', type='int',
+                      dest='mixdepth', default=None,
+                      help="highest mixdepth to use in the wallet")
+    (options, args) = parser.parse_args()
+    if len(args) < 1:
+        parser.error('Needs a wallet')
+        sys.exit(0)
+    wallet_name = args[0]
+
+    load_program_config()
+
+    wallet_path = get_wallet_path(wallet_name, 'wallets')
+    wallet = open_test_wallet_maybe(wallet_path, wallet_name, options.mixdepth)
+
+    while not jm_single().bc_interface.wallet_synced:
+        sync_wallet(wallet, fast=options.fastsync)
+
+    # this uses the default acceptance callback, which accepts any
+    # transaction meeting the income threshold:
+    sR = SNICKERReceiver(wallet, income_threshold=options.income)
+    if jm_single().config.get("BLOCKCHAIN", "network") in ["regtest", "testnet"]:
+        sR.proposals_source = "test_proposals.txt"
+        startLogging(sys.stdout)
+
+    # since this is a monitoring loop, not a service, we can avoid
+    # instantiating a protocol instance and just use a looping call.
+    loop = LoopingCall(sR.poll_for_proposals)
+
+    jmprint("Starting to monitor the proposals source every 10 seconds...", "info")
+    loop.start(10, now=False)
+
+    reactor.run()
+
+if __name__ == "__main__":
+    snicker_receive()
+    jmprint('done', "success")


### PR DESCRIPTION
For what "SNICKER" is, see https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2019-September/017283.html and the blog post (optional, discursive, not up to date) and the gist (technical spec, currently draft) directly linked there. I'll call that spec "BIP-SNICKER" in the following.

Function
===
Since the changes are quite substantial (almost all additions), I'll list them below, but first, explaining of exactly what functionality is and isn't added by this PR:

I doubt anyone is crazy or patient enough but in any case, **DO NOT USE ON MAINNET, NOT READY** .

This PR currently only allows a user to run an independent [script](https://github.com/JoinMarket-Org/joinmarket-clientserver/blob/2346ff3272c2184d88b8d34d15d67c59f5c6f5d2/scripts/snicker-receiver.py) (`snicker-receiver.py`) from the `scripts` directory on a Joinmarket wallet to passively listen for new proposals dropped into a file (`proposals.txt`) (only proposals with public keys attached are currently supported). If you follow that link I hope it helps to appreciate just how simple this will look at the top layer: just poll a resource periodically and automatically co-sign and broadcast if income > threshold (or other configurable condition); that's it.

Note the very restricted implementation so far:

* Only proposals from a file (todo, ping a url instead)
* Only proposals with pubkeys attached (code supports search for a key but not yet tested)
* Acceptance filter on proposals: only simple default "income of coinjoin > x" with x=0 by default, can be configured as command line argument).
* Only automated co-sign and publish, no option to temporarily store and check the coinjoin before broadcast (although easy enough to add in simple form).
* the Joinmarket standard utxo type p2sh-p2wpkh was assumed for now, although again updating to add support for counterparties with other types may be fairly simple
* biggest limitation is important: **coinjoin destination scripts are imported using Joinmarket's existing private key import function, stored in a "fake" branch at mixdepth 0**. This means there is no scanning code to search for and recover those coins as of yet. However the code is written to ensure that that scanning is possible in future, using the algorithm described in BIP-SNICKER.

Setting aside the whole issue of how BIP-SNICKER "Proposer"s will function, the Receiver side will need only a little more work from this to be integrated into a Maker with no impact on the Maker workflow except the key recovery issue. We can just add the `task.LoopingCall` to the yg script, and twisted will slot that into the event loop.

Primitives
===

Two modules `secp256k1_ecdh.py` and `secp256k1_ecies.py` are added for providing the ECDH and ECIES algorithms for key sharing and encryption, respectively. The algos are exactly as in the current BIP-SNICKER. In case it wasn't already clear, the `secp256k1*` naming scheme for files here reflects the use of a binding to libsecp256k1. Note that the ECIES implementation uses AES and so now imports `pyaes`, and is using AES exactly as the wallet currently does for encryption in `jmclient` (see `storage.py`).

Apart from the snicker functionality, there is a very minor change in `secp256k1_transaction` to allow for export of reading bitcoin serializations.

PSBT: a simple/partial implementation of this in Python was taken from [here](https://github.com/bjarnemagnussen/python-psbt) (see the README in that package for credit); a couple of edits were needed for support of p2sh-p2wpkh. The implementation is incomplete and would need more work; I chose it for now to minimize time. I'm still vacillating between copying my implementation [here](https://github.com/btcsuite/btcutil/pull/126) wholesale over to Python as I think it's a lot more complete and tested, but otoh for this task we don't need it to be perfect, right now; the only thing that's really important is that the half-signed PSBT in flight is valid for compatibility.
Additionally there is a `jm_psbt.py` module added to `jmbitcoin` to give an interface layer above whatever PSBT implementation we use.

A further small primitive addition was BIP69 as specified in BIP-SNICKER for input/output ordering, this was added in `secp256k1_transaction.py` as the function `bip69_sort(tx)`.

Wallet
===
Two minor convenience functions are added: `get_all_utxos` (this is relevant for SNICKER as the source utxo can be from any mixdepth) and `sign_tx_at_index`, simply making signing more convenient in cases where we know the input index. These additions hint towards future changes: we will in future (I expect, anyway) make both signing and interfacing with the blockchain much more encapsulated within the wallet. This is more difficult with coinjoin wallets than with ordinary wallets (especially when we do funky things like PoDLE or ECDH with keys etc etc, just to bear in mind), but is still a relevant point (mainly key access encapsulation).

SNICKER functions
===
SNICKER as an algorithm is implemented in `snicker.py` in the `jmbitcoin` package. This makes use of the PSBT, ECDH and ECIES primitives mentioned above. It offers functions to create and parse "proposals" as defined in BIP-SNICKER, as well as lower level functions to standardise the creation of 'tweaked keys' and to verify them (particular paranoia is appropriate for the checking of these tweaked keys as any error will result in permanent funds loss!).
In `jmclient` the `snicker_receiver.py` module simply offers a `SNICKERReceiver` object that can query proposals and then process them, checking their validity and apply a default or user-chosen filter as to which proposals to accept based on economics (income).
In `scripts` the already mentioned `snicker-receiver.py` user level script just instantiates a `SNICKERReceiver` and then polls it in a loop.

Tests
===
Tests have been added for BIP69, ECDH, ECIES, PSBT in `jmclient/test/test_tx_creation.py` (this needs more, but note the basic PSBT functions were already tested in the github repo linked above, and anyway more work is needed on that), and for SNICKER, test is in `jmclient/test/test_snicker.py` which follows the whole create and parse (via SNICKERReceiver) workflow of SNICKER.

This is only the basics of the Receiver function and is not something that affects normal Joinmarket usage (wallet, Taker, Maker) if not used.

Next steps: automated Proposals setup and a testnet infrastructure is probably needed to do some real world testing. Add some configuration to `joinmarket.cfg` for people to switch this on or off. Some code to poll a URL (preferably Tor HS) for proposals. Improving or changing the PSBT code. And other stuff.

Help appreciated.