### PR TITLE
Bugfix: mnemonic extension display in Qt generate

### DIFF
--- a/jmclient/jmclient/wallet.py
+++ b/jmclient/jmclient/wallet.py
@@ -1245,7 +1245,11 @@ class BIP39WalletMixin(object):
             storage, network, max_mixdepth, timestamp, entropy,
             write=False, **kwargs)
         if entropy_extension:
-            storage.data[cls._BIP39_EXTENSION_KEY] = entropy_extension
+            # Note: future reads from storage will retrieve this data
+            # as binary, so set it as binary on initialization for consistency.
+            # Note that this is in contrast to the mnemonic wordlist, which is
+            # handled by the mnemonic package, which returns the words as a string.
+            storage.data[cls._BIP39_EXTENSION_KEY] = entropy_extension.encode("utf-8")
 
         if write:
             storage.save()

--- a/jmclient/jmclient/wallet_utils.py
+++ b/jmclient/jmclient/wallet_utils.py
@@ -562,7 +562,8 @@ def cli_get_wallet_file_name(defaultname="wallet.jmdat"):
 def cli_display_user_words(words, mnemonic_extension):
     text = 'Write down this wallet recovery mnemonic\n\n' + words +'\n'
     if mnemonic_extension:
-        text += '\nAnd this mnemonic extension: ' + mnemonic_extension + '\n'
+        text += '\nAnd this mnemonic extension: ' + mnemonic_extension.decode(
+            'utf-8') + '\n'
     jmprint(text, "important")
 
 def cli_user_mnemonic_entry():


### PR DESCRIPTION
Prior to this fix, doing Wallet->Generate in Qt and
choosing the mnemonic extension option creates an
erroneous error dialog on completion of wallet creation
(even though the wallet is created correctly), due to #565
which correctly decoded the binary mnemonic extension for
the Wallet->Show Seed function, but this was not correct
for the Wallet->Generate case.
The cause for this was the difference between the type of
the mnemonic extension variable when it was created, and
when it is received from storage.
This commit ensures consistency between the two cases by
making a newly created mnemonic extension variable binary.