### PR TITLE
Rename "Exit" to "Quit" in Wallet menu

### DIFF
--- a/scripts/joinmarket-qt.py
+++ b/scripts/joinmarket-qt.py
@@ -1295,10 +1295,10 @@ class JMMainWindow(QMainWindow):
         exportPrivAction = QAction('&Export keys', self)
         exportPrivAction.setStatusTip('Export all private keys to a  file')
         exportPrivAction.triggered.connect(self.exportPrivkeysJson)
-        exitAction = QAction(QIcon('exit.png'), '&Exit', self)
-        exitAction.setShortcut('Ctrl+Q')
-        exitAction.setStatusTip('Exit application')
-        exitAction.triggered.connect(qApp.quit)
+        quitAction = QAction(QIcon('exit.png'), '&Quit', self)
+        quitAction.setShortcut('Ctrl+Q')
+        quitAction.setStatusTip('Quit application')
+        quitAction.triggered.connect(qApp.quit)
 
         aboutAction = QAction('About Joinmarket', self)
         aboutAction.triggered.connect(self.showAboutDialog)
@@ -1310,7 +1310,7 @@ class JMMainWindow(QMainWindow):
         walletMenu.addAction(recoverAction)
         walletMenu.addAction(showSeedAction)
         walletMenu.addAction(exportPrivAction)
-        walletMenu.addAction(exitAction)
+        walletMenu.addAction(quitAction)
         aboutMenu = menubar.addMenu('&About')
         aboutMenu.addAction(aboutAction)
 


### PR DESCRIPTION
Rationale:
* E as a hot key for menu item conflicts with "Export keys".
* Ctrl+Q is already used as a global shortcut, seems more logical to have the same one (Q) under menu.
* Electrum also uses Ctrl+Q and "Quit" (but OTOH, bitcoin-qt has "E&xit" and Ctrl+Q).