### PR TITLE
Fixes #639. Allow export of private keys in Qt.

### DIFF
--- a/jmclient/jmclient/cryptoengine.py
+++ b/jmclient/jmclient/cryptoengine.py
@@ -115,6 +115,10 @@ class BTCEngine(object):
 
     @classmethod
     def wif_to_privkey(cls, wif):
+        """ Note July 2020: the `key_type` construction below is
+        custom and is not currently used. Future code should
+        not use this returned `key_type` variable.
+        """
         raw = btc.b58check_to_bin(wif)[1]
         # see note to `privkey_to_wif`; same applies here.
         # We only handle valid private keys, not any byte string.

--- a/scripts/add-utxo.py
+++ b/scripts/add-utxo.py
@@ -31,9 +31,9 @@ def add_ext_commitments(utxo_datas):
         This calls the underlying 'raw' code based on the class PoDLE, not the
         library 'generate_podle' which intelligently searches and updates commitments.
         """
-        #Convert priv from wif; require P2SH-P2WPKH keys
-        rawpriv, keytype = BTCEngine.wif_to_privkey(priv)
-        assert keytype == BTC_P2SH_P2WPKH
+        # Convert priv from wif; note that wallet type
+        # isn't relevant since we only work with pubkeys in PoDLE:
+        rawpriv, _ = BTCEngine.wif_to_privkey(priv)
         podle = PoDLE(u, rawpriv)
         r = podle.generate_podle(i)
         return (r['P'], r['P2'], r['sig'],

--- a/scripts/joinmarket-qt.py
+++ b/scripts/joinmarket-qt.py
@@ -1581,13 +1581,8 @@ class JMMainWindow(QMainWindow):
             with open(os.path.join(jm_single().datadir,
                                    privkeys_fn + '.json'), "wb") as f:
                 for addr, pk in private_keys.items():
-                    #sanity check
-                    rawpriv, keytype = BTCEngine.wif_to_privkey(pk)
-                    if not keytype == BTC_P2SH_P2WPKH:
-                        JMQtMessageBox(None, "Failed to create privkey export, "
-                                       "should be keytype p2sh-p2wpkh but is not.",
-                                       mbtype='crit')
-                        return
+                    # sanity check
+                    rawpriv, _ = BTCEngine.wif_to_privkey(pk)
                     if not addr == self.wallet_service._ENGINE.privkey_to_address(rawpriv):
                         JMQtMessageBox(None, "Failed to create privkey export -" +\
                                        " critical error in key parsing.",


### PR DESCRIPTION
Additionally, we add a note to wif_to_privkey()
in jmclient.cryptoenging.BTCEngine because the
'keytype' variable constructed there is not currently
usabe, and we remove a check of that keytype in
the add_utxo script used for PoDLE (it is not relevant).