### PR TITLE
Qt: "Show QR code" only for "new" addresses

### DIFF
--- a/scripts/joinmarket-qt.py
+++ b/scripts/joinmarket-qt.py
@@ -1171,8 +1171,10 @@ class JMWalletTab(QWidget):
         if address_valid:
             menu.addAction("Copy address to clipboard",
                            lambda: app.clipboard().setText(txt))
-            menu.addAction("Show QR code",
-                           lambda: self.openQRCodePopup(txt))
+            # Show QR code option only for new addresses to avoid address reuse
+            if item.text(3) == "new":
+                menu.addAction("Show QR code",
+                               lambda: self.openQRCodePopup(txt))
         if xpub_exists:
             menu.addAction("Copy extended pubkey to clipboard",
                            lambda: app.clipboard().setText(xpub))


### PR DESCRIPTION
To avoid address reuse. In theory QR code can be used to just copy address to different device, but in practice everybody uses it for sending coins to address.