### PR TITLE
tests: Fix 0.20 compatibility of test suite

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -120,7 +120,7 @@ def setup(request):
                        "-rpcuser=" + bitcoin_rpcusername,
                        "-rpcpassword=" + bitcoin_rpcpassword]
     for i in range(2):
-        destn_addr = local_command(root_cmd + ["getnewaddress"])
+        destn_addr = local_command(root_cmd + ["getnewaddress"])[:-1].decode('utf-8')
         local_command(root_cmd + ["generatetoaddress", "301", destn_addr])
         time.sleep(1)
     

--- a/test/bitcoin.conf
+++ b/test/bitcoin.conf
@@ -1,2 +1,3 @@
 rpcuser=bitcoinrpc
 rpcpassword=123456abcdef
+fallbackfee=0.0002


### PR DESCRIPTION
This PR fixes two issues that prevented us from running the master test suite with Bitcoin 0.20
7eab576 adds `fallbackfee=0.0002` to our test bitcoin.conf, as suggested [here](https://github.com/bitcoin/bitcoin/blob/master/doc/release-notes/release-notes-0.20.0.md) ( under Tests section )
536bef5 gets rid of the newline, and decodes the result of our `getnewaddress` command. I have no idea why it wasn't complaining in earlier versions. 

Tests green on 0.20, 0.19.1, and 0.18.0