### PR TITLE
Add support for BIP78 payjoins to .onion receivers

### DIFF
--- a/docs/PAYJOIN.md
+++ b/docs/PAYJOIN.md
@@ -155,6 +155,7 @@ The process here is to use the syntax of sendpayment.py:
 Notes on this:
 * Payjoins BIP78 style are done using the `sendpayment` script (there is no Qt support yet, but it will come later).
 * They are done using BIP21 URIs. These can be copy/pasted from a website (e.g. a btcpayserver invoice page), note that double quotes are required because the string contains special characters. Note also that you must see `pj=` in the URI, otherwise payjoin is not supported by that server.
+* If the url in `pj=` is `****.onion` it means you must be using Tor, remember to have Tor running on your system and change the configuration (see below) for sock5 port if necessary. If you are running the Tor browser the port is 9150 instead of 9050.
 * Don't forget to specify the mixdepth you are spending from with `-m 0`. The payment amount is of course in the URI, along with the address.
 * Pay attention to address type; this point is complicated, but: some servers will not be able to match the address type of the sender, and so won't be able to construct sensible Payjoin transactions. In that case they may fallback to the non-Payjoin payment (which is not a disaster). If you want to do a Payjoin with a server that only supports bech32, you will have to create a new Joinmarket wallet, specifying `native=true` in the `POLICY` section of `joinmarket.cfg` before you generate the wallet.
 
@@ -191,6 +192,15 @@ max_additional_fee_contribution = default
 # this is the minimum satoshis per vbyte we allow in the payjoin
 # transaction; note it is decimal, not integer.
 min_fee_rate = 1.1
+
+
+# for payjoins to hidden service endpoints, the socks5 configuration:
+onion_socks5_host = localhost
+onion_socks5_port = 9050
+# in some exceptional case the HS may be SSL configured,
+# this feature is not yet implemented in code, but here for the
+# future:
+hidden_service_ssl = false
 ```
 
 As the notes mention, you should probably find the defaults here are absolutely fine, and

--- a/jmclient/jmclient/configure.py
+++ b/jmclient/jmclient/configure.py
@@ -323,6 +323,14 @@ max_additional_fee_contribution = default
 # this is the minimum satoshis per vbyte we allow in the payjoin
 # transaction; note it is decimal, not integer.
 min_fee_rate = 1.1
+
+# for payjoins to hidden service endpoints, the socks5 configuration:
+onion_socks5_host = localhost
+onion_socks5_port = 9050
+# in some exceptional case the HS may be SSL configured,
+# this feature is not yet implemented in code, but here for the
+# future:
+hidden_service_ssl = false
 """
 
 #This allows use of the jmclient package with a

--- a/test/payjoinclient.py
+++ b/test/payjoinclient.py
@@ -10,19 +10,37 @@ from jmclient.payjoin import send_payjoin, parse_payjoin_setup
 if __name__ == "__main__":
     wallet_name = sys.argv[1]
     mixdepth = int(sys.argv[2])
+
+    # for now these tests are lazy and only cover two scenarios
+    # (which may be the most likely):
+    # (1) TLS clearnet server
+    # (0) onion non-SSL server
+    # so the third argument is 0 or 1 as per that.
+    # the 4th argument, serverport, is required for (0),
+    # since it's an ephemeral HS address and must include the port
+    # Note on setting up the Hidden Service:
+    # this happens automatically when running test/payjoinserver.py
+    # under pytest, and it prints out the hidden service url after
+    # some seconds (just as it prints out the wallet hex).
+
     usessl = int(sys.argv[3])
-    bip21uri = None
+    serverport = None
     if len(sys.argv) > 4:
-        bip21uri = sys.argv[4]
+        serverport = sys.argv[4]
     load_test_config()
     jm_single().datadir = "."
     check_regtest()
-    if not bip21uri:
-        if usessl == 0:
-            pjurl = "http://127.0.0.1:8080"
+    if not usessl:
+        if not serverport:
+            print("test configuration error: usessl = 0 assumes onion "
+                  "address which must be specified as the fourth argument")
         else:
-            pjurl = "https://127.0.0.1:8080"
-        bip21uri = "bitcoin:2N7CAdEUjJW9tUHiPhDkmL9ukPtcukJMoxK?amount=0.3&pj=" + pjurl
+            pjurl = "http://" + serverport
+    else:
+        # hardcoded port for tests:
+        pjurl = "https://127.0.0.1:8080"
+    bip21uri = "bitcoin:2N7CAdEUjJW9tUHiPhDkmL9ukPtcukJMoxK?amount=0.3&pj=" + pjurl
+
     wallet_path = get_wallet_path(wallet_name, None)
     if jm_single().config.get("POLICY", "native") == "true":
         walletclass = SegwitWallet

--- a/test/regtest_joinmarket.cfg
+++ b/test/regtest_joinmarket.cfg
@@ -91,3 +91,10 @@ max_additional_fee_contribution = default
 # transaction; note it is decimal, not integer.
 min_fee_rate = 1.1
 
+# for payjoins to hidden service endpoints, the socks5 configuration:
+onion_socks5_host = localhost
+onion_socks5_port = 9050
+# in some exceptional case the HS may be SSL configured,
+# this feature is not yet implemented in code, but here for the
+# future:
+hidden_service_ssl = false


### PR DESCRIPTION
In this commit, the jmclient.payjoin module now supports
sending payments to BIP21 URIs where the pj= parameter is
to a hidden service address.
Additionally, the test/payjoinclient and test/payjoinserver
modules are edited to support optionally testing payments to
an ephemeral hidden service.