### PR TITLE
Added missing dependencies libltdl-dev and libssl-dev

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -15,13 +15,13 @@ deps_install ()
 {
     if [[ ${install_os} == 'debian' ]]; then
         if is_python3; then
-            if deb_deps_install "python-virtualenv curl python3-dev python3-pip build-essential automake pkg-config libtool libgmp-dev libltdl-dev"; then
+            if deb_deps_install "python-virtualenv curl python3-dev python3-pip build-essential automake pkg-config libtool libgmp-dev libltdl-dev libssl-dev"; then
                 return 0
             else
                 return 1
             fi
         else
-            if deb_deps_install "python-virtualenv curl python-dev python-pip build-essential automake pkg-config libtool libgmp-dev libltdl-dev"; then
+            if deb_deps_install "python-virtualenv curl python-dev python-pip build-essential automake pkg-config libtool libgmp-dev libltdl-dev libssl-dev"; then
                 return 0
             else
                 return 1

--- a/install.sh
+++ b/install.sh
@@ -15,13 +15,13 @@ deps_install ()
 {
     if [[ ${install_os} == 'debian' ]]; then
         if is_python3; then
-            if deb_deps_install "python-virtualenv curl python3-dev python3-pip build-essential automake pkg-config libtool libgmp-dev"; then
+            if deb_deps_install "python-virtualenv curl python3-dev python3-pip build-essential automake pkg-config libtool libgmp-dev libltdl-dev"; then
                 return 0
             else
                 return 1
             fi
         else
-            if deb_deps_install "python-virtualenv curl python-dev python-pip build-essential automake pkg-config libtool libgmp-dev"; then
+            if deb_deps_install "python-virtualenv curl python-dev python-pip build-essential automake pkg-config libtool libgmp-dev libltdl-dev"; then
                 return 0
             else
                 return 1


### PR DESCRIPTION
On my machine running Mint I wasn't able to run the install.sh without getting the error ``configure.ac:451: error: possibly undefined macro: LT_SYS_SYMBOL_USCORE``. This was due to a missing dependency (libltdl-dev) which I hereby added to the installation process.