### PR TITLE
Refactor: #566 use python3 super() syntax

### DIFF
--- a/jmbase/jmbase/support.py
+++ b/jmbase/jmbase/support.py
@@ -67,7 +67,7 @@ DUST_THRESHOLD = 2730
 class JoinMarketStreamHandler(ColorizingStreamHandler):
 
     def __init__(self):
-        super(JoinMarketStreamHandler, self).__init__(colorizer=jm_colorizer)
+        super().__init__(colorizer=jm_colorizer)
 
     def emit(self, record):
         if joinmarket_alert[0]:
@@ -75,7 +75,7 @@ class JoinMarketStreamHandler(ColorizingStreamHandler):
         if core_alert[0]:
             print('Core Alert Message: ' + core_alert[0])
         if not debug_silence[0]:
-            super(JoinMarketStreamHandler, self).emit(record)
+            super().emit(record)
 
 handler = JoinMarketStreamHandler()
 handler.setFormatter(logFormatter)

--- a/jmclient/jmclient/blockchaininterface.py
+++ b/jmclient/jmclient/blockchaininterface.py
@@ -76,7 +76,7 @@ class ElectrumWalletInterface(BlockchainInterface): #pragma: no cover
     """
 
     def __init__(self, testnet=False):
-        super(ElectrumWalletInterface, self).__init__()
+        super().__init__()
         self.last_sync_unspent = 0
 
     def set_wallet(self, wallet):
@@ -150,7 +150,7 @@ class ElectrumWalletInterface(BlockchainInterface): #pragma: no cover
         return result
 
     def estimate_fee_per_kb(self, N):
-        if super(ElectrumWalletInterface, self).fee_per_kb_has_been_manually_set(N):
+        if super().fee_per_kb_has_been_manually_set(N):
             # use a floor of 1000 to not run into node relay problems
             return int(max(1000, random.uniform(N * float(0.8), N * float(1.2))))
         fee = self.wallet.network.synchronous_get(('blockchain.estimatefee', [N]
@@ -162,7 +162,7 @@ class ElectrumWalletInterface(BlockchainInterface): #pragma: no cover
 class BitcoinCoreInterface(BlockchainInterface):
 
     def __init__(self, jsonRpc, network):
-        super(BitcoinCoreInterface, self).__init__()
+        super().__init__()
         self.jsonRpc = jsonRpc
         blockchainInfo = self.rpc("getblockchaininfo", [])
         if not blockchainInfo:
@@ -394,7 +394,7 @@ class BitcoinCoreInterface(BlockchainInterface):
         return result
 
     def estimate_fee_per_kb(self, N):
-        if super(BitcoinCoreInterface, self).fee_per_kb_has_been_manually_set(N):
+        if super().fee_per_kb_has_been_manually_set(N):
             # use the local bitcoin core relay fee as floor to avoid relay problems
             btc_relayfee = -1
             rpc_result = self.rpc('getnetworkinfo', None)
@@ -516,7 +516,7 @@ class RegtestBitcoinCoreMixin():
 class BitcoinCoreNoHistoryInterface(BitcoinCoreInterface, RegtestBitcoinCoreMixin):
 
     def __init__(self, jsonRpc, network):
-        super(BitcoinCoreNoHistoryInterface, self).__init__(jsonRpc, network)
+        super().__init__(jsonRpc, network)
         self.import_addresses_call_count = 0
         self.wallet_name = None
         self.scan_result = None
@@ -575,7 +575,7 @@ class BitcoinCoreNoHistoryInterface(BitcoinCoreInterface, RegtestBitcoinCoreMixi
                 "amount": u["amount"]
                 } for u in self.scan_result["unspents"]]
         else:
-            return super(BitcoinCoreNoHistoryInterface, self).rpc(method, args)
+            return super().rpc(method, args)
 
     def set_wallet_no_history(self, wallet):
         #make wallet-tool not display any new addresses
@@ -588,7 +588,7 @@ class BitcoinCoreNoHistoryInterface(BitcoinCoreInterface, RegtestBitcoinCoreMixi
 
     def tick_forward_chain(self, n):
         self.destn_addr = self.rpc("getnewaddress", [])
-        super(BitcoinCoreNoHistoryInterface, self).tick_forward_chain(n)
+        super().tick_forward_chain(n)
 
 # class for regtest chain access
 # running on local daemon. Only
@@ -597,7 +597,7 @@ class BitcoinCoreNoHistoryInterface(BitcoinCoreInterface, RegtestBitcoinCoreMixi
 class RegtestBitcoinCoreInterface(BitcoinCoreInterface, RegtestBitcoinCoreMixin): #pragma: no cover
 
     def __init__(self, jsonRpc):
-        super(RegtestBitcoinCoreInterface, self).__init__(jsonRpc, 'regtest')
+        super().__init__(jsonRpc, 'regtest')
         self.pushtx_failure_prob = 0
         self.tick_forward_chain_interval = -1
         self.absurd_fees = False
@@ -607,8 +607,7 @@ class RegtestBitcoinCoreInterface(BitcoinCoreInterface, RegtestBitcoinCoreMixin)
 
     def estimate_fee_per_kb(self, N):
         if not self.absurd_fees:
-            return super(RegtestBitcoinCoreInterface,
-                         self).estimate_fee_per_kb(N)
+            return super().estimate_fee_per_kb(N)
         else:
             return jm_single().config.getint("POLICY",
                                              "absurd_fee_per_kb") + 100
@@ -635,7 +634,7 @@ class RegtestBitcoinCoreInterface(BitcoinCoreInterface, RegtestBitcoinCoreMixin)
                       (self.pushtx_failure_prob * 100))
             return True
 
-        ret = super(RegtestBitcoinCoreInterface, self).pushtx(txhex)
+        ret = super().pushtx(txhex)
         if not self.simulating and self.tick_forward_chain_interval > 0:
             log.debug('will call tfc after ' + str(self.tick_forward_chain_interval) + ' seconds.')
             reactor.callLater(self.tick_forward_chain_interval,

--- a/jmclient/jmclient/configure.py
+++ b/jmclient/jmclient/configure.py
@@ -52,7 +52,7 @@ class AttributeDict(object):
             fileHandler.setFormatter(logFormatter)
             log.addHandler(fileHandler)
 
-        super(AttributeDict, self).__setattr__(name, value)
+        super().__setattr__(name, value)
 
     def __getitem__(self, key):
         """

