### PR TITLE
Add loop in the CLI for freezing UTXOs

### DIFF
--- a/jmclient/jmclient/wallet_utils.py
+++ b/jmclient/jmclient/wallet_utils.py
@@ -980,6 +980,7 @@ def display_utxos_for_disable_choice_default(utxos_enabled, utxos_disabled):
             start += 1
             yield txid, idx
 
+    jmprint("List of UTXOs:")
     ulist = list(output_utxos(utxos_disabled, 'FROZEN'))
     disabled_max = len(ulist) - 1
     ulist.extend(output_utxos(utxos_enabled, 'NOT FROZEN', start=len(ulist)))
@@ -1032,22 +1033,23 @@ def wallet_freezeutxo(wallet, md, display_callback=None, info_callback=None):
     if md is None:
         info_callback("Specify the mixdepth with the -m flag", "error")
         return "Failed"
-    utxos_enabled, utxos_disabled = get_utxos_enabled_disabled(wallet, md)
-    if utxos_disabled == {} and utxos_enabled == {}:
-        info_callback("The mixdepth: " + str(md) + \
-            " contains no utxos to freeze/unfreeze.", "error")
-        return "Failed"
-    display_ret = display_callback(utxos_enabled, utxos_disabled)
-    if display_ret is None:
-        return "OK"
-    (txid, index), disable = display_ret
-    wallet.disable_utxo(txid, index, disable)
-    if disable:
-        info_callback("Utxo: {} is now frozen and unavailable for spending."
-                      .format(fmt_utxo((txid, index))))
-    else:
-        info_callback("Utxo: {} is now unfrozen and available for spending."
-                      .format(fmt_utxo((txid, index))))
+    while True:
+        utxos_enabled, utxos_disabled = get_utxos_enabled_disabled(wallet, md)
+        if utxos_disabled == {} and utxos_enabled == {}:
+            info_callback("The mixdepth: " + str(md) + \
+                " contains no utxos to freeze/unfreeze.", "error")
+            return "Failed"
+        display_ret = display_callback(utxos_enabled, utxos_disabled)
+        if display_ret is None:
+            break
+        (txid, index), disable = display_ret
+        wallet.disable_utxo(txid, index, disable)
+        if disable:
+            info_callback("Utxo: {} is now frozen and unavailable for spending."
+                          .format(fmt_utxo((txid, index))))
+        else:
+            info_callback("Utxo: {} is now unfrozen and available for spending."
+                          .format(fmt_utxo((txid, index))))
     return "Done"
 
 def get_wallet_type():


### PR DESCRIPTION
Prior to this commit the wallet-tool (un)freeze tool would only
allow a single freeze or unfreeze per run. So a user intending
to (un)freeze several UTXOs would have to run the script several
times which would be slow due to the need to sync the wallet
many times.

See also the discussion in: http://gnusha.org/joinmarket/2020-01-09.log


Following a discussion on IRC the other day I realized this feature would be very quick to code and also useful.

