### PR TITLE
Change initial fee guess logic in taker scripts

### DIFF
--- a/scripts/sendpayment.py
+++ b/scripts/sendpayment.py
@@ -133,15 +133,12 @@ def main():
     if int(options.txfee) > 0:
         jm_single().config.set("POLICY", "tx_fees", str(options.txfee))
 
-    # Dynamically estimate a realistic fee if it currently is the default value.
+    # Dynamically estimate a realistic fee.
     # At this point we do not know even the number of our own inputs, so
     # we guess conservatively with 2 inputs and 2 outputs each.
-    if options.txfee == -1:
-        options.txfee = max(options.txfee, estimate_tx_fee(2, 2,
-                                        txtype="p2sh-p2wpkh"))
-        log.debug("Estimated miner/tx fee for each cj participant: " + str(
-            options.txfee))
-    assert (options.txfee >= 0)
+    fee_per_cp_guess = estimate_tx_fee(2, 2, txtype="p2sh-p2wpkh")
+    log.debug("Estimated miner/tx fee for each cj participant: " + str(
+        fee_per_cp_guess))
 
     maxcjfee = (1, float('inf'))
     if not options.p2ep and not options.pickorders and options.makercount != 0:
@@ -176,7 +173,7 @@ def main():
             total_cj_amount = wallet_service.get_balance_by_mixdepth()[options.mixdepth]
             if total_cj_amount == 0:
                 raise ValueError("No confirmed coins in the selected mixdepth. Quitting")
-        exp_tx_fees_ratio = ((1 + options.makercount) * options.txfee) / total_cj_amount
+        exp_tx_fees_ratio = ((1 + options.makercount) * fee_per_cp_guess) / total_cj_amount
         if exp_tx_fees_ratio > 0.05:
             jmprint('WARNING: Expected bitcoin network miner fees for this coinjoin'
                 ' amount are roughly {:.1%}'.format(exp_tx_fees_ratio), "warning")

--- a/scripts/tumbler.py
+++ b/scripts/tumbler.py
@@ -119,12 +119,9 @@ def main():
 
     # Dynamically estimate an expected tx fee for the whole tumbling run.
     # This is very rough: we guess with 2 inputs and 2 outputs each.
-    if options['txfee'] == -1:
-        options['txfee'] = max(options['txfee'], estimate_tx_fee(2, 2,
-                                        txtype="p2sh-p2wpkh"))
-        log.debug("Estimated miner/tx fee for each cj participant: " + str(
-            options['txfee']))
-    assert (options['txfee'] >= 0)
+    fee_per_cp_guess = estimate_tx_fee(2, 2, txtype="p2sh-p2wpkh")
+    log.debug("Estimated miner/tx fee for each cj participant: " + str(
+            fee_per_cp_guess))
 
     # From the estimated tx fees, check if the expected amount is a
     # significant value compared the the cj amount
@@ -138,7 +135,7 @@ def main():
         total_tumble_amount += wallet_service.get_balance_by_mixdepth()[i]
         if total_tumble_amount == 0:
             raise ValueError("No confirmed coins in the selected mixdepth(s). Quitting")
-    exp_tx_fees_ratio = (involved_parties * options['txfee']) \
+    exp_tx_fees_ratio = (involved_parties * fee_per_cp_guess) \
         / total_tumble_amount
     if exp_tx_fees_ratio > 0.05:
         jmprint('WARNING: Expected bitcoin network miner fees for the whole '


### PR DESCRIPTION
As per discussion in #569 the use of options.txfee
to set fee rates conflicted with its earlier use
to make a first guess of fees for user warnings.
Now this connection is removed, the guess for warning
calculation is done independent of this option setting.