### PR TITLE
Fix context menu for bech32 addresses in tx history tab

### DIFF
--- a/scripts/joinmarket-qt.py
+++ b/scripts/joinmarket-qt.py
@@ -985,11 +985,7 @@ class TxHistoryTab(QWidget):
         address_valid = False
         if item:
             address = str(item.text(0))
-            try:
-                btc.b58check_to_hex(address)
-                address_valid = True
-            except AssertionError:
-                log.debug('no btc address found, not creating menu item')
+            address_valid = validate_address(address)
 
         menu = QMenu()
         if address_valid:


### PR DESCRIPTION
Before this change, `jmbitcoin.secp256k1_main.InvalidBase58Error: Character '0' is not a valid base58 character` is thrown when doing right mouse click on entry with bech32 address.

Also, I didn't understand the reasoning for not showing menu at all in case of invalid address, other menu items are still useful, log message is wrong.