### PR TITLE
Close wallet when WalletService is stopped.

### DIFF
--- a/jmclient/jmclient/wallet_service.py
+++ b/jmclient/jmclient/wallet_service.py
@@ -91,9 +91,12 @@ class WalletService(Service):
 
     def stopService(self):
         """ Encapsulates shut down actions.
-        Here shut down main tx monitoring loop.
+        Note that after the service is stopped, it
+        should *not* be restarted, instead a new
+        WalletService instance should be created.
         """
         self.monitor_loop.stop()
+        self.wallet.close()
         super(WalletService, self).stopService()
 
     def isRunning(self):

--- a/scripts/joinmarket-qt.py
+++ b/scripts/joinmarket-qt.py
@@ -1754,6 +1754,7 @@ class JMMainWindow(QMainWindow):
         self.wallet_service.autofreeze_warning_cb = self.autofreeze_warning_cb
 
         self.wallet_service.startService()
+        self.syncmsg = ""
         self.walletRefresh = task.LoopingCall(self.updateWalletInfo)
         self.walletRefresh.start(5.0)
 


### PR DESCRIPTION
Fixes #594.

For a little background/context, note: previous to this, the wallet file lock was removed in a call to `.close()` method of `Storage` in an override of `Storage.__del__` in `storage.py` (wallet is saved, then closed, then lock is removed).

The use case in #594 does not involve deleting the wallet object, so lock was not removed.
But here #359 architecture change shows its value again; we just include wallet close as part of stopping the WalletService.