### PR TITLE
Qt: Retry in selectWallet() only on non-fatal errors

### DIFF
--- a/jmclient/jmclient/__init__.py
+++ b/jmclient/jmclient/__init__.py
@@ -18,7 +18,7 @@ from .wallet import (Mnemonic, estimate_tx_fee, WalletError, BaseWallet, ImportW
                      BIP39WalletMixin, BIP32Wallet, BIP49Wallet, LegacyWallet,
                      SegwitWallet, SegwitLegacyWallet, UTXOManager,
                      WALLET_IMPLEMENTATIONS)
-from .storage import (Argon2Hash, Storage, StorageError,
+from .storage import (Argon2Hash, Storage, StorageError, RetryableStorageError,
                       StoragePasswordError, VolatileStorage)
 from .cryptoengine import BTCEngine, BTC_P2PKH, BTC_P2SH_P2WPKH, EngineError
 from .configure import (load_test_config,

--- a/jmclient/jmclient/storage.py
+++ b/jmclient/jmclient/storage.py
@@ -46,7 +46,11 @@ class StorageError(Exception):
     pass
 
 
-class StoragePasswordError(StorageError):
+class RetryableStorageError(StorageError):
+    pass
+
+
+class StoragePasswordError(RetryableStorageError):
     pass
 
 
@@ -185,7 +189,7 @@ class Storage(object):
 
         if magic == self.MAGIC_ENC:
             if password is None:
-                raise StorageError("Password required to open wallet.")
+                raise RetryableStorageError("Password required to open wallet.")
             data = self._decrypt_file(password, data)
         else:
             assert magic == self.MAGIC_UNENC
@@ -286,7 +290,8 @@ class Storage(object):
             with open(self._lock_file, 'r') as f:
                 locked_by_pid = f.read()
             self._lock_file = None
-            raise StorageError("File is currently in use (locked by pid {}). "
+            raise RetryableStorageError(
+                               "File is currently in use (locked by pid {}). "
                                "If this is a leftover from a crashed instance "
                                "you need to remove the lock file `{}` manually." .
                                format(locked_by_pid, lock_filename))

--- a/jmclient/jmclient/wallet_utils.py
+++ b/jmclient/jmclient/wallet_utils.py
@@ -1152,7 +1152,7 @@ def open_wallet(path, ask_for_password=True, password=None, read_only=False,
     if not Storage.is_storage_file(path):
         raise Exception("Failed to open wallet at '{}': not a valid joinmarket"
                         " wallet.\n\nIf this wallet is in the old json format "
-                        "you need to convert it using the conversion script"
+                        "you need to convert it using the conversion script "
                         "at `scripts/convert_old_wallet.py`".format(path))
 
     if ask_for_password and Storage.is_encrypted_storage_file(path):

--- a/scripts/joinmarket-qt.py
+++ b/scripts/joinmarket-qt.py
@@ -76,7 +76,7 @@ from jmclient import load_program_config, get_network, update_persist_config,\
     get_tumble_log, restart_wait, tumbler_filter_orders_callback,\
     wallet_generate_recover_bip39, wallet_display, get_utxos_enabled_disabled,\
     NO_ROUNDING, get_max_cj_fee_values, get_default_max_absolute_fee, \
-    get_default_max_relative_fee
+    get_default_max_relative_fee, RetryableStorageError
 from qtsupport import ScheduleWizard, TumbleRestartWizard, config_tips,\
     config_types, QtHandler, XStream, Buttons, OkButton, CancelButton,\
     PasswordDialog, MyTreeWidget, JMQtMessageBox, BLUE_FG,\
@@ -1578,7 +1578,14 @@ class JMMainWindow(QMainWindow):
                 if not ok:
                     return
                 pwd = str(text).strip()
-                decrypted = self.loadWalletFromBlockchain(firstarg[0], pwd)
+                try:
+                    decrypted = self.loadWalletFromBlockchain(firstarg[0], pwd)
+                except Exception as e:
+                    JMQtMessageBox(self,
+                               str(e),
+                               mbtype='warn',
+                               title="Error")
+                    return
         else:
             if not testnet_seed:
                 testnet_seed, ok = QInputDialog.getText(self,
@@ -1599,7 +1606,7 @@ class JMMainWindow(QMainWindow):
                 wallet = open_test_wallet_maybe(wallet_path, str(firstarg),
                         None, ask_for_password=False, password=pwd.encode('utf-8') if pwd else None,
                         gap_limit=jm_single().config.getint("GUI", "gaplimit"))
-            except Exception as e:
+            except RetryableStorageError as e:
                 JMQtMessageBox(self,
                                str(e),
                                mbtype='warn',


### PR DESCRIPTION
There is no point in asking for password again and retrying on fatal errors, like invalid wallet file format or wrong wallet network (mainnet vs testnet).