### PR TITLE
[Refactor] Make explicit args in wallet_generate_recover_bip39

### DIFF
--- a/scripts/joinmarket-qt.py
+++ b/scripts/joinmarket-qt.py
@@ -1548,11 +1548,14 @@ class JMMainWindow(QMainWindow):
 
     def recoverWallet(self):
         try:
-            success = wallet_generate_recover_bip39("recover", "wallets",
-                                                    "wallet.jmdat",
-                                                    callbacks=(None, self.seedEntry,
-                                                           self.getPassword,
-                                                           self.getWalletFileName))
+            success = wallet_generate_recover_bip39(
+                "recover", "wallets", "wallet.jmdat",
+                display_seed_callback=None,
+                enter_seed_callback=self.seedEntry,
+                enter_wallet_password_callback=self.getPassword,
+                enter_wallet_file_name_callback=self.getWalletFileName,
+                enter_if_use_seed_extension=None,
+                enter_seed_extension_callback=None)
             if not success:
                 JMQtMessageBox(self,
                            "Failed to recover wallet.",
@@ -1767,15 +1770,15 @@ class JMMainWindow(QMainWindow):
             try:
                 # guaranteed to exist as load_program_config was called on startup:
                 wallets_path = os.path.join(jm_single().datadir, 'wallets')
-                success = wallet_generate_recover_bip39("generate",
-                                                   wallets_path,
-                                                   "wallet.jmdat",
-                                                   callbacks=(self.displayWords,
-                                                              None,
-                                                              self.getPassword,
-                                                              self.getWalletFileName,
-                                                              self.promptUseMnemonicExtension,
-                                                              self.promptInputMnemonicExtension))
+                success = wallet_generate_recover_bip39(
+                    "generate", wallets_path, "wallet.jmdat",
+                    display_seed_callback=self.displayWords,
+                    enter_seed_callback=None,
+                    enter_wallet_password_callback=self.getPassword,
+                    enter_wallet_file_name_callback=self.getWalletFileName,
+                    enter_if_use_seed_extension=self.promptUseMnemonicExtension,
+                    enter_seed_extension_callback=self.promptInputMnemonicExtension)
+
                 if not success:
                     JMQtMessageBox(self, "Failed to create new wallet file.",
                                    title="Error", mbtype="warn")


### PR DESCRIPTION
Small refactor here of giving names to the callback parameters of `wallet_generate_recover_bip39()`.

Previously the callbacks would be referenced as `callbacks[0]`, `callbacks[1]`, etc. I think giving them explicit names makes the function a bit more readable and self-documenting.

Self-documenting is better than comments/docs because its less likely to go out of date. Note that the doc string of this function was already out of date, because the callback `cli_do_use_mnemonic_extension` was added without the doc string being updated.

I tested this by generating and recovering wallets on CLI and in GUI, with and without the seed extension,

Changing this function is needed for adding fidelity bonds, and I may as well make the refactor edits separate.