### PR TITLE
Fix showing seed for wallets with mnemonic extension

### DIFF
--- a/jmclient/jmclient/wallet_utils.py
+++ b/jmclient/jmclient/wallet_utils.py
@@ -872,7 +872,7 @@ def wallet_showseed(wallet):
     seed, extension = wallet.get_mnemonic_words()
     text = "Wallet mnemonic recovery phrase:\n\n{}\n".format(seed)
     if extension:
-        text += "\nWallet mnemonic extension: {}\n".format(extension)
+        text += "\nWallet mnemonic extension: {}\n".format(extension.decode('utf-8'))
     return text
 
 

--- a/scripts/joinmarket-qt.py
+++ b/scripts/joinmarket-qt.py
@@ -1773,7 +1773,7 @@ class JMMainWindow(QMainWindow):
         mb.setText("<br/>".join(seed_recovery_warning))
         text = "<strong>" + words + "</strong>"
         if mnemonic_extension:
-            text += "<br/><br/>Seed extension: <strong>" + mnemonic_extension + "</strong>"
+            text += "<br/><br/>Seed extension: <strong>" + mnemonic_extension.decode('utf-8') + "</strong>"
         mb.setInformativeText(text)
         mb.setStandardButtons(QMessageBox.Ok)
         ret = mb.exec_()


### PR DESCRIPTION
Fixes error:
```
Traceback (most recent call last):
  File "joinmarket-qt.py", line 1725, in showSeedDialog
    self.displayWords(*self.wallet_service.get_mnemonic_words())
  File "joinmarket-qt.py", line 1776, in displayWords
    text += "<br/><br/>Seed extension: <strong>" + mnemonic_extension + "</strong>"
TypeError: must be str, not bytes
```