### PR TITLE
Search for correct library extension on mac os

### DIFF
--- a/jmbitcoin/jmbitcoin/__init__.py
+++ b/jmbitcoin/jmbitcoin/__init__.py
@@ -5,7 +5,11 @@ import coincurve as secp256k1
 # if not, it is assumed to be present at the system level
 # See: https://github.com/Simplexum/python-bitcointx/commit/79333106eeb55841df2935781646369b186d99f7#diff-1ea6586127522e62d109ec5893a18850R301-R310
 import os, sys
-expected_secp_location = os.path.join(sys.prefix, "lib", "libsecp256k1.so")
+if sys.platform == "darwin":
+    secp_name = "libsecp256k1.dylib"
+else:
+    secp_name = "libsecp256k1.so"
+expected_secp_location = os.path.join(sys.prefix, "lib", secp_name)
 if os.path.exists(expected_secp_location):
     import bitcointx
     bitcointx.set_custom_secp256k1_path(expected_secp_location)


### PR DESCRIPTION
This is a complement to #536 

This adds a script to install libsecp256k1 on mac os machines. It is mostly copy pasting the relevant functions from install.sh with two main modifications.

Mac os now uses the Z-shell as as the default shell, so installsecp256k1.sh uses that shell.

We remove the `--prefix "${jm_root}"` option for the build.