### PR TITLE
[WIP] Install on FreeBSD

### DIFF
--- a/FreeBSD_rc.sh
+++ b/FreeBSD_rc.sh
@@ -1,0 +1,66 @@
+#!/bin/sh
+
+# PROVIDE: joinmarket
+# REQUIRE: bitcoind tor
+# KEYWORD: shutdown
+
+. /etc/rc.subr
+
+name="joinmarket"
+rcvar="joinmarket_enable"
+
+: ${joinmarket_enable:="no"}
+: ${joinmarket_wallet:="wallet.jmdat"}
+: ${joinmarket_bin_dir:="/usr/local/bin/${name}"}
+: ${joinmarket_etc_dir:="/usr/local/etc/${name}"}
+    PASSWORD="asdf"
+
+command="$joinmarket_bin_dir/jmvenv/bin/python"
+
+procname=$command
+pidfile="/var/run/${name}.pid"
+
+required_files="$joinmarket_etc_dir/wallets/$joinmarket_wallet"
+
+start_cmd="${name}_start"
+stop_cmd="${name}_stop"
+
+extra_commands="history wallet generate"
+history_cmd="joinmarket_history"
+wallet_cmd="joinmarket_wallet"
+generate_cmd="joinmarket_generate"
+
+joinmarket_wallet()
+{
+    echo -n $PASSWORD | $command $joinmarket_bin_dir/scripts/wallet-tool.py --wallet-password-stdin --datadir=$joinmarket_etc_dir $joinmarket_wallet
+}
+
+joinmarket_history()
+{
+    echo -n $PASSWORD | $command $joinmarket_bin_dir/scripts/wallet-tool.py --wallet-password-stdin --datadir=$joinmarket_etc_dir $joinmarket_wallet history
+}
+
+joinmarket_generate()
+{
+    $command $joinmarket_bin_dir/scripts/wallet-tool.py --datadir=$joinmarket_etc_dir --datadir=$joinmarket_etc_dir generate
+}
+
+joinmarket_start()
+{
+    echo -n $PASSWORD | /usr/sbin/daemon -o $joinmarket_etc_dir/daemon.log -p $pidfile $command $joinmarket_bin_dir/scripts/yg-privacyenhanced.py --wallet-password-stdin --datadir=$joinmarket_etc_dir wallet.jmdat
+}
+joinmarket_stop()
+{
+    echo "Stopping joinmarket:"
+    pid=$(check_pidfile "${pidfile}" "${procname}")
+    if [ -z "${pid}" ]
+    then
+        echo "joinmarket is not running"
+        return 1
+    else
+        kill ${pid}
+    fi
+}
+
+load_rc_config ${name}
+run_rc_command "$1"

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -64,6 +64,73 @@ Then:
 If you have installed this "full" version of the client, you can use it with the
 command line scripts as explained in the [scripts README](https://github.com/AdamISZ/joinmarket-clientserver/tree/master/scripts).
 
+### Installation on FreeBSD
+
+1) Fetch and extract ports
+    ```
+    portsnap fetch
+    portsnap extract
+    
+2) Install dependencies
+    ```
+    pkg install -y bash python py37-pip py37-openssl py37-gmpy py37-sqlite3 libffi libsodium
+
+3) Build OpenSSL with SSL3 support
+    ```
+    cd /usr/ports/security/openssl/ && make deinstall && make WITH=SSL3 BATCH=1 install clean
+
+4) Decide where to keep the application and settings
+    ```
+    JM_BIN_DIR_PATH=/usr/local/bin/joinmarket
+    JM_ETC_DIR_PATH=/usr/local/etc/joinmarket
+
+4) Clone the joinmarket-clientserver repo and checkout current release tag
+    ```
+    git clone https://github.com/Joinmarket-Org/joinmarket-clientserver $JM_BIN_DIR_PATH
+    cd $JM_BIN_DIR_PATH && git checkout current_release
+
+5) Install python dependencies
+    ```
+    cd $JM_BIN_DIR_PATH && pip install virtualenv && virtualenv --python=python3 jmvenv
+
+6) Configure python virtual environment
+    ```
+    /usr/local/bin/bash -c "source $JM_BIN_DIR_PATH/jmvenv/bin/activate; python setupall.py --daemon"
+    /usr/local/bin/bash -c "source $JM_BIN_DIR_PATH/jmvenv/bin/activate; python setupall.py --client-bitcoin"
+
+7) Generate config file
+    ```
+    $JM_BIN_DIR_PATH/jmvenv/bin/python $JM_BIN_DIR_PATH/scripts/wallet-tool.py --datadir=$INTERNAL_ETC_PATH
+
+8) Install rc.script
+    ```
+    cp $JM_BIN_DIR_PATH/FreeBSD_rc.sh /usr/local/etc/rc.d/joinmarket && chmod +x /usr/local/etc/rc.d/joinmarket
+
+9) Update settings
+    ```
+    $EDITOR $JM_ETC_DIR_PATH/joinmarket.cfg
+    $EDITOR $JM_BIN_DIR_PATH/scripts/yg-privacyenhanced.py
+
+10) Generate wallet
+    ```
+    service joinmarket onegenerate
+
+11) Write password to .secrets file to enable joinmarket to start automatically after booting
+    ```
+    echo REPLACE_THIS_WITH_YOUR_PASSWORD > $JM_ETC_DIR_PATH/.secrets
+
+12) Automate startup
+    ```
+    sysrc joinmarket_enable="YES"
+    service joinmarket start
+
+#### Commands to control joinmarket on FreeBSD
+    ```
+    service joinmarket start    # start joinmarket
+    service joinmarket stop     # stop joinmarket
+    service joinmarket wallet   # list addresses
+    service joinmarket history  # display history
+
 ### Installation on macOS
 
 1) Install Apple Command Line Tools


### PR DESCRIPTION
I've added installation instructions for running joinmarket on FreeBSD.

This is a draft, I basically copied the script from one I use for myself to configure a jail containing bitcoind, tor, lnd and joinmarket. It is as of right now untested after the copy pasting. Before I spend any more time I wanted to make sure there is some kind of interest in it.

There are a couple of issues that I'm aware of:

* it requires a "current_release" tag to enable direct copy pasting of the instructions when installing
* I'm not sure where to store the rc script for automatically running it
* I'm uncertain if automatically running joinmarket at boot is something that should be recommended
* How and where should the password be store? I'm thinking a .secrets file inside the settings folder (right now the password inside the rc script is hardcoded to "asdf")
* What user should everything be run as? I would personally run it as root inside a jail, but I have not included instructions on setting up a jail