### PR TITLE
Fixes #621. Adds +B to joinmarket IRC bots.

### DIFF
--- a/jmdaemon/jmdaemon/irc.py
+++ b/jmdaemon/jmdaemon/irc.py
@@ -265,6 +265,9 @@ class txIRC_Client(irc.IRCClient, object):
 
     def joined(self, channel):
         wlog("INFO", "joined: " + str(channel) + " " + str(self.hostname))
+        # for admin purposes, IRC servers *usually* require bots to identify
+        # themselves as such:
+        self.sendLine("MODE " + self.nickname + " +B")
         #Use as trigger for start to mcc:
         reactor.callLater(0.0, self.wrapper.on_welcome, self.wrapper)
 


### PR DESCRIPTION
Notes:

* the twisted `IRCClient.mode` function appears to be wrongly written, hence this is a hardcoded `sendLine` call.
* tested OK in operation on both our current default server. darkscience shows the bot mode in the WHOIS info.
* this could be done on a per-server basis. Would require that we configure this specifically per server, then adding a line to check the `self.hostname` is trivia.