### PR TITLE
Get rid of most of direct rpc() calls outside blockchaininterface

### DIFF
--- a/jmclient/jmclient/blockchaininterface.py
+++ b/jmclient/jmclient/blockchaininterface.py
@@ -275,11 +275,12 @@ class BitcoinCoreInterface(BlockchainInterface):
         hexval = str(rpcretval["hex"])
         return btc.deserialize(hexval)
 
-    def list_transactions(self, num):
+    def list_transactions(self, num, skip=0):
         """ Return a list of the last `num` transactions seen
-        in the wallet (under any label/account).
+        in the wallet (under any label/account), optionally
+        skipping some.
         """
-        return self.rpc("listtransactions", ["*", num, 0, True])
+        return self.rpc("listtransactions", ["*", num, skip, True])
 
     def get_transaction(self, txid):
         """ Returns a serialized transaction for txid txid,
@@ -389,7 +390,17 @@ class BitcoinCoreInterface(BlockchainInterface):
         return int(Decimal(1e8) * Decimal(estimate))
 
     def get_current_block_height(self):
-        return self.rpc("getblockchaininfo", [])["blocks"]
+        return self.rpc("getblockcount", [])
+
+    def get_best_block_hash(self):
+        return self.rpc('getbestblockhash', [])
+
+    def get_block_time(self, blockhash):
+        try:
+            # works with pruning enabled, but only after v0.12
+            return self.rpc('getblockheader', [blockhash])['time']
+        except JsonRpcError:
+            return self.rpc('getblock', [blockhash])['time']
 
 
 class RegtestBitcoinCoreMixin():

--- a/jmclient/jmclient/taker_utils.py
+++ b/jmclient/jmclient/taker_utils.py
@@ -131,14 +131,8 @@ def restart_wait(txid):
     and confirmed (it must be an in-wallet transaction since it always
     spends coins from the wallet).
     """
-    try:
-        res = jm_single().bc_interface.rpc('gettransaction', [txid, True])
-    except JsonRpcError as e:
-        return False
+    res = jm_single().bc_interface.get_transaction(txid)
     if not res:
-        return False
-    if "confirmations" not in res:
-        log.debug("Malformed gettx result: " + str(res))
         return False
     if res["confirmations"] == 0:
         return False

--- a/jmclient/jmclient/wallet_service.py
+++ b/jmclient/jmclient/wallet_service.py
@@ -70,7 +70,7 @@ class WalletService(Service):
         the right height.
         """
         try:
-            self.current_blockheight = self.bci.rpc("getblockcount", [])
+            self.current_blockheight = self.bci.get_current_block_height()
             assert isinstance(self.current_blockheight, Integral)
         except Exception as e:
             jlog.error("Failure to get blockheight from Bitcoin Core:")
@@ -578,7 +578,7 @@ class WalletService(Service):
     def sync_unspent(self):
         st = time.time()
         # block height needs to be real time for addition to our utxos:
-        current_blockheight = self.bci.rpc("getblockcount", [])
+        current_blockheight = self.bci.get_current_block_height()
         wallet_name = self.get_wallet_name()
         self.reset_utxos()
 

--- a/jmclient/test/test_wallet.py
+++ b/jmclient/test/test_wallet.py
@@ -50,7 +50,7 @@ def get_populated_wallet(amount=10**8, num=3):
 
 def fund_wallet_addr(wallet, addr, value_btc=1):
     txin_id = jm_single().bc_interface.grab_coins(addr, value_btc)
-    txinfo = jm_single().bc_interface.rpc('gettransaction', [txin_id])
+    txinfo = jm_single().bc_interface.get_transaction(txin_id)
     txin = btc.deserialize(unhexlify(txinfo['hex']))
     utxo_in = wallet.add_new_utxos_(txin, unhexlify(txin_id), 1)
     assert len(utxo_in) == 1


### PR DESCRIPTION
The ones still left are `testmempoolaccept`, `listaddressgroupings` and `listunspent`. Will look at them at some point later, if somebody else will not. 