### PR TITLE
Correct `import matplotlib` exception handling

### DIFF
--- a/scripts/obwatch/ob-watcher.py
+++ b/scripts/obwatch/ob-watcher.py
@@ -20,15 +20,16 @@ from twisted.internet import reactor
 from jmbase.support import EXIT_FAILURE
 
 
-# https://stackoverflow.com/questions/2801882/generating-a-png-with-matplotlib-when-display-is-undefined
 try:
     import matplotlib
-    matplotlib.use('Agg')
-    import matplotlib.pyplot as plt
 except:
     print("matplotlib not found; do `pip install matplotlib` "
           "in the joinmarket virtualenv.")
     sys.exit(EXIT_FAILURE)
+
+# https://stackoverflow.com/questions/2801882/generating-a-png-with-matplotlib-when-display-is-undefined
+matplotlib.use('Agg')
+import matplotlib.pyplot as plt
 
 from jmbase import get_log
 from jmclient import jm_single, load_program_config, calc_cj_fee, \


### PR DESCRIPTION
Error message about missing matplotlib is only correct in case of
exception during `import matplotlib`. If there is fatal exception
later, it is some other issue and it's better display it as is. On a
RaspiBolt for me `import matplotlib.pyplot as plt` causes
"ImportError: libopenjp2.so.7: cannot open shared object file: No such file or directory".

See also #657.