--- a/jmclient/jmclient/maker.py
+++ b/jmclient/jmclient/maker.py
@@ -302,7 +302,7 @@ class P2EPMaker(Maker):
     is not possible.
     """
     def __init__(self, wallet_service, mixdepth, amount):
-        super(P2EPMaker, self).__init__(wallet_service)
+        super().__init__(wallet_service)
         self.receiving_amount = amount
         self.mixdepth = mixdepth
         # destination mixdepth must be different from that

--- a/jmclient/jmclient/storage.py
+++ b/jmclient/jmclient/storage.py
@@ -321,8 +321,7 @@ class VolatileStorage(Storage):
 
     def __init__(self, password=None, data=None):
         self.file_data = None
-        super(VolatileStorage, self).__init__('VOLATILE', password,
-                                              create=True)
+        super().__init__('VOLATILE', password, create=True)
         if data:
             self.file_data = data
             self._load_file(password)

--- a/jmclient/jmclient/taker.py
+++ b/jmclient/jmclient/taker.py
@@ -886,7 +886,8 @@ class P2EPTaker(Taker):
     """
 
     def __init__(self, counterparty, wallet_service, schedule, callbacks):
-        super(P2EPTaker, self).__init__(wallet_service, schedule, (1, float('inf')), callbacks=callbacks)
+        super().__init__(wallet_service, schedule, (1, float('inf')),
+                         callbacks=callbacks)
         self.p2ep_receiver_nick = counterparty
         # Callback to request user permission (for e.g. GUI)
         # args: (1) message, as string

--- a/jmclient/jmclient/wallet.py
+++ b/jmclient/jmclient/wallet.py
@@ -1005,7 +1005,7 @@ class PSBTWalletMixin(object):
     functions.
     """
     def __init__(self, storage, **kwargs):
-        super(PSBTWalletMixin, self).__init__(storage, **kwargs)
+        super().__init__(storage, **kwargs)
 
     def is_input_finalized(self, psbt_input):
         """ This should be a convenience method in python-bitcointx.
@@ -1258,7 +1258,7 @@ class SNICKERWalletMixin(object):
     SUPPORTED_SNICKER_VERSIONS = bytes([0, 1])
 
     def __init__(self, storage, **kwargs):
