### PR TITLE
Restore support for pre-0.17 Bitcoin Core in wallet

### DIFF
--- a/jmclient/jmclient/blockchaininterface.py
+++ b/jmclient/jmclient/blockchaininterface.py
@@ -32,6 +32,10 @@ class BlockchainInterface(object):
             return len(self.rpc('getaddressinfo', [addr])['labels']) > 0
 
     @abc.abstractmethod
+    def is_address_labeled(self, utxo, walletname):
+        """checks that UTXO belongs to the JM wallet"""
+
+    @abc.abstractmethod
     def pushtx(self, txhex):
         """pushes tx to the network, returns False if failed"""
 
@@ -181,6 +185,13 @@ class BitcoinCoreInterface(BlockchainInterface):
             log.debug('rpc: ' + method + " " + str(args))
         res = self.jsonRpc.call(method, args)
         return res
+
+    def is_address_labeled(self, utxo, walletname):
+        # Bitcoin Core before 0.17 used accounts, new versions has labels
+        return (
+            ("label" in utxo and utxo["label"] == walletname) or
+            ("account" in utxo and utxo["account"] == walletname)
+        )
 
     def import_addresses(self, addr_list, wallet_name, restart_cb=None):
         """Imports addresses in a batch during initial sync.

--- a/jmclient/jmclient/wallet_service.py
+++ b/jmclient/jmclient/wallet_service.py
@@ -225,8 +225,8 @@ class WalletService(Service):
             # transaction pertains to anything known (but must
             # have correct label per above); filter on this Joinmarket wallet label,
             # or the external monitoring label:
-            if "label" in tx and tx["label"] in [
-                self.EXTERNAL_WALLET_LABEL, self.get_wallet_name()]:
+            if (self.bci.is_address_labeled(tx, self.get_wallet_name()) or
+                self.bci.is_address_labeled(tx, self.EXTERNAL_WALLET_LABEL)):
                 for f in self.callbacks["all"]:
                     # note we need no return value as we will never
                     # remove these from the list
@@ -491,13 +491,13 @@ class WalletService(Service):
                 'POLICY', 'listunspent_args'))
 
         unspent_list = self.bci.rpc('listunspent', listunspent_args)
-        unspent_list = [x for x in unspent_list if "label" in x]
         # filter on label, but note (a) in certain circumstances (in-
         # wallet transfer) it is possible for the utxo to be labeled
         # with the external label, and (b) the wallet will know if it
         # belongs or not anyway (is_known_addr):
-        our_unspent_list = [x for x in unspent_list if x["label"] in [
-            wallet_name, self.EXTERNAL_WALLET_LABEL]]
+        our_unspent_list = [x for x in unspent_list if (
+            self.bci.is_address_labeled(x, wallet_name) or
+            self.bci.is_address_labeled(x, self.EXTERNAL_WALLET_LABEL))]
         for u in our_unspent_list:
             if not self.is_known_addr(u['address']):
                 continue


### PR DESCRIPTION
With #359 changes, some places in code now assumes UTXO's has labels. But that's not true with Bitcoin Core 0.16.3, it still uses accounts, labels were introduced with 0.17. Don't think dropping support for 0.16 is a good idea currently, as it is stable default for some Linux distros, for example, Gentoo.

It fixes wallet-tool for me, but still needs more testing, both with 0.16.3 and 0.17+.