### PR TITLE
Pin PyQt5 to 5.14.2

### DIFF
--- a/requirements/gui.txt
+++ b/requirements/gui.txt
@@ -1,4 +1,5 @@
 -r base.txt
 PySide2
+PyQt5==5.14.2
 qrcode[pil]
 https://github.com/sunu/qt5reactor/archive/58410aaead2185e9917ae9cac9c50fe7b70e4a60.zip#egg=qt5reactor


### PR DESCRIPTION
See #597 and https://bugreports.qt.io/browse/PYSIDE-1317?gerritReviewStatus=Open

Installation working correctly as per my tests in Ubuntu1804 VM, after this change (including doing a coinjoin via Qt).

Given the comments in #597 and thus we have 3 reports, now, of it working after this change, it seems a sensible one, and probably needed.

(I will note here an issue I had on Virtual Box using my Ubuntu1804 VM, as much for my own reference as anything: I had a problem with Qt core dumping, independent of this PR, that could only be fixed with `sudo apt install --reinstall libxcb-xinerama0` .. for no reason I can easily discern, although from websearching, this issue is not uncommon).