### PR TITLE
Don't allow receive-payjoin start up without coins

### DIFF
--- a/scripts/receive-payjoin.py
+++ b/scripts/receive-payjoin.py
@@ -77,6 +77,12 @@ def receive_payjoin_main(makerclass):
     while not wallet_service.synced:
         wallet_service.sync_wallet(fast=not options.recoversync)
     wallet_service.startService()
+    # having enforced wallet sync, we can check if we have coins
+    # to do payjoin in the mixdepth
+    if wallet_service.get_balance_by_mixdepth()[options.mixdepth] == 0:
+        jlog.error("Cannot do payjoin from mixdepth " + str(
+            options.mixdepth) + ", no coins. Shutting down.")
+        sys.exit(EXIT_ARGERROR)
 
     maker = makerclass(wallet_service, options.mixdepth, receiving_amount)
     


### PR DESCRIPTION
Fixes #459. If the mixdepth chosen is empty, shutdown
immediately with ARGERROR. User can either choose a
different mixdepth and try again, or receive payment
another way.