### PR TITLE
Update macos installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,12 +24,14 @@ For a quick introduction to Joinmarket you can watch [this demonstration](https:
 * PayJoin - both [BIP78](https://github.com/bitcoin/bips/blob/master/bip-0078.mediawiki) to pay users of other wallets (e.g. merchants), as well as between two JM wallet users. This is a way to boost fungibility/privacy while paying.
 * Protection from [forced address reuse](https://en.bitcoin.it/wiki/Privacy#Forced_address_reuse) attacks.
 
-### Quickstart - RECOMMENDED INSTALLATION METHOD (Linux only)
+### Quickstart - RECOMMENDED INSTALLATION METHOD (Linux and macOS only)
 
 Once you've downloaded this repo, either as a tar/zip file, and extracted it, or via `git clone`:
 
 Make sure to validate the signature on the tar/zip file provided on the [release page](https://github.com/Joinmarket-Org/joinmarket-clientserver/releases),
 or check the signature in git if you install that way using `git log --show-signature`.
+
+**macOS users**: Make sure that you have Homebrew and Apple's Command Line Tools installed.
 
     ./install.sh
     (follow instructions on screen; provide sudo password when prompted)
@@ -48,7 +50,7 @@ Alternative to this "quickstart": follow the [install guide](docs/INSTALL.md).
 
 ### More installation guides
 
-* Installation on MacOS or Windows. Follow [this install guide](docs/INSTALL.md).
+* Installation on macOS or Windows. Follow [this install guide](docs/INSTALL.md).
 * [Installation guide for RaspiBlitz](https://github.com/openoms/bitcoin-tutorials/blob/master/joinmarket/README.md).
 * [Installation guide for RaspiBolt](https://github.com/kristapsk/raspibolt-extras/blob/master/joinmarket.md).
 * [Installation guide for Qubes+Whonix](https://github.com/qubenix/qubes-whonix-bitcoin/blob/master/1_joinmarket.md).

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -74,28 +74,41 @@ command line scripts as explained in the [scripts README](https://github.com/Ada
     ```
     /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
     ```
-3) Install python3 and libsodium
+3) Install automake, libtool, and libsodium
     ```
-    brew install python libsodium
+    brew install automake libtool libsodium
     ```
-4) Create virtualenv "jmvenv"
-    ```sh
-    pip3 install virtualenv
-    virtualenv jmvenv
-    source jmvenv/bin/activate
+4) Build secp256k1
     ```
-    At this point you should see `(jmvenv)` at the beginning of your command prompt.
-
+    git clone https://github.com/bitcoin-core/secp256k1
+    cd secp256k1
+    git checkout 0d9540b13ffcd7cd44cc361b8744b93d88aa76ba
+    ./autogen.sh
+    ./configure --enable-module-recovery --disable-jni --enable-experimental --enable-module-ecdh --enable-benchmark=no
+    make
+    make check
+    sudo make install
+    cd ..
+    rm -rf secp256k1
+    ```
 5) Clone the joinmarket-clientserver repo.
     ```
     git clone https://github.com/Joinmarket-Org/joinmarket-clientserver
     cd joinmarket-clientserver
     ```
-6) Setup joinmarket-qt
+6) Create virtualenv "jmvenv"
+    ```sh
+    sudo pip3 install virtualenv
+    virtualenv jmvenv
+    source jmvenv/bin/activate
+    ```
+    At this point you should see `(jmvenv)` at the beginning of your command prompt.
+
+7) Setup joinmarket-qt
     ```
     pip install -r requirements/gui.txt
     ```
-7) Start joinmarket-qt
+8) Start joinmarket-qt
     ```
     cd scripts
     python joinmarket-qt.py

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -50,7 +50,7 @@ First thing to do: go into `scripts/`, and run:
 This *should* quit with an error, because the connection to Bitcoin Core is not configured; we'll cover that in the next section.
 However, this first run will have automatically created a data directory.
 Locate the newly created file `joinmarket.cfg` which will be in your user home directory under `.joinmarket/`.
-So on Linux you should find it under `/home/username/.joinmarket/joinmarket.cfg`, and similarly for MacOS and Windows.
+So on Linux you should find it under `/home/username/.joinmarket/joinmarket.cfg`, and similarly for macOS and Windows.
 You should see the following files and folders for an initial setup:
 
 ```

--- a/install.sh
+++ b/install.sh
@@ -30,7 +30,7 @@ http_get ()
 
 deps_install ()
 {
-    common_deps=( \
+    debian_deps=( \
         'curl' \
         'build-essential' \
         'automake' \
@@ -41,13 +41,20 @@ deps_install ()
         'virtualenv' \
         'python3-pip' )
 
+    darwin_deps=( \
+        'automake' \
+        'libtool' )
+
     if ! is_python3; then
         echo "Python 2 is no longer supported. Please use a compatible Python 3 version."
         return 1
     fi
 
     if [[ ${install_os} == 'debian' ]]; then
-        deb_deps_install "${common_deps[@]}"
+        deb_deps_install "${debian_deps[@]}"
+        return "$?"
+    elif [[ ${install_os} == 'darwin' ]]; then
+        dar_deps_install "${darwin_deps[@]}"
         return "$?"
     else
         echo "OS can not be determined. Trying to build."
@@ -73,6 +80,22 @@ deb_deps_install ()
         if ! sudo apt-get install ${deb_deps[@]}; then
             return 1
         fi
+    fi
+}
+
+dar_deps_install ()
+{
+    dar_deps=( ${@} )
+    if ! brew install ${dar_deps[@]}; then
+        return 1
+    fi
+    echo "
+        sudo password required to run :
+
+        \`sudo pip3 install virtualenv\`
+        "
+    if ! sudo pip3 install virtualenv; then
+        return 1
     fi
 }
 
@@ -394,6 +417,11 @@ os_is_deb ()
     ( which apt-get && which dpkg-query ) 2>/dev/null 1>&2
 }
 
+os_is_dar ()
+{
+    [[ "$(uname)" == "Darwin" ]]
+}
+
 is_python3 ()
 {
     if [[ ${python} == python3* ]]; then
@@ -409,6 +437,8 @@ install_get_os ()
 {
     if os_is_deb; then
         echo 'debian'
+    elif os_is_dar; then
+        echo 'darwin'
     else
         echo 'unknown'
     fi


### PR DESCRIPTION
This should be merged after #536, and is a followup to #629 

It includes build instructions for libsecp256k1 for those who don't use `install.sh`

@AdamISZ I was wrong, it turns out that `install.sh` does need some modifications to work on mac os from scratch.

My biggest question at this point is whether I have the list of darwin dependencies correct in `install.sh: line 44`

With the current list, I was able to build, and pass the testsuite on fresh installations of Mac OS Catalina with Apple Command Line Tools and Homebrew installed.