### PR TITLE
Add BIP21 bitcoin payment URI support to sendpayment.py

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -382,7 +382,11 @@ Here is an example:
 
         (jmvenv)$ python sendpayment.py wallet.jmdat 5000000 mprGzBA9rQk82Ly41TsmpQGa8UPpZb2w8c
 
-This sends 5000000 satoshi (0.05btc) to the address *mprGzBA9rQk82Ly41TsmpQGa8UPpZb2w8c* (testnet), with the default 5-7 (randomized) other parties from the default 0-th mixing depth from the wallet contained in the file *wallet.jmdat*. This will take some time, since Joinmarket will connect to remote messaging servers and do end to end encrypted communication with other bots, and also you will be paying some fees (more on this later in this section).
+Or you can use BIP21 bitcoin payment URI:
+
+        (jmvenv)$ python sendpayment.py wallet.jmdat bitcoin:mprGzBA9rQk82Ly41TsmpQGa8UPpZb2w8c?amount=0.05
+
+These send 5000000 satoshi (0.05btc) to the address *mprGzBA9rQk82Ly41TsmpQGa8UPpZb2w8c* (testnet), with the default 5-7 (randomized) other parties from the default 0-th mixing depth from the wallet contained in the file *wallet.jmdat*. This will take some time, since Joinmarket will connect to remote messaging servers and do end to end encrypted communication with other bots, and also you will be paying some fees (more on this later in this section).
 
 <a name="no-coinjoin-sending-funds" />
 

--- a/jmbitcoin/jmbitcoin/__init__.py
+++ b/jmbitcoin/jmbitcoin/__init__.py
@@ -5,4 +5,5 @@ from jmbitcoin.secp256k1_deterministic import *
 from jmbitcoin.btscript import *
 from jmbitcoin.bech32 import *
 from jmbitcoin.amount import *
+from jmbitcoin.bip21 import *
 

--- a/jmbitcoin/jmbitcoin/bip21.py
+++ b/jmbitcoin/jmbitcoin/bip21.py
@@ -1,0 +1,41 @@
+# https://github.com/bitcoin/bips/blob/master/bip-0021.mediawiki
+# bitcoin:<address>[?amount=<amount>][?label=<label>][?message=<message>]
+# We don't check validity of Bitcoin address here, as all the tools using
+# this are expected to do address validation independently anyway.
+
+from jmbitcoin import amount_to_sat
+from urllib.parse import parse_qs, urlparse
+from url_decode import urldecode
+import re
+
+
+def is_bip21_uri(uri):
+    parsed = urlparse(uri)
+    return parsed.scheme == 'bitcoin' and parsed.path != ''
+
+
+def is_bip21_amount_str(amount):
+    return re.compile("^[0-9]{1,8}(\.[0-9]{1,8})?$").match(amount) != None
+
+
+def decode_bip21_uri(uri):
+    if not is_bip21_uri(uri):
+        raise ValueError("Not a valid BIP21 URI: " + uri)
+    result = {}
+    parsed = urlparse(uri)
+    result['address'] = parsed.path
+    params = parse_qs(parsed.query)
+    for key in params:
+        if key.startswith('req-'):
+            raise ValueError("Unknown required parameter " + key +
+                " in BIP21 URI.")
+        if key == 'amount':
+            amount_str = params['amount'][0]
+            if not is_bip21_amount_str(amount_str):
+                raise ValueError("Invalid BTC amount " + amount_str +
+                    " vs. " + str(amount_to_sat(amount_str)) + " sat")
+            # Convert amount to sats, as used internally by JM
+            result['amount'] = amount_to_sat(amount_str + "btc")
+        else:
+            result[key] = urldecode(params[key][0])
+    return result

--- a/jmbitcoin/setup.py
+++ b/jmbitcoin/setup.py
@@ -9,5 +9,5 @@ setup(name='joinmarketbitcoin',
       author_email='',
       license='GPL',
       packages=['jmbitcoin'],
-      install_requires=['future', 'coincurve',],
+      install_requires=['future', 'coincurve', 'urldecode'],
       zip_safe=False)

