### PR TITLE
Simple improvements for ob-watcher.py

### DIFF
--- a/scripts/obwatch/ob-watcher.py
+++ b/scripts/obwatch/ob-watcher.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 from future.utils import iteritems
 from past.builtins import cmp
 from functools import cmp_to_key

--- a/scripts/obwatch/ob-watcher.py
+++ b/scripts/obwatch/ob-watcher.py
@@ -271,7 +271,8 @@ class OrderbookPageRequestHeader(http.server.SimpleHTTPRequestHandler):
         pages = ['/', '/ordersize', '/depth', '/orderbook.json']
         if self.path not in pages:
             return
-        fd = open('orderbook.html', 'r')
+        fd = open(os.path.join(os.path.dirname(os.path.realpath(__file__)),
+            'orderbook.html'), 'r')
         orderbook_fmt = fd.read()
         fd.close()
         alert_msg = ''

--- a/scripts/obwatch/ob-watcher.py
+++ b/scripts/obwatch/ob-watcher.py
@@ -372,8 +372,12 @@ class HTTPDThread(threading.Thread):
 
     def run(self):
         # hostport = ('localhost', 62601)
-        httpd = http.server.HTTPServer(self.hostport,
+        try:
+            httpd = http.server.HTTPServer(self.hostport,
                                           OrderbookPageRequestHeader)
+        except Exception as e:
+            print("Failed to start HTTP server: " + str(e))
+            os._exit(EXIT_FAILURE)
         httpd.taker = self.taker
         print('\nstarted http server, visit http://{0}:{1}/\n'.format(
                 *self.hostport))

--- a/scripts/obwatch/orderbook.html
+++ b/scripts/obwatch/orderbook.html
@@ -86,8 +86,7 @@
 	            <li><a href="/ordersize">Size Distribution</a></li>
 	            <li><a href="/depth">Depth</a></li>
 	            <li><a href="/orderbook.json">Export orders</a></li>
-	            <li><a target="_blank" href="https://github.com/AdamISZ/joinmarket-clientserver/releases">New segwit version</a></li>
-		    <li><a target="_blank" href="https://github.com/Joinmarket-Org/joinmarket/releases">Non segwit version</a></li>
+	            <li><a target="_blank" href="https://github.com/JoinMarket-Org/joinmarket-clientserver/releases">New segwit version</a></li>
 	          </ul>
 	        </div><!--/.nav-collapse -->
 	      </div>


### PR DESCRIPTION
* Terminate immediately if HTTP server fails to start.
* Make `ob-watcher.py` runnable from any directory.
* Shebang and +x (like was done in #524 for other scripts).