### PR TITLE
[Refactor] Fix get_script_path and get_addr_path

### DIFF
--- a/jmclient/jmclient/electruminterface.py
+++ b/jmclient/jmclient/electruminterface.py
@@ -354,7 +354,7 @@ class ElectrumInterface(BlockchainInterface):
                 for index in range(wallet.get_next_unused_index(md, internal)):
                     addrs.add(wallet.get_addr(md, internal, index))
             for path in wallet.yield_imported_paths(md):
-                addrs.add(wallet.get_addr_path(path))
+                addrs.add(wallet.get_address_from_path(path))
 
         self.listunspent_calls = len(addrs)
         for a in addrs:

--- a/jmclient/jmclient/wallet_service.py
+++ b/jmclient/jmclient/wallet_service.py
@@ -735,7 +735,7 @@ class WalletService(Service):
                 saved_indices[md][internal] = next_unused
             # include any imported addresses
             for path in self.yield_imported_paths(md):
-                addresses.add(self.get_addr_path(path))
+                addresses.add(self.get_address_from_path(path))
 
         return addresses, saved_indices
 

--- a/jmclient/jmclient/wallet_utils.py
+++ b/jmclient/jmclient/wallet_utils.py
@@ -330,8 +330,8 @@ def get_tx_info(txid):
 def get_imported_privkey_branch(wallet_service, m, showprivkey):
     entries = []
     for path in wallet_service.yield_imported_paths(m):
-        addr = wallet_service.get_addr_path(path)
-        script = wallet_service.get_script_path(path)
+        addr = wallet_service.get_address_from_path(path)
+        script = wallet_service.get_script_from_path(path)
         balance = 0.0
         for data in wallet_service.get_utxos_by_mixdepth(include_disabled=True,
                                              hexfmt=False)[m].values():
@@ -432,7 +432,7 @@ def wallet_display(wallet_service, showprivkey, displayall=False,
             unused_index = wallet_service.get_next_unused_index(m, forchange)
             for k in range(unused_index + wallet_service.gap_limit):
                 path = wallet_service.get_path(m, forchange, k)
-                addr = wallet_service.get_addr_path(path)
+                addr = wallet_service.get_address_from_path(path)
                 balance, used = get_addr_status(
                     path, utxos[m], k >= unused_index, forchange)
                 if showprivkey:
@@ -637,7 +637,7 @@ def wallet_fetch_history(wallet, options):
         'FROM transactions '
         'WHERE (blockhash IS NOT NULL AND blocktime IS NOT NULL) OR conflicts = 0 '
         'ORDER BY blocktime').fetchall()
-    wallet_script_set = set(wallet.get_script_path(p)
+    wallet_script_set = set(wallet.get_script_from_path(p)
                             for p in wallet.yield_known_paths())
 
     def s():
@@ -915,7 +915,7 @@ def wallet_importprivkey(wallet, mixdepth, key_type):
             print("Failed to import key {}: {}".format(wif, e))
             import_failed += 1
         else:
-            imported_addr.append(wallet.get_addr_path(path))
+            imported_addr.append(wallet.get_address_from_path(path))
 
     if not imported_addr:
         jmprint("Warning: No keys imported!", "error")

--- a/jmclient/test/test_wallet.py
+++ b/jmclient/test/test_wallet.py
@@ -277,8 +277,8 @@ def test_import_key(setup_wallet):
     assert len(imported_paths_md1) == 1
 
     # verify imported addresses
-    assert wallet.get_addr_path(imported_paths_md0[0]) == '2MzY5yyonUY7zpHspg7jB7WQs1uJxKafQe4'
-    assert wallet.get_addr_path(imported_paths_md1[0]) == 'mpCX9EbdXpcrKMtjEe1fqFhvzctkfzMYTX'
+    assert wallet.get_address_from_path(imported_paths_md0[0]) == '2MzY5yyonUY7zpHspg7jB7WQs1uJxKafQe4'
+    assert wallet.get_address_from_path(imported_paths_md1[0]) == 'mpCX9EbdXpcrKMtjEe1fqFhvzctkfzMYTX'
 
     # test remove key
     wallet.remove_imported_key(path=imported_paths_md0[0])
@@ -301,10 +301,10 @@ def test_signing_imported(setup_wallet, wif, keytype, type_check):
 
     MIXDEPTH = 0
     path = wallet.import_private_key(MIXDEPTH, wif, keytype)
-    utxo = fund_wallet_addr(wallet, wallet.get_addr_path(path))
+    utxo = fund_wallet_addr(wallet, wallet.get_address_from_path(path))
     tx = btc.deserialize(btc.mktx(['{}:{}'.format(hexlify(utxo[0]).decode('ascii'), utxo[1])],
                                   ['00'*17 + ':' + str(10**8 - 9000)]))
-    script = wallet.get_script_path(path)
+    script = wallet.get_script_from_path(path)
     tx = wallet.sign_tx(tx, {0: (script, 10**8)})
     type_check(tx)
     txout = jm_single().bc_interface.pushtx(btc.serialize(tx))
@@ -580,7 +580,7 @@ def test_addr_script_conversion(setup_wallet):
     wallet = get_populated_wallet(num=1)
 
     path = wallet.get_path(0, True, 0)
-    script = wallet.get_script_path(path)
+    script = wallet.get_script_from_path(path)
     addr = wallet.script_to_addr(script)
 
     assert script == wallet.addr_to_script(addr)
@@ -597,14 +597,14 @@ def test_imported_key_removed(setup_wallet):
     wallet = SegwitLegacyWallet(storage)
 
     path = wallet.import_private_key(1, wif, key_type)
-    script = wallet.get_script_path(path)
+    script = wallet.get_script_from_path(path)
     assert wallet.is_known_script(script)
 
     wallet.remove_imported_key(path=path)
     assert not wallet.is_known_script(script)
 
     with pytest.raises(WalletError):
-        wallet.get_script_path(path)
+        wallet.get_script_from_path(path)
 
 
 def test_wallet_mixdepth_simple(setup_wallet):


### PR DESCRIPTION
Those names as confusing. They could imply that the function obtains
a path or address given a script. To help the code be more
self-documenting I add the verb from.

I'm reading in detail parts of the wallet code now, and refactoring things as I go. This function name tripped me up earlier. A project’s long-term success rests (among other things) on its maintainability, so I believe this is worth doing.