### PR TITLE
Remove jm_single config var call from jmdaemon

### DIFF
--- a/jmdaemon/jmdaemon/daemon_protocol.py
+++ b/jmdaemon/jmdaemon/daemon_protocol.py
@@ -415,22 +415,12 @@ class JMDaemonServerProtocol(amp.AMP, OrderbookWatch):
     @maker_only
     def on_commitment_seen(self, nick, commitment):
         """Triggered when we see a commitment for blacklisting
-	appear in the public pit channel. If the policy is set,
-	we blacklist this commitment.
+	appear in the public pit channel.
 	"""
-        if jm_single().config.has_option("POLICY", "accept_commitment_broadcasts"):
-            blacklist_add = jm_single().config.getint("POLICY",
-                                                    "accept_commitment_broadcasts")
-        else:
-            blacklist_add = 0
-        if blacklist_add > 0:
-            #just add if necessary, ignore return value.
-            check_utxo_blacklist(commitment, persist=True)
-            log.msg("Received commitment broadcast by other maker: " + str(
-                commitment) + ", now blacklisted.")
-        else:
-            log.msg("Received commitment broadcast by other maker: " + str(
-                commitment) + ", ignored.")
+        #just add if necessary, ignore return value.
+        check_utxo_blacklist(commitment, persist=True)
+        log.msg("Received commitment broadcast by other maker: " + str(
+            commitment) + ", now blacklisted.")
 
     @maker_only
     def on_commitment_transferred(self, nick, commitment):

--- a/jmdaemon/jmdaemon/message_channel.py
+++ b/jmdaemon/jmdaemon/message_channel.py
@@ -805,10 +805,11 @@ class MessageChannel(object):
                 else:
                     if self.on_commitment_seen:
                         self.on_commitment_seen(counterparty, commitment)
-            except IndexError as e:
+            except Exception as e:
                 log.debug(e)
-                log.debug('index error parsing chunks, possibly malformed'
-                          'offer by other party. No user action required.')
+                log.debug('Error parsing chunks, possibly malformed'
+                          'commitment by other party. No user action required.')
+                log.debug("the chunks were: " + str(_chunks))
             finally:
                 return True
         return False


### PR DESCRIPTION
Prior to this commit, the callback method in the
DaemonServerProtocol, on_commitment_seen, was using
a reference to jm_single (to access the config var
accept_commitment_broadcasts) which was not valid
as jm_single() is part of jmclient and is not accessible
to jmdaemon. This error was being swallowed by a finally:
block in the message channel method check_for_commitments,
resulting in public broadcast hp2 messages being ignored.
This commit removes the reference to accept_commitment_broadcasts,
thus resulting in all publically broadcast hp2 messages being
stored in the commitmentlist.