### PR TITLE
QValidator port number restriction only for ports

### DIFF
--- a/scripts/joinmarket-qt.py
+++ b/scripts/joinmarket-qt.py
@@ -271,7 +271,13 @@ class SettingsTab(QDialog):
                 else:
                     qt = QLineEdit(val)
                     if t == int:
-                        qt.setValidator(QIntValidator(0, 65535))
+                        if name in ["rpc_port", "socks5_port", "daemon_port"]:
+                            qt.setValidator(QIntValidator(0, 65535))
+                        elif name == "tx_fees":
+                            # must account for both tx_fees settings type,
+                            # and we set upper limit well above default absurd
+                            # check just in case a high value is needed:
+                            qt.setValidator(QIntValidator(1, 1000000))
             else:
                 qt = QLineEdit(val)
             label = 'Testnet' if name == 'network' else name


### PR DESCRIPTION
Prior to this fix, the settings which were integers
were all restricted to numbers <= 65535, but this is
not acceptable for the tx_fees setting which can be
sats per kilobyte. Note that several other integer inputs
are left without any specific validation; this change
is considered important because there will be use cases
where a large sat/kB is needed.