### PR TITLE
Add hackint IRC

### DIFF
--- a/jmclient/jmclient/configure.py
+++ b/jmclient/jmclient/configure.py
@@ -149,6 +149,20 @@ socks5_port = 9050
 #usessl = false
 #socks5 = true
 
+[MESSAGING:server3]
+host = irc.hackint.org
+channel = joinmarket-pit
+port = 6697
+usessl = true
+socks5 = false
+socks5_host = localhost
+socks5_port = 9050
+
+#for tor
+#host = ncwkrwxpq2ikcngxq3dy2xctuheniggtqeibvgofixpzvrwpa77tozqd.onion
+#port = 6667
+#usessl = false
+#socks5 = true
 
 
 [LOGGING]


### PR DESCRIPTION
AgoraIRC is not suitable for our purposes. I found hackint
IRC which allows both clearnet and tor connections, and has
many populated channels so will presumably be well-maintained.

I registered all the relevant channels on hackint IRC. We should give the network a try.