### PR TITLE
Fix unwanted display of privkeys in GUI

### DIFF
--- a/scripts/joinmarket-qt.py
+++ b/scripts/joinmarket-qt.py
@@ -1776,8 +1776,7 @@ def get_wallet_printout(wallet_service):
     xpubs: [[xpubext, xpubint], ...]
     Bitcoin amounts returned are in btc, not satoshis
     """
-    walletview = wallet_display(wallet_service, jm_single().config.getint("GUI",
-                                            "gaplimit"), False, serialized=False)
+    walletview = wallet_display(wallet_service, False, serialized=False)
     rows = []
     mbalances = []
     xpubs = []


### PR DESCRIPTION
Bug introduced with cbf69c6a601edee2e69d31c92733ec1f3bb31e86 (#444) when `gap_limit` parameter was removed from `wallet_display()`. As a result they were added to used/new address status string, which caused QR code functionality to stop working after #448 was merged (all testing there was done against old master, before merging of #444).