### PR TITLE
Implement BIP78 payjoin in JoinMarketQt GUI

### DIFF
--- a/jmclient/jmclient/payjoin.py
+++ b/jmclient/jmclient/payjoin.py
@@ -19,6 +19,7 @@ import jmbitcoin as btc
 from .wallet import PSBTWalletMixin, SegwitLegacyWallet, SegwitWallet
 from .wallet_service import WalletService
 from .taker_utils import direct_send
+from jmclient import RegtestBitcoinCoreInterface
 
 """
 For some documentation see:
@@ -426,7 +427,7 @@ def get_max_additional_fee_contribution(manager):
     return max_additional_fee_contribution
 
 def send_payjoin(manager, accept_callback=None,
-                 info_callback=None, tls_whitelist=None):
+                 info_callback=None):
     """ Given a JMPayjoinManager object `manager`, initialised with the
     payment request data from the server, use its wallet_service to construct
     a payment transaction, with coins sourced from mixdepth `mixdepth`,
@@ -434,10 +435,6 @@ def send_payjoin(manager, accept_callback=None,
     The info and accept callbacks are to ask the user to confirm the creation of
     the original payment transaction (None defaults to terminal/CLI processing),
     and are as defined in `taker_utils.direct_send`.
-
-    If `tls_whitelist` is a list of bytestrings, they are treated as hostnames
-    for which tls certificate verification is ignored. Obviously this is ONLY for
-    testing.
 
     Returns:
     (True, None) in case of payment setup successful (response will be delivered
@@ -455,6 +452,12 @@ def send_payjoin(manager, accept_callback=None,
                              with_final_psbt=True)
     if not payment_psbt:
         return (False, "could not create non-payjoin payment")
+
+    # TLS whitelist is for regtest testing, it is treated as hostnames for
+    # which tls certificate verification is ignored.
+    tls_whitelist = None
+    if isinstance(jm_single().bc_interface, RegtestBitcoinCoreInterface):
+        tls_whitelist = ["127.0.0.1"]
 
     manager.set_payment_tx_and_psbt(payment_psbt)
 

--- a/scripts/qtsupport.py
+++ b/scripts/qtsupport.py
@@ -611,10 +611,17 @@ class BitcoinAmountEdit(QWidget):
                 self.valueInputBox.setText(str(btc_to_sat(btc_amount)))
 
     def setText(self, text):
-        if self.unitChooser.currentIndex() == 0:
-            self.valueInputBox.setText(str(sat_to_btc(text)))
+        if text:
+            if self.unitChooser.currentIndex() == 0:
+                self.valueInputBox.setText(str(sat_to_btc(text)))
+            else:
+                self.valueInputBox.setText(str(text))
         else:
-            self.valueInputBox.setText(str(text))
+            self.valueInputBox.setText('')
+
+    def setEnabled(self, enabled):
+        self.valueInputBox.setEnabled(enabled)
+        self.unitChooser.setEnabled(enabled)
 
     def text(self):
         if len(self.valueInputBox.text()) == 0:

--- a/scripts/sendpayment.py
+++ b/scripts/sendpayment.py
@@ -325,7 +325,7 @@ def main():
     elif bip78url:
         # TODO sanity check wallet type is segwit
         manager = parse_payjoin_setup(args[1], wallet_service, options.mixdepth)
-        reactor.callWhenRunning(send_payjoin, manager, tls_whitelist=["127.0.0.1"])
+        reactor.callWhenRunning(send_payjoin, manager)
         reactor.run()
         return
 

--- a/test/payjoinclient.py
+++ b/test/payjoinclient.py
@@ -59,9 +59,5 @@ if __name__ == "__main__":
     # the sync call here will now be a no-op:
     wallet_service.startService()
     manager = parse_payjoin_setup(bip21uri, wallet_service, mixdepth)
-    if usessl == 0:
-        tlshostnames = None
-    else:
-        tlshostnames = [b"127.0.0.1"]
-    reactor.callWhenRunning(send_payjoin, manager, tls_whitelist=tlshostnames)
+    reactor.callWhenRunning(send_payjoin, manager)
     reactor.run()


### PR DESCRIPTION
<del>Not finished, but I was able to successfully do a testnet payjoin from bech32 JM wallet to Kukks payjoin test site.</del>

I tried to follow the UX Wasabi have, just instead of adding dynamically adding another input box when the BIP78 URI is pasted in address field, Payjoin endpoint field replaces Number of counterparties field. You can get back to JoinMarket coinjoins mode by deleting that URI and pressing Tab or clicking on another field.

Can be tested and any feedback is welcome.