### PR TITLE
Change shebang to python3 and +x for scripts

### DIFF
--- a/scripts/add-utxo.py
+++ b/scripts/add-utxo.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python3
 from future.utils import iteritems
 """A very simple command line tool to import utxos to be used
 as commitments into joinmarket's commitments.json file, allowing

--- a/scripts/convert_old_wallet.py
+++ b/scripts/convert_old_wallet.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import argparse
 import json
 import os.path

--- a/scripts/joinmarket-qt.py
+++ b/scripts/joinmarket-qt.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 from future.utils import iteritems
 
 '''

--- a/scripts/joinmarket-qt.sh
+++ b/scripts/joinmarket-qt.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+cd $(dirname "$0")/.. && \
+source jmvenv/bin/activate && \
+cd scripts && \
+python3 joinmarket-qt.py

--- a/scripts/joinmarketd.py
+++ b/scripts/joinmarketd.py
@@ -1,5 +1,4 @@
-#! /usr/bin/env python
-
+#!/usr/bin/env python3
 import sys
 from twisted.internet import reactor
 from twisted.python.log import startLogging

--- a/scripts/receive-payjoin.py
+++ b/scripts/receive-payjoin.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python3
 
 from optparse import OptionParser
 

--- a/scripts/sendpayment.py
+++ b/scripts/sendpayment.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python3
 
 """
 A sample implementation of a single coinjoin script,

--- a/scripts/sendtomany.py
+++ b/scripts/sendtomany.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python3
 """A simple command line tool to create a bunch
 of utxos from one (thus giving more potential commitments
 for a Joinmarket user, although of course it may be useful

--- a/scripts/tumbler.py
+++ b/scripts/tumbler.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python3
 
 import sys
 from twisted.internet import reactor

--- a/scripts/wallet-tool.py
+++ b/scripts/wallet-tool.py
@@ -1,5 +1,4 @@
-#! /usr/bin/env python
-
+#!/usr/bin/env python3
 from jmbase import jmprint
 from jmclient import wallet_tool_main
 

--- a/scripts/yg-privacyenhanced.py
+++ b/scripts/yg-privacyenhanced.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python3
 from future.utils import iteritems
 
 import random

--- a/scripts/yield-generator-basic.py
+++ b/scripts/yield-generator-basic.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python3
 
 from jmbase import jmprint
 from jmclient import YieldGeneratorBasic, ygmain


### PR DESCRIPTION
Python2 support is dropped after merging #504, so change shebangs to python3 and make all scripts executable (previously there could be problems with python2 vs python3 thing with that). I think `/usr/bin/env python3` should work on every distro, but others could test, I'm not 100% sure.