### PR TITLE
Add 'no-blockchain' blockchain_source option.

### DIFF
--- a/jmclient/jmclient/configure.py
+++ b/jmclient/jmclient/configure.py
@@ -107,9 +107,13 @@ daemon_host = localhost
 use_ssl = false
 
 [BLOCKCHAIN]
-#options: bitcoin-rpc, regtest, bitcoin-rpc-no-history
-# when using bitcoin-rpc-no-history remember to increase the gap limit to scan for more addresses, try -g 5000
+# options: bitcoin-rpc, regtest, bitcoin-rpc-no-history, no-blockchain
+# When using bitcoin-rpc-no-history remember to increase the gap limit to scan for more addresses, try -g 5000
+# Use 'no-blockchain' to run the ob-watcher.py script in scripts/obwatch without current access
+# to Bitcoin Core; note that use of this option for any other purpose is currently unsupported.
 blockchain_source = bitcoin-rpc
+# options: testnet, mainnet
+# Note: for regtest, use network = testnet
 network = mainnet
 rpc_host = localhost
 rpc_port = 8332
@@ -528,7 +532,6 @@ def get_blockchain_interface_instance(_config):
     from jmclient.blockchaininterface import BitcoinCoreInterface, \
         RegtestBitcoinCoreInterface, ElectrumWalletInterface, \
         BitcoinCoreNoHistoryInterface
-    from jmclient.electruminterface import ElectrumInterface
     source = _config.get("BLOCKCHAIN", "blockchain_source")
     network = get_network()
     testnet = network == 'testnet'
@@ -549,8 +552,8 @@ def get_blockchain_interface_instance(_config):
             assert 0
     elif source == 'electrum':
         bc_interface = ElectrumWalletInterface(testnet)
-    elif source == 'electrum-server':
-        bc_interface = ElectrumInterface(testnet) #can specify server, config, TODO
+    elif source == 'no-blockchain':
+        bc_interface = None
     else:
         raise ValueError("Invalid blockchain source")
     return bc_interface

--- a/scripts/joinmarket-qt.py
+++ b/scripts/joinmarket-qt.py
@@ -1813,6 +1813,15 @@ except Exception as e:
              ])
     JMQtMessageBox(None, config_load_error, mbtype='crit', title='failed to load')
     exit(1)
+# Qt does not currently support any functioning without a Core interface:
+if jm_single().bc_interface is None:
+    blockchain_error = ''.join(["Joinmarket-Qt requires Bitcoin Core as a blockchain ",
+                                "interface; change the setting of 'blockchain_source' ",
+                                "in the joinmarket.cfg file to a value not equal to ",
+                                "'no-blockchain'; see comments for details."])
+    JMQtMessageBox(None, blockchain_error, mbtype='crit',
+                   title='Invalid blockchain source')
+    exit(1)
 #refuse to load non-segwit wallet (needs extra work in wallet-utils).
 if not jm_single().config.get("POLICY", "segwit") == "true":
     wallet_load_error = ''.join(["Joinmarket-Qt only supports segwit based wallets, ",


### PR DESCRIPTION
This is intended primarily to support running the
ob-watcher.py script from any environment that has no
blockchain access.
It could be used in debug and possibly recovery scenarios,
but this is explicitly unsupported (see comments in config).