### PR TITLE
Fixed path for accessing wallets when receiving payjoin transactions

### DIFF
--- a/scripts/receive-payjoin.py
+++ b/scripts/receive-payjoin.py
@@ -56,7 +56,7 @@ def receive_payjoin_main(makerclass):
     # log.info (via P2EPMaker.user_info).
     set_logging_level("INFO")
 
-    wallet_path = get_wallet_path(wallet_name, 'wallets')
+    wallet_path = get_wallet_path(wallet_name, None)
     max_mix_depth = max([options.mixdepth, options.amtmixdepths - 1])
     wallet = open_test_wallet_maybe(
         wallet_path, wallet_name, max_mix_depth,


### PR DESCRIPTION
This is a small bug fix that prevents joinmarket from looking for wallets in `~/.joinmarket/wallets/wallets/` but instead uses the correct path: `~/.joinmarket/wallets/`