### PR TITLE
Abort wallet generation if mnemonic extension choosen but not provided

### DIFF
--- a/jmclient/jmclient/wallet_utils.py
+++ b/jmclient/jmclient/wallet_utils.py
@@ -489,12 +489,16 @@ def cli_user_mnemonic_entry():
         mnemonic_extension = None
     return (mnemonic_phrase, mnemonic_extension)
 
-def cli_get_mnemonic_extension():
+def cli_do_use_mnemonic_extension():
     uin = input("Would you like to use a two-factor mnemonic recovery "
                     "phrase? write 'n' if you don't know what this is (y/n): ")
     if len(uin) == 0 or uin[0] != 'y':
         jmprint("Not using mnemonic extension", "info")
-        return None #no mnemonic extension
+        return False #no mnemonic extension
+    else:
+        return True
+
+def cli_get_mnemonic_extension():
     jmprint("Note: This will be stored in a reversible way. Do not reuse!",
             "info")
     return input("Enter mnemonic extension: ")
@@ -506,6 +510,7 @@ def wallet_generate_recover_bip39(method, walletspath, default_wallet_name,
                                              cli_user_mnemonic_entry,
                                              cli_get_wallet_passphrase_check,
                                              cli_get_wallet_file_name,
+                                             cli_do_use_mnemonic_extension,
                                              cli_get_mnemonic_extension)):
     """Optionally provide callbacks:
     0 - display seed
@@ -518,7 +523,10 @@ def wallet_generate_recover_bip39(method, walletspath, default_wallet_name,
     entropy = None
     mnemonic_extension = None
     if method == "generate":
-        mnemonic_extension = callbacks[4]()
+        if callbacks[4]():
+            mnemonic_extension = callbacks[5]()
+            if not mnemonic_extension:
+                return False
     elif method == 'recover':
         words, mnemonic_extension = callbacks[1]()
         mnemonic_extension = mnemonic_extension and mnemonic_extension.strip()

--- a/scripts/joinmarket-qt.py
+++ b/scripts/joinmarket-qt.py
@@ -1678,12 +1678,13 @@ class JMMainWindow(QMainWindow):
         mb.setStandardButtons(QMessageBox.Ok)
         ret = mb.exec_()
 
-    def promptMnemonicExtension(self):
+    def promptUseMnemonicExtension(self):
         msg = "Would you like to use a two-factor mnemonic recovery phrase?\nIf you don\'t know what this is press No."
         reply = QMessageBox.question(self, 'Use mnemonic extension?',
                     msg, QMessageBox.Yes, QMessageBox.No)
-        if reply == QMessageBox.No:
-            return None
+        return reply == QMessageBox.Yes
+
+    def promptInputMnemonicExtension(self):
         mnemonic_extension, ok = QInputDialog.getText(self,
                                      'Input Mnemonic Extension',
                                      'Enter mnemonic Extension:',
@@ -1705,7 +1706,8 @@ class JMMainWindow(QMainWindow):
                                                               None,
                                                               self.getPassword,
                                                               self.getWalletFileName,
-                                                              self.promptMnemonicExtension))
+                                                              self.promptUseMnemonicExtension,
+                                                              self.promptInputMnemonicExtension))
                 if not success:
                     JMQtMessageBox(self, "Failed to create new wallet file.",
                                    title="Error", mbtype="warn")


### PR DESCRIPTION
Prior this change, if you choose to have mnemonic extension in Qt, but then pressed Cancel at following dialog, wallet creation was not aborted.