### PR TITLE
Add BIP21 support for Payjoin

### DIFF
--- a/jmbitcoin/setup.py
+++ b/jmbitcoin/setup.py
@@ -10,4 +10,5 @@ setup(name='joinmarketbitcoin',
       license='GPL',
       packages=['jmbitcoin'],
       install_requires=['future', 'coincurve', 'urldecode'],
+      python_requires='>=3.5',
       zip_safe=False)

--- a/jmbitcoin/test/test_bip21.py
+++ b/jmbitcoin/test/test_bip21.py
@@ -2,7 +2,7 @@ import jmbitcoin as btc
 import pytest
 
 
-def test_bip21():
+def test_bip21_decode():
 
     # These should raise exception because of not being valid BIP21 URI's
     with pytest.raises(ValueError):
@@ -56,3 +56,61 @@ def test_bip21():
     assert(parsed['somethingyoudontunderstand'] == '50')
     assert(parsed['somethingelseyoudontget'] == '999')
 
+
+def test_bip21_encode():
+    assert(
+        btc.encode_bip21_uri('175tWpb8K1S7NmH4Zx6rewF9WQrcZv245W', {}) ==
+        'bitcoin:175tWpb8K1S7NmH4Zx6rewF9WQrcZv245W'
+    )
+    assert(
+        btc.encode_bip21_uri('175tWpb8K1S7NmH4Zx6rewF9WQrcZv245W', {
+            'label': 'Luke-Jr'
+        }) ==
+        'bitcoin:175tWpb8K1S7NmH4Zx6rewF9WQrcZv245W?label=Luke-Jr'
+    )
+    assert(
+        btc.encode_bip21_uri('175tWpb8K1S7NmH4Zx6rewF9WQrcZv245W', {
+            'amount': 20.3,
+            'label': 'Luke-Jr'
+        }) ==
+        'bitcoin:175tWpb8K1S7NmH4Zx6rewF9WQrcZv245W?amount=20.3&label=Luke-Jr'
+    )
+    assert(
+        btc.encode_bip21_uri('175tWpb8K1S7NmH4Zx6rewF9WQrcZv245W', {
+            'amount': 50,
+            'label': 'Luke-Jr',
+            'message': 'Donation for project xyz'
+        }) ==
+        'bitcoin:175tWpb8K1S7NmH4Zx6rewF9WQrcZv245W?amount=50&label=Luke-Jr&message=Donation%20for%20project%20xyz'
+    )
+    assert(
+        btc.encode_bip21_uri('175tWpb8K1S7NmH4Zx6rewF9WQrcZv245W', {
+            'req-somethingyoudontunderstand': 50,
+            'req-somethingelseyoudontget': 999
+        }) ==
+        'bitcoin:175tWpb8K1S7NmH4Zx6rewF9WQrcZv245W?req-somethingyoudontunderstand=50&req-somethingelseyoudontget=999'
+    )
+    assert(
+        btc.encode_bip21_uri('175tWpb8K1S7NmH4Zx6rewF9WQrcZv245W', {
+            'somethingyoudontunderstand': 50,
+            'somethingelseyoudontget': 999
+        }) ==
+        'bitcoin:175tWpb8K1S7NmH4Zx6rewF9WQrcZv245W?somethingyoudontunderstand=50&somethingelseyoudontget=999'
+    )
+    # Invalid amounts must raise ValueError
+    with pytest.raises(ValueError):
+        btc.encode_bip21_uri('175tWpb8K1S7NmH4Zx6rewF9WQrcZv245W', {
+            'amount': ''
+        })
+        btc.encode_bip21_uri('175tWpb8K1S7NmH4Zx6rewF9WQrcZv245W', {
+            'amount': 'XYZ'
+        })
+        btc.encode_bip21_uri('175tWpb8K1S7NmH4Zx6rewF9WQrcZv245W', {
+            'amount': '100\'000'
+        })
+        btc.encode_bip21_uri('175tWpb8K1S7NmH4Zx6rewF9WQrcZv245W', {
+            'amount': '100,000'
+        })
+        btc.encode_bip21_uri('175tWpb8K1S7NmH4Zx6rewF9WQrcZv245W', {
+            'amount': '100000000'
+        })

--- a/jmclient/jmclient/maker.py
+++ b/jmclient/jmclient/maker.py
@@ -328,10 +328,16 @@ class P2EPMaker(Maker):
             self.receiving_amount) + " satoshis.")
         self.user_info("The sender also needs to know your ephemeral "
                   "nickname: " + jm_single().nickname)
-        self.user_info("This information has been stored in a file payjoin.txt;"
+        receive_uri = btc.encode_bip21_uri(self.destination_addr, {
+            'amount': btc.sat_to_btc(self.receiving_amount),
+            'jmnick': jm_single().nickname
+        })
+        self.user_info("Receive URI: " + receive_uri)
+        self.user_info("This information has also been stored in a file payjoin.txt;"
                   " send it to your counterparty when you are ready.")
         with open("payjoin.txt", "w") as f:
             f.write("Payjoin transfer details:\n\n")
+            f.write("Receive URI: " + receive_uri + "\n")
             f.write("Address: " + self.destination_addr + "\n")
             f.write("Amount (in sats): " + str(self.receiving_amount) + "\n")
             f.write("Receiver nick: " + jm_single().nickname + "\n")

--- a/scripts/sendpayment.py
+++ b/scripts/sendpayment.py
@@ -74,6 +74,8 @@ def main():
                 parser.error("Given BIP21 URI does not contain amount.")
                 sys.exit(EXIT_ARGERROR)
             destaddr = parsed['address']
+            if 'jmnick' in parsed:
+                options.p2ep = parsed['jmnick']
         else:
             amount = btc.amount_to_sat(args[1])
             if amount == 0:


### PR DESCRIPTION
Was re-reading [this discussion](https://gist.github.com/AdamISZ/4551b947789d3216bacfcb7af25e029e) this morning and understood that now that we have BIP21 support, implementing it for existing JM payjoin is pretty easy. Most code was actually adding generic BIP21 encoding support. It uses `jmnick` parameter to specify JM payjoin.

TODO is adding information about this to documentation too.

Also, I tested just URI generation and parsing so far, didn't yet do complete payjoin test.

This covers only cli, can be added to GUI in future, but I'm not yet sure about proper UX there, probably should be done together with #557.

Note that this raises Python requirement to 3.5+, because it needs `quote_via` parameter for `urlencode()`.