### PR TITLE
Add --version option to cli scripts

### DIFF
--- a/jmbase/jmbase/support.py
+++ b/jmbase/jmbase/support.py
@@ -1,8 +1,10 @@
 
-import logging
+import logging, sys
 from getpass import getpass
 from os import path, environ
-import sys
+
+# JoinMarket version
+JM_CORE_VERSION = '0.6.2'
 
 # global Joinmarket constants
 JM_WALLET_NAME_PREFIX = "joinmarket-wallet-"
@@ -144,3 +146,7 @@ def lookup_appdata_folder(appname):
     else:
         data_folder = path.expanduser(path.join("~", "." + appname + "/"))
     return data_folder
+
+def print_jm_version(option, opt_str, value, parser):
+    print("JoinMarket " + JM_CORE_VERSION)
+    sys.exit(EXIT_SUCCESS)

--- a/jmclient/jmclient/cli_options.py
+++ b/jmclient/jmclient/cli_options.py
@@ -6,6 +6,7 @@ from configparser import NoOptionError
 import jmclient.support
 from jmbase import JM_APP_NAME
 from jmclient import jm_single, RegtestBitcoinCoreInterface, cryptoengine
+from jmbase.support import print_jm_version
 
 """This exists as a separate module for two reasons:
 to reduce clutter in main scripts, and refactor out
@@ -46,6 +47,10 @@ def add_base_options(parser):
                       default=False,
                       dest='wallet_password_stdin',
                       help='Read wallet password from stdin')
+    parser.add_option('--version',
+                      action='callback',
+                      callback=print_jm_version,
+                      help='Print JoinMarket version and exit.')
 
 def add_common_options(parser):
     add_base_options(parser)

--- a/scripts/joinmarket-qt.py
+++ b/scripts/joinmarket-qt.py
@@ -41,6 +41,7 @@ else:
     MONOSPACE_FONT = 'monospace'
 
 import jmbitcoin as btc
+from jmbase.support import JM_CORE_VERSION
 
 # This is required to change the decimal separator
 # to '.' regardless of the locale; TODO don't require
@@ -60,8 +61,6 @@ donation_address = "1AZgQZWYRteh6UyF87hwuvyWj73NvWKpL"
 donation_address_sw = "bc1q5x02zqj5nshw0yhx2s4tj75z6vkvuvww26jak5"
 donation_address_url = "https://bitcoinprivacy.me/joinmarket-donations"
 
-#Underlying joinmarket code version (as per setup.py etc.)
-JM_CORE_VERSION = '0.6.2'
 #Version of this Qt script specifically
 JM_GUI_VERSION = '12'
 


### PR DESCRIPTION
As was discussed in IRC. Could help troubleshooting, so that users can always check what version they are running easy way.

But we need to remember setting `JM_CORE_VERSION` not only when releasing, but also add some suffix to it afterwards, so that we know it's not exact release version (I added `-dirty`, it's up for discussion). Tagging @AdamISZ , as he is doing releases.

Maybe it could be automated somehow to show commit hash if JM is ran from the git cloned repo dir?

Don't like duplication in `jmclient/jmclient/wallet_utils.py` and `scripts/cli_options.py`, but that's out of the scope of this PR.