### PR TITLE
Display INFO level log message on estimate_fee_per_kb() with result

### DIFF
--- a/jmbitcoin/jmbitcoin/amount.py
+++ b/jmbitcoin/jmbitcoin/amount.py
@@ -1,7 +1,9 @@
 from decimal import Decimal
 
+
 def btc_to_sat(btc):
     return int(Decimal(btc) * Decimal('1e8'))
+
 
 def sat_to_btc(sat):
     return Decimal(sat) / Decimal('1e8')
@@ -15,6 +17,7 @@ def sat_to_btc(sat):
 # 1.12300000sat = 0.00000001 BTC = 1sat
 # 1btc          = 1.00000000 BTC = 10000000sat
 
+
 def amount_to_sat(amount_str):
     amount_str = str(amount_str)
     if amount_str.lower().endswith("btc"):
@@ -26,21 +29,31 @@ def amount_to_sat(amount_str):
     else:
         return int(Decimal(amount_str))
 
+
 def amount_to_btc(amount_str):
     return amount_to_sat(amount_str) / Decimal('1e8')
+
 
 def amount_to_sat_str(amount_str):
     return str(amount_to_sat(amount_str)) + " sat"
 
+
 def amount_to_btc_str(amount_str):
     return str(amount_to_btc(amount_str)) + " BTC"
 
+
 def amount_to_str(amount_str):
-    return amount_to_btc_str(amount_str) + " (" + amount_to_sat_str(amount_str) + ")"
+    return (amount_to_btc_str(amount_str) + " (" +
+            amount_to_sat_str(amount_str) + ")")
+
 
 def sat_to_str(sat):
     return '%.8f' % sat_to_btc(sat)
 
+
 def sat_to_str_p(sat):
     return '%+.8f' % sat_to_btc(sat)
 
+
+def fee_per_kb_to_str(feerate):
+    return str(feerate) + " sat/vkB (" + str(feerate / 1000) + " sat/vB)"

--- a/jmclient/jmclient/blockchaininterface.py
+++ b/jmclient/jmclient/blockchaininterface.py
@@ -157,8 +157,8 @@ class ElectrumWalletInterface(BlockchainInterface): #pragma: no cover
             return int(max(1000, random.uniform(N * float(0.8), N * float(1.2))))
         fee = self.wallet.network.synchronous_get(('blockchain.estimatefee', [N]
                                                   ))
-        log.debug("Got fee: " + str(fee))
         fee_per_kb_sat = int(float(fee) * 100000000)
+        log.info("Got fee: " + btc.fee_per_kb_to_str(fee_per_kb_sat))
         return fee_per_kb_sat
 
 class BitcoinCoreInterface(BlockchainInterface):
@@ -367,10 +367,12 @@ class BitcoinCoreInterface(BlockchainInterface):
             btc_relayfee = rpc_result.get('relayfee', btc_relayfee)
             if btc_relayfee > 0:
                 relayfee_in_sat = int(Decimal(1e8) * Decimal(btc_relayfee))
-                log.debug("Using this min relay fee as tx fee floor: " + str(relayfee_in_sat))
+                log.info("Using this min relay fee as tx fee floor: " +
+                    btc.fee_per_kb_to_str(relayfee_in_sat))
                 return int(max(relayfee_in_sat, random.uniform(N * float(0.8), N * float(1.2))))
             else:   # cannot get valid relayfee: fall back to 1000 sat/kbyte
-                log.debug("Using this min relay fee as tx fee floor (fallback): 1000")
+                log.info("Using this min relay fee as tx fee floor " +
+                    "(fallback): " + btc.fee_per_kb_to_str(1000))
                 return int(max(1000, random.uniform(N * float(0.8), N * float(1.2))))
 
         # Special bitcoin core case: sometimes the highest priority
@@ -379,14 +381,19 @@ class BitcoinCoreInterface(BlockchainInterface):
         tries = 2 if N == 1 else 1
 
         estimate = -1
+        retval = -1
         for i in range(tries):
             rpc_result = self.rpc('estimatesmartfee', [N + i])
             estimate = rpc_result.get('feerate', estimate)
             if estimate > 0:
                 break
         else:  # estimate <= 0
-            return 10000
-        return int(Decimal(1e8) * Decimal(estimate))
+            retval = 10000
+
+        if retval == -1:
+            retval = int(Decimal(1e8) * Decimal(estimate))
+        log.info("Using tx fee: " + btc.fee_per_kb_to_str(retval))
+        return retval
 
     def get_current_block_height(self):
         return self.rpc("getblockchaininfo", [])["blocks"]


### PR DESCRIPTION
Today I accidentally did a tx with smaller fee than I wanted to, because I forgot that `joinmarket.cfg` is moved from `scripts/` to `~/.joinmarket/` in current master and looked in a wrong file for a current setting. This adds INFO log level message on every call to `estimate_fee_per_kb()`. Very likely with this change I would have noticed wrong tx fee setting before tx was negotiated and broadcast to the network. It displays both sat/vkB and sat/vB values, as first is kinda what JM uses internally, but second one might be the one most people are familiar with. As we are talking about the money here, I do believe it's better to display the same info two different ways than for people to do some mistake.

Also additional minor changes to `jmbitcoin/jmbitcoin/amount.py` to make `pycodestyle` happy (our current code is far from that, but I don't see downside for at least to try to write the new code according to PEP 8 guidelines).