### PR TITLE
Move some logs into config_location/logs

### DIFF
--- a/jmclient/jmclient/maker.py
+++ b/jmclient/jmclient/maker.py
@@ -3,6 +3,7 @@ from future.utils import iteritems
 import base64
 import pprint
 import random
+import os
 import sys
 import abc
 from binascii import unhexlify
@@ -20,6 +21,8 @@ from twisted.internet import task, reactor
 from .cryptoengine import EngineError
 
 jlog = get_log()
+logsdir = os.path.join(os.path.dirname(
+    jm_single().config_location), "logs")
 
 class Maker(object):
     def __init__(self, wallet_service):
@@ -335,7 +338,7 @@ class P2EPMaker(Maker):
         self.user_info("Receive URI: " + receive_uri)
         self.user_info("This information has also been stored in a file payjoin.txt;"
                   " send it to your counterparty when you are ready.")
-        with open("payjoin.txt", "w") as f:
+        with open(os.path.join(logsdir, "payjoin.txt"), "w") as f:
             f.write("Payjoin transfer details:\n\n")
             f.write("Receive URI: " + receive_uri + "\n")
             f.write("Address: " + self.destination_addr + "\n")

--- a/jmclient/jmclient/podle.py
+++ b/jmclient/jmclient/podle.py
@@ -7,11 +7,14 @@ import hashlib
 import json
 import binascii
 import struct
+from jmclient.configure import jm_single
 from jmbase import jmprint
 from jmbitcoin import multiply, add_pubkeys, getG, podle_PublicKey,\
     podle_PrivateKey, encode, decode, N, podle_PublicKey_class
 from jmbase.support import EXIT_FAILURE
 
+logsdir = os.path.join(os.path.dirname(
+    jm_single().config_location), "logs")
 
 PODLE_COMMIT_FILE = None
 
@@ -246,7 +249,7 @@ def verify_all_NUMS(write=False):
     for i in range(256):
         nums_points[i] = binascii.hexlify(getNUMS(i).format()).decode('ascii')
     if write:
-        with open("nums_basepoints.txt", "wb") as f:
+        with open(os.path.join(logsdir, "nums_basepoints.txt"), "wb") as f:
             from pprint import pformat
             f.write(pformat(nums_points).encode('utf-8'))
     assert nums_points == precomp_NUMS, "Precomputed NUMS points are not valid!"

--- a/jmclient/jmclient/taker.py
+++ b/jmclient/jmclient/taker.py
@@ -3,6 +3,7 @@ from future.utils import iteritems
 
 import base64
 import pprint
+import os
 import random
 from twisted.internet import reactor, task
 from binascii import hexlify, unhexlify
@@ -22,6 +23,8 @@ from .schedule import NO_ROUNDING
 
 
 jlog = get_log()
+logsdir = os.path.join(os.path.dirname(
+    jm_single().config_location), "logs")
 
 
 class JMTakerError(Exception):
@@ -753,7 +756,7 @@ class Taker(object):
                         jm_single().config.get("POLICY", "taker_utxo_age"),
                         jm_single().config.get("POLICY", "taker_utxo_amtpercent"))
 
-            with open("commitments_debug.txt", "wb") as f:
+            with open(os.path.join(logsdir, "commitments_debug.txt"), "wb") as f:
                 errmsgfileheader = (b"THIS IS A TEMPORARY FILE FOR DEBUGGING; "
                         b"IT CAN BE SAFELY DELETED ANY TIME.\n")
                 errmsgfileheader += (b"***\n")


### PR DESCRIPTION
Some log files were created at the working directory instead of being put into the configuration location. Probably the log files should all be put in `~/.joinmarket/logs` by default.