### PR TITLE
Add "manual" tx_broadcast method

### DIFF
--- a/jmclient/jmclient/configure.py
+++ b/jmclient/jmclient/configure.py
@@ -239,10 +239,11 @@ absurd_fee_per_kb = 350000
 # spends from unconfirmed inputs, which may then get malleated or double-spent!
 # other counterparties are likely to reject unconfirmed inputs... don't do it.
 
-# options: self, random-peer, not-self (note: currently, ONLY 'self' works).
+# options: self, random-peer, not-self, manual (note: currently, ONLY 'self' and 'manual' works).
 # self = broadcast transaction with your bitcoin node's ip
 # random-peer = everyone who took part in the coinjoin has a chance of broadcasting
 # not-self = never broadcast with your own ip
+# manual = don't broadcast at all, output tx data for manual broadcast by the user
 tx_broadcast = self
 
 # If makers do not respond while creating a coinjoin transaction,

--- a/jmclient/jmclient/taker.py
+++ b/jmclient/jmclient/taker.py
@@ -13,7 +13,7 @@ from binascii import hexlify, unhexlify
 from jmbitcoin import SerializationError, SerializationTruncationError
 import jmbitcoin as btc
 from jmclient.configure import jm_single, validate_address
-from jmbase.support import get_log
+from jmbase.support import get_log, jmprint
 from jmclient.support import (calc_cj_fee, weighted_order_choose, choose_orders,
                               choose_sweep_orders)
 from jmclient.wallet import estimate_tx_fee
@@ -819,8 +819,12 @@ class Taker(object):
             else:
                 nick_to_use = list(self.maker_utxo_data.keys())[i]
                 pushed = True
+        elif tx_broadcast == 'manual':
+            jmprint("Transaction data for manual broadcast:")
+            jmprint(tx)
+            pushed = True
         else:
-            jlog.info("Only self, random-peer and not-self broadcast "
+            jlog.info("Only self, random-peer, not-self and manual broadcast "
                       "methods supported. Reverting to self-broadcast.")
             pushed = jm_single().bc_interface.pushtx(tx)
         if not pushed:

--- a/scripts/qtsupport.py
+++ b/scripts/qtsupport.py
@@ -110,8 +110,8 @@ config_tips = {
     "consider switching to DEBUG in case of problems.",
     "absurd_fee_per_kb": "maximum satoshis/kilobyte you are willing to pay,\n" +
     "whatever the fee estimate currently says.",
-    "tx_broadcast": "Options: self, random-peer, not-self (note: random-maker\n" +
-    "is not currently supported).\n" +
+    "tx_broadcast": "Options: self, random-peer, not-self, manual\n" +
+    "(note: only self and manual is currently supported).\n" +
     "self = broadcast transaction with your own ip\n" +
     "random-peer = everyone who took part in the coinjoin has\n" +
     "a chance of broadcasting.\n" +


### PR DESCRIPTION
Ensures that no attempts to broadcast transaction will be made by JoinMarket. This is needed for Lightning channel opening with c-lightning and it's `fundchannel_start` and `fundchannel_complete` commands.

> Note that the funding transaction MUST NOT be broadcast until after
channel establishment has been successfully completed by running
`fundchannel_complete`, as the commitment transactions for this channel
are not secured until the complete command succeeds. Broadcasting
transaction before that can lead to unrecoverable loss of funds.

I plan to write scripts to automate channel opening/closing in the future, but this already allows to do it manually.