### PR TITLE
Remove nonstandard scripts from test suite

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -113,10 +113,6 @@ def setup(request):
     #start up regtest blockchain
     bitcoin_args = ["-regtest", "-daemon", "-conf=" + bitcoin_conf]
 
-    #for bitcoin-core >= 0.19
-    if not (bitcoind_version[0] == 0 and bitcoind_version[1] < 19):
-        bitcoin_args += ['-acceptnonstdtxn']
-
     btc_proc = subprocess.call([bitcoin_path + "bitcoind"] + bitcoin_args)
     time.sleep(4)
     #generate blocks; segwit activates around block 500-600

--- a/jmclient/test/test_tx_creation.py
+++ b/jmclient/test/test_tx_creation.py
@@ -41,7 +41,8 @@ def test_create_p2sh_output_tx(setup_tx_creation, nw, wallet_structures,
         wallet_service = w['wallet']
         ins_full = wallet_service.select_utxos(0, amount)
         script = bitcoin.mk_multisig_script(pubs, k)
-        output_addr = bitcoin.script_to_address(script, vbyte=196)
+        output_addr = bitcoin.p2sh_scriptaddr(bitcoin.safe_from_hex(script),
+                                              magicbyte=196)
         txid = make_sign_and_push(ins_full,
                                   wallet_service,
                                   amount,


### PR DESCRIPTION
Fixes #477. Removes nonstandard script support
from 0.19+ bitcoind configuration for regtest and
changes scripts in test_wallet and test_tx_creation
to make them standard.