-        super(SNICKERWalletMixin, self).__init__(storage, **kwargs)
+        super().__init__(storage, **kwargs)
 
     def create_snicker_proposal(self, our_input, their_input, our_input_utxo,
                                 their_input_utxo, net_transfer, network_fee,
@@ -1502,10 +1502,10 @@ class ImportWalletMixin(object):
         # {mixdepth: [(privkey, type)]}
         self._imported = None
         # path is (_IMPORTED_ROOT_PATH, mixdepth, key_index)
-        super(ImportWalletMixin, self).__init__(storage, **kwargs)
+        super().__init__(storage, **kwargs)
 
     def _load_storage(self):
-        super(ImportWalletMixin, self)._load_storage()
+        super()._load_storage()
         self._imported = collections.defaultdict(list)
         for md, keys in self._storage.data[self._IMPORTED_STORAGE_KEY].items():
             md = int(md)
@@ -1522,7 +1522,7 @@ class ImportWalletMixin(object):
         for md in self._imported:
             import_data[_int_to_bytestr(md)] = self._imported[md]
         self._storage.data[self._IMPORTED_STORAGE_KEY] = import_data
-        super(ImportWalletMixin, self).save()
+        super().save()
 
     @classmethod
     def initialize(cls, storage, network, max_mixdepth=2, timestamp=None,
@@ -1621,14 +1621,14 @@ class ImportWalletMixin(object):
 
     def _get_mixdepth_from_path(self, path):
         if not self._is_imported_path(path):
-            return super(ImportWalletMixin, self)._get_mixdepth_from_path(path)
+            return super()._get_mixdepth_from_path(path)
 
         assert len(path) == 3
         return path[1]
 
     def _get_key_from_path(self, path):
         if not self._is_imported_path(path):
-            return super(ImportWalletMixin, self)._get_key_from_path(path)
+            return super()._get_key_from_path(path)
 
         assert len(path) == 3
         md, i = path[1], path[2]
@@ -1652,13 +1652,13 @@ class ImportWalletMixin(object):
     def path_repr_to_path(self, pathstr):
         spath = pathstr.encode('ascii').split(b'/')
         if not self._is_imported_path(spath):
-            return super(ImportWalletMixin, self).path_repr_to_path(pathstr)
+            return super().path_repr_to_path(pathstr)
 
         return self._IMPORTED_ROOT_PATH, int(spath[1]), int(spath[2])
 
     def get_path_repr(self, path):
         if not self._is_imported_path(path):
-            return super(ImportWalletMixin, self).get_path_repr(path)
+            return super().get_path_repr(path)
 
         assert len(path) == 3
         return 'imported/{}/{}'.format(*path[1:])
@@ -1673,12 +1673,12 @@ class ImportWalletMixin(object):
 
     def get_details(self, path):
         if not self._is_imported_path(path):
-            return super(ImportWalletMixin, self).get_details(path)
+            return super().get_details(path)
         return path[1], 'imported', path[2]
 
     def get_script_from_path(self, path):
         if not self._is_imported_path(path):
-            return super(ImportWalletMixin, self).get_script_from_path(path)
+            return super().get_script_from_path(path)
 
         priv, engine = self._get_key_from_path(path)
         return engine.key_to_script(priv)
@@ -1692,7 +1692,7 @@ class BIP39WalletMixin(object):
     MNEMONIC_LANG = 'english'
 
     def _load_storage(self):
-        super(BIP39WalletMixin, self)._load_storage()
+        super()._load_storage()
         self._entropy_extension = self._storage.data.get(self._BIP39_EXTENSION_KEY)
 
     @classmethod
@@ -1722,7 +1722,7 @@ class BIP39WalletMixin(object):
         return ent and len(ent) % 4 == 0
 
     def get_mnemonic_words(self):
-        entropy = super(BIP39WalletMixin, self)._create_master_key()
+        entropy = super()._create_master_key()
         m = Mnemonic(self.MNEMONIC_LANG)
         return m.to_mnemonic(entropy), self._entropy_extension
 
@@ -1757,7 +1757,7 @@ class BIP32Wallet(BaseWallet):
         # path is a tuple of BIP32 levels,
         # m is the master key's fingerprint
         # other levels are ints
-        super(BIP32Wallet, self).__init__(storage, **kwargs)
+        super().__init__(storage, **kwargs)
         assert self._index_cache is not None
         assert self._verify_entropy(self._entropy)
 
@@ -1796,7 +1796,7 @@ class BIP32Wallet(BaseWallet):
             storage.save()
 
     def _load_storage(self):
-        super(BIP32Wallet, self)._load_storage()
+        super()._load_storage()
         self._entropy = self._storage.data[self._STORAGE_ENTROPY_KEY]
 
         self._index_cache = collections.defaultdict(
@@ -1833,7 +1833,7 @@ class BIP32Wallet(BaseWallet):
 
             self._storage.data[self._STORAGE_INDEX_CACHE][str_md] = str_data
 
-        super(BIP32Wallet, self).save()
+        super().save()
 
     def _create_master_key(self):
         """
@@ -2177,7 +2177,7 @@ class FidelityBondMixin(object):
             return False
 
     def _populate_script_map(self):
-        super(FidelityBondMixin, self)._populate_script_map()
+        super()._populate_script_map()
         for md in self._index_cache:
             address_type = self.BIP32_TIMELOCK_ID
             for i in range(self._index_cache[md][address_type]):
@@ -2187,8 +2187,7 @@ class FidelityBondMixin(object):
                     self._script_map[script] = path
 
     def add_utxo(self, txid, index, script, value, height=None):
-        super(FidelityBondMixin, self).add_utxo(txid, index, script, value,
-            height)
+        super().add_utxo(txid, index, script, value, height)
         #dont use coin control freeze if wallet readonly
         if self._storage.read_only:
             return
@@ -2200,7 +2199,7 @@ class FidelityBondMixin(object):
             self.disable_utxo(txid, index, disable=True)
 
     def get_bip32_pub_export(self, mixdepth=None, address_type=None):
-        bip32_pub = super(FidelityBondMixin, self).get_bip32_pub_export(mixdepth, address_type)
+        bip32_pub = super().get_bip32_pub_export(mixdepth, address_type)
         if address_type == None and mixdepth == self.FIDELITY_BOND_MIXDEPTH:
             bip32_pub = self._BIP32_PUBKEY_PREFIX + bip32_pub
         return bip32_pub
@@ -2217,12 +2216,12 @@ class FidelityBondMixin(object):
             privkey = engine.derive_bip32_privkey(self._master_key, key_path)
             return (privkey, locktime), engine
         else:
-            return super(FidelityBondMixin, self)._get_key_from_path(path)
+            return super()._get_key_from_path(path)
 
     def get_path(self, mixdepth=None, address_type=None, index=None, timenumber=None):
         if address_type == None or address_type in (self.BIP32_EXT_ID, self.BIP32_INT_ID,
                 self.BIP32_BURN_ID) or index == None:
-            return super(FidelityBondMixin, self).get_path(mixdepth, address_type, index)
+            return super().get_path(mixdepth, address_type, index)
         elif address_type == self.BIP32_TIMELOCK_ID:
             assert timenumber != None
             timestamp = self._time_number_to_timestamp(timenumber)
@@ -2240,28 +2239,25 @@ class FidelityBondMixin(object):
     """
     def get_path_repr(self, path):
         if self.is_timelocked_path(path) and len(path) == 7:
-            return super(FidelityBondMixin, self).get_path_repr(path[:-1]) +\
-                 ":" + str(path[-1])
+            return super().get_path_repr(path[:-1]) + ":" + str(path[-1])
         else:
-            return super(FidelityBondMixin, self).get_path_repr(path)
+            return super().get_path_repr(path)
 
     def path_repr_to_path(self, pathstr):
         if pathstr.find(":") == -1:
-            return super(FidelityBondMixin, self).path_repr_to_path(pathstr)
+            return super().path_repr_to_path(pathstr)
         else:
             colon_chunks = pathstr.split(":")
             if len(colon_chunks) != 2:
                 raise WalletError("Not a valid wallet timelock path: {}".format(pathstr))
             return tuple(chain(
-                super(FidelityBondMixin, self).path_repr_to_path(colon_chunks[0]),
-                (int(colon_chunks[1]),)
-            ))
+                super().path_repr_to_path(colon_chunks[0]), (int(colon_chunks[1]),)))
 
     def get_details(self, path):
         if self.is_timelocked_path(path):
             return self._get_mixdepth_from_path(path), path[-3], path[-2]
         else:
-            return super(FidelityBondMixin, self).get_details(path)
+            return super().get_details(path)
 
     def _get_default_used_indices(self):
         return {x: [0, 0, 0, 0] for x in range(self.max_mixdepth + 1)}
@@ -2333,8 +2329,7 @@ class FidelityBondWatchonlyWallet(FidelityBondMixin, BIP49Wallet):
         return btc.bip32_deserialize(master_entropy.decode())
 
     def _get_bip32_export_path(self, mixdepth=None, address_type=None):
-        path = super(FidelityBondWatchonlyWallet, self)._get_bip32_export_path(
-            mixdepth, address_type)
+        path = super()._get_bip32_export_path(mixdepth, address_type)
         return path
 
 

--- a/jmclient/jmclient/wallet_service.py
+++ b/jmclient/jmclient/wallet_service.py
@@ -120,7 +120,7 @@ class WalletService(Service):
         """ Encapsulates start up actions.
         Here wallet sync.
         """
-        super(WalletService, self).startService()
+        super().startService()
         self.request_sync_wallet()
 
     def stopService(self):
@@ -132,7 +132,7 @@ class WalletService(Service):
         if self.monitor_loop:
             self.monitor_loop.stop()
         self.wallet.close()
-        super(WalletService, self).stopService()
+        super().stopService()
 
     def isRunning(self):
         if self.running == 1:

--- a/jmclient/jmclient/wallet_utils.py
+++ b/jmclient/jmclient/wallet_utils.py
@@ -170,8 +170,8 @@ class WalletViewBase(object):
 class WalletViewEntry(WalletViewBase):
     def __init__(self, wallet_path_repr, account, address_type, aindex, addr, amounts,
                  used = 'new', serclass=str, priv=None, custom_separator=None):
-        super(WalletViewEntry, self).__init__(wallet_path_repr, serclass=serclass,
-                                              custom_separator=custom_separator)
+        super().__init__(wallet_path_repr, serclass=serclass,
+                         custom_separator=custom_separator)
         self.account = account
         assert address_type in [SegwitWallet.BIP32_EXT_ID,
             SegwitWallet.BIP32_INT_ID, -1, FidelityBondMixin.BIP32_TIMELOCK_ID,
@@ -229,9 +229,8 @@ class WalletViewEntryBurnOutput(WalletViewEntry):
 class WalletViewBranch(WalletViewBase):
     def __init__(self, wallet_path_repr, account, address_type, branchentries=None,
                  xpub=None, serclass=str, custom_separator=None):
-        super(WalletViewBranch, self).__init__(wallet_path_repr, children=branchentries,
-                                               serclass=serclass,
-                                               custom_separator=custom_separator)
+        super().__init__(wallet_path_repr, children=branchentries,
+                         serclass=serclass, custom_separator=custom_separator)
         self.account = account
         assert address_type in [SegwitWallet.BIP32_EXT_ID,
             SegwitWallet.BIP32_INT_ID, -1, FidelityBondMixin.BIP32_TIMELOCK_ID,
@@ -263,9 +262,8 @@ class WalletViewBranch(WalletViewBase):
 class WalletViewAccount(WalletViewBase):
     def __init__(self, wallet_path_repr, account, branches=None, account_name="mixdepth",
                  serclass=str, custom_separator=None, xpub=None):
-        super(WalletViewAccount, self).__init__(wallet_path_repr, children=branches,
-                                                serclass=serclass,
-                                                custom_separator=custom_separator)
+        super().__init__(wallet_path_repr, children=branches, serclass=serclass,
+                         custom_separator=custom_separator)
         self.account = account
         self.account_name = account_name
         self.xpub = xpub
@@ -290,9 +288,8 @@ class WalletViewAccount(WalletViewBase):
 class WalletView(WalletViewBase):
     def __init__(self, wallet_path_repr, accounts, wallet_name="JM wallet",
                  serclass=str, custom_separator=None):
-        super(WalletView, self).__init__(wallet_path_repr, children=accounts,
-                                         serclass=serclass,
-                                         custom_separator=custom_separator)
+        super().__init__(wallet_path_repr, children=accounts, serclass=serclass,
+                         custom_separator=custom_separator)
         self.wallet_name = wallet_name
         assert all([isinstance(x, WalletViewAccount) for x in accounts])
         self.accounts = accounts

--- a/jmclient/jmclient/yieldgenerator.py
+++ b/jmclient/jmclient/yieldgenerator.py
@@ -73,7 +73,7 @@ class YieldGeneratorBasic(YieldGenerator):
     def __init__(self, wallet_service, offerconfig):
         self.txfee, self.cjfee_a, self.cjfee_r, self.ordertype, self.minsize \
              = offerconfig
-        super(YieldGeneratorBasic,self).__init__(wallet_service)
+        super().__init__(wallet_service)
 
     def create_my_orders(self):
         mix_balance = self.get_available_mixdepths()

--- a/jmclient/test/test_storage.py
+++ b/jmclient/test/test_storage.py
@@ -7,7 +7,7 @@ class MockStorage(storage.Storage):
     def __init__(self, data, *args, **kwargs):
         self.file_data = data
         self.locked = False
-        super(type(self), self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     def _read_file(self):
         if hasattr(self, 'file_data'):

--- a/jmclient/test/test_taker.py
+++ b/jmclient/test/test_taker.py
@@ -27,9 +27,8 @@ def convert_utxos(utxodict):
 class DummyWallet(SegwitLegacyWallet):
     def __init__(self):
         storage = VolatileStorage()
-        super(DummyWallet, self).initialize(storage, get_network(),
-                                            max_mixdepth=5)
-        super(DummyWallet, self).__init__(storage)
+        super().initialize(storage, get_network(), max_mixdepth=5)
+        super().__init__(storage)
         self._add_utxos()
         self.inject_addr_get_failure = False
 

--- a/jmclient/test/test_yieldgenerator.py
+++ b/jmclient/test/test_yieldgenerator.py
@@ -20,9 +20,8 @@ class CustomUtxoWallet(SegwitLegacyWallet):
         load_test_config()
 
         storage = VolatileStorage()
-        super(CustomUtxoWallet, self).initialize(storage, get_network(),
-                                                 max_mixdepth=len(balances)-1)
-        super(CustomUtxoWallet, self).__init__(storage)
+        super().initialize(storage, get_network(), max_mixdepth=len(balances)-1)
+        super().__init__(storage)
 
         for m, b in enumerate(balances):
             self.add_utxo_at_mixdepth(m, b)

--- a/jmdaemon/test/test_daemon_protocol.py
+++ b/jmdaemon/test/test_daemon_protocol.py
@@ -187,15 +187,13 @@ def end_test():
 class JMDaemonTestServerProtocol(JMDaemonServerProtocol):
 
     def __init__(self, factory):
-        super(JMDaemonTestServerProtocol, self).__init__(factory)
+        super().__init__(factory)
         #respondtoioauths should do nothing unless jmstate = 2
         self.respondToIoauths(True)
         #calling on_JM_MAKE_TX should also do nothing in wrong state
-        assert super(JMDaemonTestServerProtocol, self).on_JM_MAKE_TX(
-            1, 2) == {'accepted': False}
+        assert super().on_JM_MAKE_TX(1, 2) == {'accepted': False}
         #calling on_JM_FILL with negative amount should reject
-        assert super(JMDaemonTestServerProtocol, self).on_JM_FILL(
-            -1000, 2, 3, 4) == {'accepted': False}
+        assert super().on_JM_FILL(-1000, 2, 3, 4) == {'accepted': False}
         #checkutxos also does nothing for rejection at the moment
         self.checkUtxosAccepted(False)
         #None should be returned requesting a cryptobox for an unknown cp
@@ -210,7 +208,7 @@ class JMDaemonTestServerProtocol(JMDaemonServerProtocol):
             self.on_order_seen(o["counterparty"], o["oid"], o["ordertype"],
                                  o["minsize"], o["maxsize"],
                                  o["txfee"], o["cjfee"])
-        return super(JMDaemonTestServerProtocol, self).on_JM_REQUEST_OFFERS()
+        return super().on_JM_REQUEST_OFFERS()
         
     @JMInit.responder
     def on_JM_INIT(self, bcsource, network, irc_configs, minmakers,
@@ -257,15 +255,13 @@ class JMDaemonTestServerProtocol(JMDaemonServerProtocol):
             reactor.callLater(1, self.on_pubkey, k, dummypub)
             reactor.callLater(2, self.on_ioauth, k, ['a', 'b'], "auth_pub",
                               "cj_addr", "change_addr", "btc_sig")
-        return super(JMDaemonTestServerProtocol, self).on_JM_FILL(amount,
-                                            commitment, revelation, filled_offers)
+        return super().on_JM_FILL(amount, commitment, revelation, filled_offers)
 
     @JMMakeTx.responder
     def on_JM_MAKE_TX(self, nick_list, txhex):
         for n in json.loads(nick_list):
             reactor.callLater(1, self.on_sig, n, "dummytxsig")
-        return super(JMDaemonTestServerProtocol, self).on_JM_MAKE_TX(nick_list,
-                                                                     txhex)
+        return super().on_JM_MAKE_TX(nick_list, txhex)
 
 
 

--- a/jmdaemon/test/test_irc_messaging.py
+++ b/jmdaemon/test/test_irc_messaging.py
@@ -16,7 +16,7 @@ class DummyDaemon(object):
     
 class DummyMC(IRCMessageChannel):
     def __init__(self, configdata, nick, daemon):
-        super(DummyMC, self).__init__(configdata, daemon=daemon)
+        super().__init__(configdata, daemon=daemon)
         self.daemon = daemon
         self.set_nick(nick)
 

--- a/jmdaemon/test/test_orderbookwatch.py
+++ b/jmdaemon/test/test_orderbookwatch.py
@@ -13,7 +13,7 @@ class DummyDaemon(object):
 
 class DummyMC(IRCMessageChannel):
     def __init__(self, configdata, nick, daemon):
-        super(DummyMC, self).__init__(configdata, daemon=daemon)
+        super().__init__(configdata, daemon=daemon)
         self.daemon = daemon
         self.set_nick(nick)
 

--- a/scripts/joinmarket-qt.py
+++ b/scripts/joinmarket-qt.py
@@ -176,7 +176,7 @@ class HelpLabel(QLabel):
 class SettingsTab(QDialog):
 
     def __init__(self):
-        super(SettingsTab, self).__init__()
+        super().__init__()
         self.initUI()
 
     def initUI(self):
@@ -319,7 +319,7 @@ class SpendStateMgr(object):
 class SpendTab(QWidget):
 
     def __init__(self):
-        super(SpendTab, self).__init__()
+        super().__init__()
         self.initUI()
         self.taker = None
         self.filter_offers_response = None
@@ -1042,7 +1042,7 @@ class SpendTab(QWidget):
 class TxHistoryTab(QWidget):
 
     def __init__(self):
-        super(TxHistoryTab, self).__init__()
+        super().__init__()
         self.initUI()
 
     def initUI(self):
@@ -1117,7 +1117,7 @@ class TxHistoryTab(QWidget):
 class CoinsTab(QWidget):
 
     def __init__(self):
-        super(CoinsTab, self).__init__()
+        super().__init__()
         self.initUI()
 
     def initUI(self):
@@ -1231,7 +1231,7 @@ class CoinsTab(QWidget):
 class BitcoinQRCodePopup(QDialog):
 
     def __init__(self, parent, address):
-        super(BitcoinQRCodePopup, self).__init__(parent)
+        super().__init__(parent)
         self.address = address
         self.setWindowTitle(address)
         img = qrcode.make('bitcoin:' + address)
@@ -1249,7 +1249,7 @@ class BitcoinQRCodePopup(QDialog):
 class JMWalletTab(QWidget):
 
     def __init__(self):
-        super(JMWalletTab, self).__init__()
+        super().__init__()
         self.wallet_name = 'NONE'
         self.initUI()
 
@@ -1388,7 +1388,7 @@ class JMMainWindow(QMainWindow):
     show_privkeys_signal = QtCore.Signal()
 
     def __init__(self, reactor):
-        super(JMMainWindow, self).__init__()
+        super().__init__()
         # the wallet service that encapsulates
         # the wallet we will interact with
         self.wallet_service = None

--- a/scripts/qtsupport.py
+++ b/scripts/qtsupport.py
@@ -167,7 +167,7 @@ def JMQtMessageBox(obj, msg, mbtype='info', title='', detailed_text= None):
                     self.setMaximumHeight(16777215)
                     self.setMinimumWidth(0)
                     self.setMaximumWidth(16777215)
-                    result = super(JMQtDMessageBox, self).resizeEvent(event)
+                    result = super().resizeEvent(event)
                     details_box = self.findChild(QTextEdit)
                     if details_box is not None:
                         details_box.setMinimumHeight(0)
@@ -366,7 +366,7 @@ def make_password_dialog(self, msg, new_pass=True):
 class PasswordDialog(QDialog):
 
     def __init__(self):
-        super(PasswordDialog, self).__init__()
+        super().__init__()
         self.initUI()
 
     def initUI(self):
@@ -511,7 +511,7 @@ class MyTreeWidget(QTreeWidget):
 # TODO implement this option
 #class SchStaticPage(QWizardPage):
 #    def __init__(self, parent):
-#        super(SchStaticPage, self).__init__(parent)
+#        super().__init__(parent)
 #        self.setTitle("Manually create a schedule entry")
 #        layout = QGridLayout()
 #        wdgts = getSettingsWidgets()
@@ -627,7 +627,7 @@ class BitcoinAmountEdit(QWidget):
 
 class SchDynamicPage1(QWizardPage):
     def __init__(self, parent):
-        super(SchDynamicPage1, self).__init__(parent)
+        super().__init__(parent)
         self.setTitle("Tumble schedule generation")
         self.setSubTitle("Set parameters for the sequence of transactions in the tumble.")
         results = []
@@ -702,7 +702,7 @@ class SchDynamicPage2(QWizardPage):
         self.setLayout(self.layout)
 
     def __init__(self, parent):
-        super(SchDynamicPage2, self).__init__(parent)
+        super().__init__(parent)
         self.setTitle("Destination addresses")
         self.setSubTitle("Enter destination addresses for coins; "
                         "minimum 3 for privacy. You may leave later ones blank.")
@@ -712,7 +712,7 @@ class SchDynamicPage2(QWizardPage):
 
 class SchFinishPage(QWizardPage):
     def __init__(self, parent):
-        super(SchFinishPage, self).__init__(parent)
+        super().__init__(parent)
         self.setTitle("Advanced options")
         self.setSubTitle("(the default values are usually sufficient)")
         layout = QGridLayout()
@@ -781,7 +781,7 @@ class SchFinishPage(QWizardPage):
 
 class SchIntroPage(QWizardPage):
     def __init__(self, parent):
-        super(SchIntroPage, self).__init__(parent)
+        super().__init__(parent)
         self.setTitle("Generate a join transaction schedule")
         self.rbgroup = QButtonGroup(self)
         self.r0 = QRadioButton("Define schedule manually (not yet implemented)")
@@ -808,7 +808,7 @@ class SchIntroPage(QWizardPage):
 
 class ScheduleWizard(QWizard):
     def __init__(self):
-        super(ScheduleWizard, self).__init__()
+        super().__init__()
         self.setWindowTitle("Joinmarket schedule generator")
         self.setPage(0, SchIntroPage(self))
         self.setPage(1, SchDynamicPage1(self))
@@ -858,7 +858,7 @@ class ScheduleWizard(QWizard):
 
 class TumbleRestartWizard(QWizard):
     def __init__(self):
-        super(TumbleRestartWizard, self).__init__()
+        super().__init__()
         self.setWindowTitle("Restart tumbler schedule")
         self.setPage(0, RestartSettingsPage(self))
 
@@ -875,7 +875,7 @@ class TumbleRestartWizard(QWizard):
 class RestartSettingsPage(QWizardPage):
 
     def __init__(self, parent):
-        super(RestartSettingsPage, self).__init__(parent)
+        super().__init__(parent)
         self.setTitle("Tumbler options")
         self.setSubTitle("Options settings that can be varied on restart")
         layout = QGridLayout()

--- a/scripts/yg-privacyenhanced.py
+++ b/scripts/yg-privacyenhanced.py
@@ -32,7 +32,7 @@ jlog = get_log()
 class YieldGeneratorPrivacyEnhanced(YieldGeneratorBasic):
 
     def __init__(self, wallet_service, offerconfig):
-        super(YieldGeneratorPrivacyEnhanced, self).__init__(wallet_service, offerconfig)
+        super().__init__(wallet_service, offerconfig)
 
     def create_my_orders(self):
         mix_balance = self.get_available_mixdepths()

--- a/test/ygrunner.py
+++ b/test/ygrunner.py
@@ -42,15 +42,13 @@ class MaliciousYieldGenerator(YieldGeneratorBasic):
             if random.randint(1, 100) < self.mfrac:
                 jmprint("Counterparty commitment rejected maliciously", "debug")
                 return (False,)
-        return super(MaliciousYieldGenerator, self).on_auth_received(nick,
-                                    offer, commitment, cr, amount, kphex)
+        return super().on_auth_received(nick, offer, commitment, cr, amount, kphex)
     def on_tx_received(self, nick, txhex, offerinfo):
         if self.txmal:
             if random.randint(1, 100) < self.mfrac:
                 jmprint("Counterparty tx rejected maliciously", "debug")
                 return (False, "malicious tx rejection")
-        return super(MaliciousYieldGenerator, self).on_tx_received(nick, txhex,
-                                                                   offerinfo)
+        return super().on_tx_received(nick, txhex, offerinfo)
 
 class DeterministicMaliciousYieldGenerator(YieldGeneratorBasic):
     """Overrides, randomly chosen persistently, some maker functions
@@ -75,14 +73,12 @@ class DeterministicMaliciousYieldGenerator(YieldGeneratorBasic):
         if self.authmal:
             jmprint("Counterparty commitment rejected maliciously", "debug")
             return (False,)
-        return super(DeterministicMaliciousYieldGenerator, self).on_auth_received(nick,
-                                    offer, commitment, cr, amount, kphex)
+        return super().on_auth_received(nick, offer, commitment, cr, amount, kphex)
     def on_tx_received(self, nick, txhex, offerinfo):
         if self.txmal:
             jmprint("Counterparty tx rejected maliciously", "debug")
             return (False, "malicious tx rejection")
-        return super(DeterministicMaliciousYieldGenerator, self).on_tx_received(nick, txhex,
-                                                                   offerinfo)
+        return super().on_tx_received(nick, txhex, offerinfo)
 
 @pytest.mark.parametrize(
     "num_ygs, wallet_structures, mean_amt, malicious, deterministic",


### PR DESCRIPTION
This should close #566.

Did a `grep -r -n "super" *` on the codebase, found all places where the method was not a classmethod, and emptied the brackets.