--- a/jmbitcoin/test/test_bip21.py
+++ b/jmbitcoin/test/test_bip21.py
@@ -1,0 +1,58 @@
+import jmbitcoin as btc
+import pytest
+
+
+def test_bip21():
+
+    # These should raise exception because of not being valid BIP21 URI's
+    with pytest.raises(ValueError):
+        btc.decode_bip21_uri('')
+        btc.decode_bip21_uri('nfdjksnfjkdsnfjkds')
+        btc.decode_bip21_uri('175tWpb8K1S7NmH4Zx6rewF9WQrcZv245W')
+        btc.decode_bip21_uri(
+            '175tWpb8K1S7NmH4Zx6rewF9WQrcZv245W?amount=20.3')
+        btc.decode_bip21_uri('bitcoin:')
+        btc.decode_bip21_uri('bitcoin:?amount=20.3')
+        btc.decode_bip21_uri(
+            'bitcoin:175tWpb8K1S7NmH4Zx6rewF9WQrcZv245W?amount=')
+        btc.decode_bip21_uri(
+            'bitcoin:175tWpb8K1S7NmH4Zx6rewF9WQrcZv245W?amount=XYZ')
+        btc.decode_bip21_uri(
+            'bitcoin:175tWpb8K1S7NmH4Zx6rewF9WQrcZv245W?amount=100\'000')
+        btc.decode_bip21_uri(
+            'bitcoin:175tWpb8K1S7NmH4Zx6rewF9WQrcZv245W?amount=100,000')
+        btc.decode_bip21_uri(
+            'bitcoin:175tWpb8K1S7NmH4Zx6rewF9WQrcZv245W?amount=100000000')
+
+    assert(btc.decode_bip21_uri('bitcoin:175tWpb8K1S7NmH4Zx6rewF9WQrcZv245W'
+        )['address'] == '175tWpb8K1S7NmH4Zx6rewF9WQrcZv245W')
+
+    parsed = btc.decode_bip21_uri(
+        'bitcoin:175tWpb8K1S7NmH4Zx6rewF9WQrcZv245W?label=Luke-Jr')
+    assert(parsed['address'] == '175tWpb8K1S7NmH4Zx6rewF9WQrcZv245W')
+    assert(parsed['label'] == 'Luke-Jr')
+
+    parsed = btc.decode_bip21_uri(
+        'bitcoin:175tWpb8K1S7NmH4Zx6rewF9WQrcZv245W?amount=20.3&label=Luke-Jr')
+    assert(parsed['address'] == '175tWpb8K1S7NmH4Zx6rewF9WQrcZv245W')
+    assert(parsed['amount'] == 2030000000)
+    assert(parsed['label'] == 'Luke-Jr')
+
+    parsed = btc.decode_bip21_uri(
+        'bitcoin:175tWpb8K1S7NmH4Zx6rewF9WQrcZv245W?amount=50&label=Luke-Jr&message=Donation%20for%20project%20xyz')
+    assert(parsed['address'] == '175tWpb8K1S7NmH4Zx6rewF9WQrcZv245W')
+    assert(parsed['amount'] == 5000000000)
+    assert(parsed['label'] == 'Luke-Jr')
+    assert(parsed['message'] == 'Donation for project xyz')
+
+    # This should raise exception because of unknown req-* parameters
+    with pytest.raises(ValueError):
+        btc.decode_bip21_uri(
+            'bitcoin:175tWpb8K1S7NmH4Zx6rewF9WQrcZv245W?req-somethingyoudontunderstand=50&req-somethingelseyoudontget=999')
+
+    parsed = btc.decode_bip21_uri(
+        'bitcoin:175tWpb8K1S7NmH4Zx6rewF9WQrcZv245W?somethingyoudontunderstand=50&somethingelseyoudontget=999')
+    assert(parsed['address'] == '175tWpb8K1S7NmH4Zx6rewF9WQrcZv245W')
+    assert(parsed['somethingyoudontunderstand'] == '50')
+    assert(parsed['somethingelseyoudontget'] == '999')
+

--- a/jmclient/jmclient/cli_options.py
+++ b/jmclient/jmclient/cli_options.py
@@ -442,7 +442,8 @@ def get_tumbler_parser():
 def get_sendpayment_parser():
     parser = OptionParser(
         usage=
-        'usage: %prog [options] [wallet file] [amount] [destaddr]',
+        'usage: %prog [options] wallet_file amount destaddr\n' +
+        '       %prog [options] wallet_file bitcoin_uri',
         description='Sends a single payment from a given mixing depth of your '
         +
         'wallet to an given address using coinjoin and then switches off. '


### PR DESCRIPTION
In future could and should be improved to add this also to Qt GUI, but didn't want to do that now, need to figure out proper UX there.

This is needed for #557.