### PR TITLE
Bugfix: Move commitmentlist to datadir

### DIFF
--- a/jmdaemon/jmdaemon/daemon_protocol.py
+++ b/jmdaemon/jmdaemon/daemon_protocol.py
@@ -66,7 +66,7 @@ def check_utxo_blacklist(commitment, persist=False):
     If flagged, persist the usage of this commitment to the above file.
     """
     #TODO format error checking?
-    fname = "commitmentlist"
+    fname = os.path.join(jm_single().datadir, "commitmentlist")
     if os.path.isfile(fname):
         with open(fname, "rb") as f:
             blacklisted_commitments = [x.decode('ascii').strip() for x in f.readlines()]


### PR DESCRIPTION
It's location wasn't changed, although v0.6.2 release notes said it was.

See https://github.com/kristapsk/raspibolt-extras/issues/4.