### PR TITLE
Made P2WSH_PRE be the correct value

### DIFF
--- a/jmbitcoin/jmbitcoin/secp256k1_transaction.py
+++ b/jmbitcoin/jmbitcoin/secp256k1_transaction.py
@@ -17,7 +17,7 @@ from jmbitcoin.bech32 import *
 P2PKH_PRE, P2PKH_POST = b'\x76\xa9\x14', b'\x88\xac'
 P2SH_P2WPKH_PRE, P2SH_P2WPKH_POST = b'\xa9\x14', b'\x87'
 P2WPKH_PRE = b'\x00\x14'
-P2WSH_PRE = b'\x00\x16'
+P2WSH_PRE = b'\x00\x20'
 
 # Transaction serialization and deserialization
 


### PR DESCRIPTION
The previous value of '0016' is wrong I believe. It doesnt appear in any literature.

According to BIP141 the options are '0014' for p2wpkh or '0020' for p2wsh.

The tests still pass. The first two bytes of the script are actually never used in any other way right now. It would be interesting to know where the 0x16 value comes from, it's possible I've missed something.