### PR TITLE
Pin pytest to 5.3.5 and fix bitcoind install for tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,11 +14,7 @@ matrix:
       env: PIP_DOWNLOAD_CACHE=$HOME/.cache/pip
       addons:
         apt:
-           sources:
-           - sourceline: 'ppa:bitcoin/bitcoin'
-             key_url: 'http://keyserver.ubuntu.com:11371/pks/lookup?op=get&search=0xD46F45428842CE5E'
            packages:
-             - bitcoind
              - python3-dev
              - python3-pip
              - python-virtualenv
@@ -46,6 +42,7 @@ before_install:
   - do_on osx pip install virtualenv
 cache:
   directories:
+   - $HOME/bitcoin/bitcoin-0.19.1/bin
    - $HOME/downloads
    - $HOME/.cache/pip
    - $HOME/Library/Caches/pip
@@ -56,6 +53,7 @@ install:
   - mkdir -p "$HOME/downloads"
   - mkdir -p "$TRAVIS_BUILD_DIR/deps/cache/"
   - find "$HOME/downloads" -type f -exec cp -v {} "$TRAVIS_BUILD_DIR/deps/cache/" \;
+  - on_host do_on linux ./install_bitcoind.sh
   - on_host do_on linux ./install.sh --develop --with-qt
   - on_host do_on osx virtualenv --python=python3 jmvenv
   - on_host find "$TRAVIS_BUILD_DIR/deps/cache/" -type f -exec cp -v {} "$HOME/downloads/" \;

--- a/install_bitcoind.sh
+++ b/install_bitcoind.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -ev
+
+export BITCOIND_VERSION=0.19.1
+
+if sudo cp ~/bitcoin/bitcoin-$BITCOIND_VERSION/bin/bitcoind /usr/local/bin/bitcoind
+then
+        echo "found cached bitcoind"
+	sudo cp ~/bitcoin/bitcoin-$BITCOIND_VERSION/bin/bitcoin-cli /usr/local/bin/bitcoin-cli
+else
+        mkdir -p ~/bitcoin && \
+        pushd ~/bitcoin && \
+        wget https://bitcoin.org/bin/bitcoin-core-$BITCOIND_VERSION/bitcoin-$BITCOIND_VERSION-x86_64-linux-gnu.tar.gz && \
+        tar xvfz bitcoin-$BITCOIND_VERSION-x86_64-linux-gnu.tar.gz && \
+        sudo cp ./bitcoin-$BITCOIND_VERSION/bin/bitcoind /usr/local/bin/bitcoind && \
+        sudo cp ./bitcoin-$BITCOIND_VERSION/bin/bitcoin-cli /usr/local/bin/bitcoin-cli && \
+        popd
+fi
+
+

--- a/requirements/testing.txt
+++ b/requirements/testing.txt
@@ -3,7 +3,7 @@
 # numpy
 pexpect
 coverage==4.0.3
-pytest
+pytest==5.3.5
 pytest-cov>=2.4.0,<2.6
 python-coveralls
 mock


### PR DESCRIPTION
As of 13 March the latest pytest breaks the twisted tests.