### PR TITLE
Qt: Only show wallet sync in status bar at start

### DIFF
--- a/scripts/joinmarket-qt.py
+++ b/scripts/joinmarket-qt.py
@@ -1292,6 +1292,10 @@ class JMMainWindow(QMainWindow):
         # the walletservice to update the GUI
         self.walletRefresh = None
 
+        # keep track of whether wallet sync message
+        # was already shown
+        self.syncmsg = ""
+
         self.reactor = reactor
         self.initUI()
 
@@ -1631,13 +1635,15 @@ class JMMainWindow(QMainWindow):
     def updateWalletInfo(self):
         t = self.centralWidget().widget(0)
         if not self.wallet_service:  #failure to sync in constructor means object is not created
-            newstmsg = "Unable to sync wallet - see error in console."
+            newsyncmsg = "Unable to sync wallet - see error in console."
         elif not self.wallet_service.synced:
             return
         else:
             t.updateWalletInfo(get_wallet_printout(self.wallet_service))
-            newstmsg = "Wallet synced successfully."
-        self.statusBar().showMessage(newstmsg)
+            newsyncmsg = "Wallet synced successfully."
+        if newsyncmsg != self.syncmsg:
+            self.syncmsg = newsyncmsg
+            self.statusBar().showMessage(self.syncmsg)
 
     def generateWallet(self):
         log.debug('generating wallet')


### PR DESCRIPTION
In refactor for #359 it was noted that the wallet
monitoring loop in Qt updated the status bar every
5 seconds, overwriting any existing status updates.
This fixes that UI bug so that the wallet synced
successfully (or unsucessfully) message is only shown
at start up or if there is a change of status (i.e.
the wallet monitoring loop stops working).