### PR TITLE
Preserve comments in config file when using Qt

### DIFF
--- a/jmclient/jmclient/__init__.py
+++ b/jmclient/jmclient/__init__.py
@@ -21,7 +21,7 @@ from .storage import (Argon2Hash, Storage, StorageError,
                       StoragePasswordError, VolatileStorage)
 from .cryptoengine import BTCEngine, BTC_P2PKH, BTC_P2SH_P2WPKH, EngineError
 from .configure import (
-    load_program_config, get_p2pk_vbyte, jm_single, get_network,
+    load_program_config, get_p2pk_vbyte, jm_single, get_network, update_persist_config,
     validate_address, get_irc_mchannels, get_blockchain_interface_instance,
     get_p2sh_vbyte, set_config, is_segwit_mode, is_native_segwit_mode)
 from .blockchaininterface import (BlockchainInterface,

--- a/scripts/joinmarket-qt.py
+++ b/scripts/joinmarket-qt.py
@@ -68,7 +68,7 @@ JM_CORE_VERSION = '0.5.5'
 JM_GUI_VERSION = '10'
 
 from jmbase import get_log
-from jmclient import load_program_config, get_network,\
+from jmclient import load_program_config, get_network, update_persist_config,\
     open_test_wallet_maybe, get_wallet_path, get_p2sh_vbyte, get_p2pk_vbyte,\
     jm_single, validate_address, weighted_order_choose, Taker,\
     JMClientProtocolFactory, start_reactor, get_schedule, schedule_to_text,\
@@ -92,8 +92,6 @@ def update_config_for_gui():
     '''The default joinmarket config does not contain these GUI settings
     (they are generally set by command line flags or not needed).
     If they are set in the file, use them, else set the defaults.
-    These *will* be persisted to joinmarket.cfg, but that will not affect
-    operation of the command line version.
     '''
     gui_config_names = ['gaplimit', 'history_file', 'check_high_fee',
                         'max_mix_depth', 'txfee_default', 'order_wait_time',
@@ -106,13 +104,6 @@ def update_config_for_gui():
     for gcn, gcv in zip(gui_config_names, gui_config_default_vals):
         if gcn not in [_[0] for _ in gui_items]:
             jm_single().config.set("GUI", gcn, gcv)
-
-
-def persist_config():
-    '''This loses all comments in the config file.
-    TODO: possibly correct that.'''
-    with open('joinmarket.cfg', 'w') as f:
-        jm_single().config.write(f)
 
 def checkAddress(parent, addr):
     valid, errmsg = validate_address(str(addr))
@@ -249,12 +240,17 @@ class SettingsTab(QDialog):
                 oval = 'true' if checked else 'false'
             log.debug('setting section: ' + section + ' and name: ' + oname +
                       ' to: ' + oval)
-            jm_single().config.set(section, oname, oval)
+            if not update_persist_config(section, oname, oval):
+                log.warn("Unable to persist config change to file: " + str(section) + str(oname) + str(oval))
 
         else:  #currently there is only QLineEdit
             log.debug('setting section: ' + section + ' and name: ' + str(t[
                 0].text()) + ' to: ' + str(t[1].text()))
-            jm_single().config.set(section, str(t[0].text()), str(t[1].text()))
+            if not update_persist_config(section, str(t[0].text()), str(t[1].text())):
+                # we don't include GUI as it's not required to be persisted:
+                if not section == "GUI":
+                    log.warn("Unable to persist config change to file: " + str(
+                        section) + str(t[0].text()) + str(t[1].text()))
             if str(t[0].text()) == 'blockchain_source':
                 jm_single().bc_interface = get_blockchain_interface_instance(
                     jm_single().config)
@@ -1270,7 +1266,6 @@ class JMMainWindow(QMainWindow):
         quit_msg = "Are you sure you want to quit?"
         reply = JMQtMessageBox(self, quit_msg, mbtype='question')
         if reply == QMessageBox.Yes:
-            persist_config()
             event.accept()
             if self.reactor.threadpool is not None:
                 self.reactor.threadpool.stop()

--- a/scripts/qtsupport.py
+++ b/scripts/qtsupport.py
@@ -68,15 +68,13 @@ config_tips = {
     'rpc_port': 'port for connecting to bitcoind over rpc',
     'rpc_user': 'user for connecting to bitcoind over rpc',
     'rpc_password': 'password for connecting to bitcoind over rpc',
-    'host': 'hostname for IRC server (or comma separated list)',
-    'channel': 'channel name on IRC server (or comma separated list)',
-    'port': 'port for connecting to IRC server (or comma separated list)',
-    'usessl': "'true'/'false' to use SSL for each connection to IRC\n" +
-    "(or comma separated list)",
-    'socks5': "'true'/'false' to use a SOCKS5 proxy for each connection" +
-    "to IRC (or comma separated list)",
-    'socks5_host': 'host for SOCKS5 proxy (or comma separated list)',
-    'socks5_port': 'port for SOCKS5 proxy (or comma separated list)',
+    'host': 'hostname for IRC server',
+    'channel': 'channel name on IRC server',
+    'port': 'port for connecting to IRC server',
+    'usessl': "'true'/'false' to use SSL for each connection to IRC\n",
+    'socks5': "'true'/'false' to use a SOCKS5 proxy for each connection",
+    'socks5_host': 'host for SOCKS5 proxy',
+    'socks5_port': 'port for SOCKS5 proxy',
     'maker_timeout_sec': 'timeout for waiting for replies from makers',
     'merge_algorithm': 'for dust sweeping, try merge_algorithm = gradual, \n' +
     'for more rapid dust sweeping, try merge_algorithm = greedy \n' +
@@ -106,6 +104,7 @@ config_tips = {
     "documentation for details on how to set up certs if you use this.",
     "history_file": "Location of the file storing transaction history",
     "segwit": "Only used for migrating legacy wallets; see documentation.",
+    "native": "NOT currently supported, except for PayJoin (command line only)",
     "console_log_level": "one of INFO, DEBUG, WARN, ERROR; INFO is least noisy;\n" +
     "consider switching to DEBUG in case of problems.",
     "absurd_fee_per_kb": "maximum satoshis/kilobyte you are willing to pay,\n" +


### PR DESCRIPTION
Fixes #436 

Since ConfigParser does not sufficiently support comments
in config objects, in order to support dynamic update of
the config from within a run, this PR edits the config
file at the same time as updating the config object, so
as to prevent the earlier problem that all comments in the
config file were lost whenever Qt updated the file with
the new config object.

Tests OK for me.

Travis failure is to do with regex syntax disallowed by flake. Fixing now but it's not a functional issue.