### PR TITLE
Update all exit() calls to sys.exit()

### DIFF
--- a/jmclient/jmclient/configure.py
+++ b/jmclient/jmclient/configure.py
@@ -4,6 +4,7 @@ import logging
 import os
 import binascii
 import re
+import sys
 
 from configparser import ConfigParser, NoOptionError
 
@@ -11,7 +12,7 @@ import jmbitcoin as btc
 from jmclient.jsonrpc import JsonRpc
 from jmbase.support import (get_log, joinmarket_alert, core_alert, debug_silence,
                             set_logging_level, jmprint, set_logging_color,
-                            JM_APP_NAME, lookup_appdata_folder)
+                            JM_APP_NAME, lookup_appdata_folder, EXIT_FAILURE)
 from jmclient.podle import set_commitment_file
 
 log = get_log()
@@ -456,7 +457,7 @@ def load_program_config(config_path="", bs=None):
             configfile.write(defaultconfig)
         jmprint("Created a new `joinmarket.cfg`. Please review and adopt the "
               "settings and restart joinmarket.", "info")
-        exit(1)
+        sys.exit(EXIT_FAILURE)
 
     #These are left as sanity checks but currently impossible
     #since any edits are overlays to the default, these sections/options will

--- a/scripts/joinmarket-qt.py
+++ b/scripts/joinmarket-qt.py
@@ -66,7 +66,7 @@ JM_CORE_VERSION = '0.6.2'
 JM_GUI_VERSION = '12'
 
 from jmbase import get_log
-from jmbase.support import DUST_THRESHOLD
+from jmbase.support import DUST_THRESHOLD, EXIT_FAILURE
 from jmclient import load_program_config, get_network, update_persist_config,\
     open_test_wallet_maybe, get_wallet_path, get_p2sh_vbyte, get_p2pk_vbyte,\
     jm_single, validate_address, weighted_order_choose, Taker,\
@@ -1868,7 +1868,7 @@ except Exception as e:
              "bitcoin.conf file."
              ])
     JMQtMessageBox(None, config_load_error, mbtype='crit', title='failed to load')
-    exit(1)
+    sys.exit(EXIT_FAILURE)
 # Qt does not currently support any functioning without a Core interface:
 if jm_single().bc_interface is None:
     blockchain_error = ''.join(["Joinmarket-Qt requires Bitcoin Core as a blockchain ",
@@ -1877,7 +1877,7 @@ if jm_single().bc_interface is None:
                                 "'no-blockchain'; see comments for details."])
     JMQtMessageBox(None, blockchain_error, mbtype='crit',
                    title='Invalid blockchain source')
-    exit(1)
+    sys.exit(EXIT_FAILURE)
 #refuse to load non-segwit wallet (needs extra work in wallet-utils).
 if not jm_single().config.get("POLICY", "segwit") == "true":
     wallet_load_error = ''.join(["Joinmarket-Qt only supports segwit based wallets, ",
@@ -1885,7 +1885,7 @@ if not jm_single().config.get("POLICY", "segwit") == "true":
                                  "of the field `segwit` in the `POLICY` section."])
     JMQtMessageBox(None, wallet_load_error, mbtype='crit',
                    title='Incompatible wallet type')
-    exit(1)
+    sys.exit(EXIT_FAILURE)
 
 update_config_for_gui()
 


### PR DESCRIPTION
Prior to this commit, the function `exit()` was unavailable
due to the removal of the builtins import in 4bf1f50.
This led to NameError exceptions instead of the intended error
messages in Qt startup with wrong configuration (I did not
investigate if it could also happen on command line).
Fix was to make all exit() calls sys.exit().