### PR TITLE
Wallet no history sync

### DIFF
--- a/docs/release-notes/release-notes-nohistory-sync.md
+++ b/docs/release-notes/release-notes-nohistory-sync.md
@@ -1,0 +1,12 @@
+Notable changes
+===============
+
+### No-history wallet synchronization
+
+The no-history synchronization method is enabled by setting `blockchain_source = bitcoin-rpc-no-history` in the `joinmarket.cfg` file.
+
+The method can be used to import a seed phrase to see whether it has any money on it within just 5-10 minutes. No-history sync doesn't require a long blockchain rescan, although it needs a full node which can be pruned.
+
+No-history sync works by scanning the full node's UTXO set. The downside is that it cannot find the history but only the current unspent balance, so it cannot avoid address reuse. Therefore when using no-history synchronization the wallet cannot generate new addresses. Any found money can only be spent by fully-sweeping the funds but not partially spending them which requires a change address. When using the method make sure to increase the gap limit to a large amount to cover all the possible bitcoin addresses where coins might be.
+
+The mode does not work with the Joinmarket-Qt GUI application but might do in future.

--- a/jmclient/jmclient/blockchaininterface.py
+++ b/jmclient/jmclient/blockchaininterface.py
@@ -463,6 +463,17 @@ class BitcoinCoreNoHistoryInterface(BitcoinCoreInterface):
         # avoidance of address reuse
         wallet.disable_new_scripts = True
 
+    ##these two functions are hacks to make the test code be able to use the
+    ##same helper functions, perhaps it would be nicer to create mixin classes
+    ##and use multiple inheritance to make the code more OOP, but its not
+    ##worth it now
+    def grab_coins(self, receiving_addr, amt=50):
+        RegtestBitcoinCoreInterface.grab_coins(self, receiving_addr, amt)
+
+    def tick_forward_chain(self, n):
+        self.destn_addr = self.rpc("getnewaddress", [])
+        RegtestBitcoinCoreInterface.tick_forward_chain(self, n)
+
 # class for regtest chain access
 # running on local daemon. Only
 # to be instantiated after network is up

--- a/jmclient/jmclient/configure.py
+++ b/jmclient/jmclient/configure.py
@@ -107,7 +107,8 @@ daemon_host = localhost
 use_ssl = false
 
 [BLOCKCHAIN]
-#options: bitcoin-rpc, regtest
+#options: bitcoin-rpc, regtest, bitcoin-rpc-no-history
+# when using bitcoin-rpc-no-history remember to increase the gap limit to scan for more addresses, try -g 5000
 blockchain_source = bitcoin-rpc
 network = mainnet
 rpc_host = localhost
@@ -516,12 +517,13 @@ def get_blockchain_interface_instance(_config):
     # todo: refactor joinmarket module to get rid of loops
     # importing here is necessary to avoid import loops
     from jmclient.blockchaininterface import BitcoinCoreInterface, \
-        RegtestBitcoinCoreInterface, ElectrumWalletInterface
+        RegtestBitcoinCoreInterface, ElectrumWalletInterface, \
+        BitcoinCoreNoHistoryInterface
     from jmclient.electruminterface import ElectrumInterface
     source = _config.get("BLOCKCHAIN", "blockchain_source")
     network = get_network()
     testnet = network == 'testnet'
-    if source in ('bitcoin-rpc', 'regtest'):
+    if source in ('bitcoin-rpc', 'regtest', 'bitcoin-rpc-no-history'):
         rpc_host = _config.get("BLOCKCHAIN", "rpc_host")
         rpc_port = _config.get("BLOCKCHAIN", "rpc_port")
         rpc_user, rpc_password = get_bitcoin_rpc_credentials(_config)
@@ -530,8 +532,12 @@ def get_blockchain_interface_instance(_config):
             rpc_wallet_file)
         if source == 'bitcoin-rpc': #pragma: no cover
             bc_interface = BitcoinCoreInterface(rpc, network)
-        else:
+        elif source == 'regtest':
             bc_interface = RegtestBitcoinCoreInterface(rpc)
+        elif source == "bitcoin-rpc-no-history":
+            bc_interface = BitcoinCoreNoHistoryInterface(rpc, network)
+        else:
+            assert 0
     elif source == 'electrum':
         bc_interface = ElectrumWalletInterface(testnet)
     elif source == 'electrum-server':

--- a/jmclient/test/test_core_nohistory_sync.py
+++ b/jmclient/test/test_core_nohistory_sync.py
@@ -1,0 +1,51 @@
+#! /usr/bin/env python
+from __future__ import (absolute_import, division,
+                        print_function, unicode_literals)
+from builtins import * # noqa: F401
+'''Wallet functionality tests.'''
+
+"""BitcoinCoreNoHistoryInterface functionality tests."""
+
+from commontest import create_wallet_for_sync
+
+import pytest
+from jmbase import get_log
+from jmclient import load_program_config
+
+log = get_log()
+
+def test_fast_sync_unavailable(setup_sync):
+    load_program_config(bs="bitcoin-rpc-no-history")
+    wallet_service = create_wallet_for_sync([0, 0, 0, 0, 0],
+        ['test_fast_sync_unavailable'])
+    with pytest.raises(RuntimeError) as e_info:
+        wallet_service.sync_wallet(fast=True)
+
+@pytest.mark.parametrize('internal', (False, True))
+def test_sync(setup_sync, internal):
+    load_program_config(bs="bitcoin-rpc-no-history")
+    used_count = [1, 3, 6, 2, 23]
+    wallet_service = create_wallet_for_sync(used_count, ['test_sync'],
+        populate_internal=internal)
+    ##the gap limit should be not zero before sync
+    assert wallet_service.gap_limit > 0
+    for md in range(len(used_count)):
+        ##obtaining an address should be possible without error before sync
+        wallet_service.get_new_script(md, internal)
+
+    wallet_service.sync_wallet(fast=False)
+
+    for md in range(len(used_count)):
+        ##plus one to take into account the one new script obtained above
+        assert used_count[md] + 1 == wallet_service.get_next_unused_index(md,
+            internal)
+    #gap limit is zero after sync
+    assert wallet_service.gap_limit == 0
+    #obtaining an address leads to an error after sync
+    with pytest.raises(RuntimeError) as e_info:
+        wallet_service.get_new_script(0, internal)
+
+
+@pytest.fixture(scope='module')
+def setup_sync():
+    pass


### PR DESCRIPTION
No-history is a method for synchronizing a wallet by scanning the UTXO
set. It can be useful for checking whether seed phrase backups have
money on them before committing the time and effort required to
rescanning the blockchain. No-history sync is compatible with pruning.
The sync method cannot tell which empty addresses have been used, so
cannot guarentee avoidance of address reuse. For this reason no-history
sync disables wallet address generation and can only be used with
wallet-tool and for sending coinjoins without change addresses.

This PR can be easily tested by setting `blockchain_source = bitcoin-rpc-no-history`, importing a seed phrase to create a new wallet file (with `$ python3 wallet-tool.py recover`) then running `$ python3 wallet-tool.py --recoversync -g 500 newwalletfile.jmdat` and checking that all your money appears. Make sure to increase the gap limit to an appropriate value so that all the addresses which might have coin on them are scanned.