### PR TITLE
Don't warn about high txfee if it's 1 sat/vB

### DIFF
--- a/scripts/sendpayment.py
+++ b/scripts/sendpayment.py
@@ -177,7 +177,7 @@ def main():
             if total_cj_amount == 0:
                 raise ValueError("No confirmed coins in the selected mixdepth. Quitting")
         exp_tx_fees_ratio = ((1 + options.makercount) * options.txfee) / total_cj_amount
-        if exp_tx_fees_ratio > 0.05:
+        if exp_tx_fees_ratio > 0.05 and options.txfee != 1000:
             jmprint('WARNING: Expected bitcoin network miner fees for this coinjoin'
                 ' amount are roughly {:.1%}'.format(exp_tx_fees_ratio), "warning")
             if input('You might want to modify your tx_fee'

--- a/scripts/tumbler.py
+++ b/scripts/tumbler.py
@@ -140,7 +140,7 @@ def main():
             raise ValueError("No confirmed coins in the selected mixdepth(s). Quitting")
     exp_tx_fees_ratio = (involved_parties * options['txfee']) \
         / total_tumble_amount
-    if exp_tx_fees_ratio > 0.05:
+    if exp_tx_fees_ratio > 0.05 and options['txfee'] != 1000:
         jmprint('WARNING: Expected bitcoin network miner fees for the whole '
             'tumbling run are roughly {:.1%}'.format(exp_tx_fees_ratio), "warning")
         if not options['restart'] and input('You might want to modify your tx_fee'


### PR DESCRIPTION
Noticed this while testing #536. Warning about high tx fee and hinting on changing joinmarket.cfg settings is pointless if effective tx fee is already 1 sat/vB.

Something is also wrong with these calculations, as I clearly didn't pay ~30% in fees, closer to 2%, but that's a different issue.
```
$ python sendpayment.py testnet123.jmdat "bitcoin:tb1qgcjg2gafhdurg46m4hjr3wvh6ecccskghcgq74?amount=0.00011082&pj=https://demo.payjoin.kukks.org/BTC/pj"
User data location: /home/user/.joinmarket/
2020-05-06 10:21:11,065 [DEBUG]  rpc: getnetworkinfo None
2020-05-06 10:21:11,066 [INFO]  Using this min relay fee as tx fee floor: 1000 sat/vkB (1.0 sat/vB)
2020-05-06 10:21:11,066 [DEBUG]  Estimated miner/tx fee for each cj participant: 364
2020-05-06 10:21:11,067 [DEBUG]  starting sendpayment
Enter wallet decryption passphrase: 
2020-05-06 10:21:13,161 [DEBUG]  rpc: listaddressgroupings []
2020-05-06 10:21:13,167 [DEBUG]  Fast sync in progress. Got this many used addresses: 9
2020-05-06 10:21:14,591 [DEBUG]  rpc: listunspent []
2020-05-06 10:21:14,594 [DEBUG]  bitcoind sync_unspent took 0.0032761096954345703sec
WARNING: Expected bitcoin network miner fees for this coinjoin amount are roughly 32.8%
You might want to modify your tx_fee settings in joinmarket.cfg. Still continue? (y/n):y
2020-05-06 10:21:35,912 [DEBUG]  rpc: getnetworkinfo None
2020-05-06 10:21:35,915 [INFO]  Using this min relay fee as tx fee floor: 1000 sat/vkB (1.0 sat/vB)
2020-05-06 10:21:35,920 [DEBUG]  rpc: getnetworkinfo None
2020-05-06 10:21:35,923 [INFO]  Using this min relay fee as tx fee floor: 1000 sat/vkB (1.0 sat/vB)
2020-05-06 10:21:35,981 [INFO]  Using a fee of : 0.00000223 BTC (223 sat).
2020-05-06 10:21:35,982 [INFO]  Using a change value of: 0.00037491 BTC (37491 sat).
```