Sample run:
```
$ python3 wallet-tool.py --datadir=. -m 0 taker.jmdat freeze
User data location: .
2020-01-10 12:38:03,885 [DEBUG]  rpc: getnewaddress []
Enter wallet decryption passphrase: 
2020-01-10 12:38:06,139 [DEBUG]  rpc: listaddressgroupings []
2020-01-10 12:38:06,140 [DEBUG]  Fast sync in progress. Got this many used addresses: 2
2020-01-10 12:38:12,238 [DEBUG]  rpc: listunspent [0]
2020-01-10 12:38:12,241 [DEBUG]  bitcoind sync_unspent took 0.004178524017333984sec
List of UTXOs:
   0: f03faf708440e6af24d2fa5112d73bfa14dd0f030424b2defee43fa07a0bee33:1  : 200000000 sats, -- NOT FROZEN
   1: 82ba534c2a9ddba4cb4eef9f31d1970002c30a05a93566b00b8efcad7874ea06:0  : 100000000 sats, -- NOT FROZEN
Choose an index 0 .. 1 to freeze/unfreeze or -1 to just quit.
0
Utxo: f03faf708440e6af24d2fa5112d73bfa14dd0f030424b2defee43fa07a0bee33:1 is now frozen and unavailable for spending.
List of UTXOs:
   0: f03faf708440e6af24d2fa5112d73bfa14dd0f030424b2defee43fa07a0bee33:1  : 200000000 sats, -- FROZEN
   1: 82ba534c2a9ddba4cb4eef9f31d1970002c30a05a93566b00b8efcad7874ea06:0  : 100000000 sats, -- NOT FROZEN
Choose an index 0 .. 1 to freeze/unfreeze or -1 to just quit.
0
Utxo: f03faf708440e6af24d2fa5112d73bfa14dd0f030424b2defee43fa07a0bee33:1 is now unfrozen and available for spending.
List of UTXOs:
   0: f03faf708440e6af24d2fa5112d73bfa14dd0f030424b2defee43fa07a0bee33:1  : 200000000 sats, -- NOT FROZEN
   1: 82ba534c2a9ddba4cb4eef9f31d1970002c30a05a93566b00b8efcad7874ea06:0  : 100000000 sats, -- NOT FROZEN
Choose an index 0 .. 1 to freeze/unfreeze or -1 to just quit.
0
Utxo: f03faf708440e6af24d2fa5112d73bfa14dd0f030424b2defee43fa07a0bee33:1 is now frozen and unavailable for spending.
List of UTXOs:
   0: f03faf708440e6af24d2fa5112d73bfa14dd0f030424b2defee43fa07a0bee33:1  : 200000000 sats, -- FROZEN
   1: 82ba534c2a9ddba4cb4eef9f31d1970002c30a05a93566b00b8efcad7874ea06:0  : 100000000 sats, -- NOT FROZEN
Choose an index 0 .. 1 to freeze/unfreeze or -1 to just quit.
1
Utxo: 82ba534c2a9ddba4cb4eef9f31d1970002c30a05a93566b00b8efcad7874ea06:0 is now frozen and unavailable for spending.
List of UTXOs:
   0: f03faf708440e6af24d2fa5112d73bfa14dd0f030424b2defee43fa07a0bee33:1  : 200000000 sats, -- FROZEN
   1: 82ba534c2a9ddba4cb4eef9f31d1970002c30a05a93566b00b8efcad7874ea06:0  : 100000000 sats, -- FROZEN
Choose an index 0 .. 1 to freeze/unfreeze or -1 to just quit.
0 
Utxo: f03faf708440e6af24d2fa5112d73bfa14dd0f030424b2defee43fa07a0bee33:1 is now unfrozen and available for spending.
List of UTXOs:
   0: 82ba534c2a9ddba4cb4eef9f31d1970002c30a05a93566b00b8efcad7874ea06:0  : 100000000 sats, -- FROZEN
   1: f03faf708440e6af24d2fa5112d73bfa14dd0f030424b2defee43fa07a0bee33:1  : 200000000 sats, -- NOT FROZEN
Choose an index 0 .. 1 to freeze/unfreeze or -1 to just quit.
0
Utxo: 82ba534c2a9ddba4cb4eef9f31d1970002c30a05a93566b00b8efcad7874ea06:0 is now unfrozen and available for spending.
List of UTXOs:
   0: f03faf708440e6af24d2fa5112d73bfa14dd0f030424b2defee43fa07a0bee33:1  : 200000000 sats, -- NOT FROZEN
   1: 82ba534c2a9ddba4cb4eef9f31d1970002c30a05a93566b00b8efcad7874ea06:0  : 100000000 sats, -- NOT FROZEN
Choose an index 0 .. 1 to freeze/unfreeze or -1 to just quit.
-1
Done
$ python3 wallet-tool.py --datadir=. -m 1 taker.jmdat freeze
User data location: .
2020-01-10 12:42:43,756 [DEBUG]  rpc: getnewaddress []
Enter wallet decryption passphrase: 
2020-01-10 12:42:45,587 [DEBUG]  rpc: listaddressgroupings []
2020-01-10 12:42:45,588 [DEBUG]  Fast sync in progress. Got this many used addresses: 2
2020-01-10 12:42:52,739 [DEBUG]  rpc: listunspent [0]
2020-01-10 12:42:52,742 [DEBUG]  bitcoind sync_unspent took 0.004225254058837891sec
The mixdepth: 1 contains no utxos to freeze/unfreeze.
Failed
```