### PR TITLE
Check for pushtx() success in direct_send()

### DIFF
--- a/scripts/joinmarket-qt.py
+++ b/scripts/joinmarket-qt.py
@@ -650,8 +650,11 @@ class SpendTab(QWidget):
         else:
             return False
 
-    def infoDirectSend(self, txid):
-        JMQtMessageBox(self, "Tx sent: " + str(txid), title="Success")
+    def infoDirectSend(self, msg):
+        JMQtMessageBox(self, msg, title="Success")
+
+    def errorDirectSend(self, msg):
+        JMQtMessageBox(self, msg, mbtype="warn", title="Error")
 
     def startSingle(self):
         if not self.spendstate.runstate == 'ready':
@@ -672,7 +675,8 @@ class SpendTab(QWidget):
             try:
                 txid = direct_send(mainWindow.wallet_service, amount, mixdepth,
                                   destaddr, accept_callback=self.checkDirectSend,
-                                  info_callback=self.infoDirectSend)
+                                  info_callback=self.infoDirectSend,
+                                  error_callback=self.errorDirectSend)
             except Exception as e:
                 JMQtMessageBox(self, e.args[0], title="Error", mbtype="warn")
                 return


### PR DESCRIPTION
Before this change scripts lie to user about success, both in GUI and cli, error is only in debug output. 
```
2020-06-16 00:20:32,141 [DEBUG]  error pushing = -26 min relay fee not met, 133 < 134 (code 66)
2020-06-16 00:20:32,149 [INFO]  Transaction sent: 466997d3dc66f430b8e325256389461fce2f418c4747132a082ff8814777a735
done
```
This affected only `direct_send()`, in other places `pushtx()` result is correctly checked.

There isn't a nice way to display detailed reason of why transaction broadcast failed in GUI, that would require change in `pushtx()` interface, can be done later.

Change in `infoDirectSend()` is to have "Transaction sent: XXX" in case of success, not "Tx sent: Transaction sent: XXX", as it was now.

Also noticed there isn't any tests for `direct_send()`, also something can be improved in future.