### PR TITLE
Fix installation of dependencies for Debian

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -62,7 +62,7 @@ deb_deps_check ()
 
 deb_deps_install ()
 {
-    deb_deps=( ${1} )
+    deb_deps=( ${@} )
     if deb_deps_check; then
         clear
         echo "


### PR DESCRIPTION
Fixing: https://github.com/JoinMarket-Org/joinmarket-clientserver/issues/541

Make `install.sh` iterate through the:
```
    common_deps=( \
        'python-virtualenv' \
        'curl' \
        'build-essential' \
        'automake' \
        'pkg-config' \
        'libtool' \
        'libgmp-dev' \
        'python3-dev' \
        'python3-pip' )
```
when installed clean on Debian.