### PR TITLE
Drop key_type argument to import_private_key

### DIFF
--- a/jmclient/jmclient/snicker_receiver.py
+++ b/jmclient/jmclient/snicker_receiver.py
@@ -195,8 +195,7 @@ class SNICKERReceiver(object):
                     # scriptPubKey type as the wallet, this has been implicitly
                     # checked above by deriving the scriptPubKey.
                     self.wallet_service.import_private_key(self.import_branch,
-                            self.wallet_service._ENGINE.privkey_to_wif(tweaked_privkey),
-                            key_type=self.wallet_service.TYPE)
+                            self.wallet_service._ENGINE.privkey_to_wif(tweaked_privkey))
 
 
                     # TODO condition on automatic brdcst or not

--- a/jmclient/jmclient/wallet.py
+++ b/jmclient/jmclient/wallet.py
@@ -1540,7 +1540,7 @@ class ImportWalletMixin(object):
         if write:
             storage.save()
 
-    def import_private_key(self, mixdepth, wif, key_type=None):
+    def import_private_key(self, mixdepth, wif):
         """
         Import a private key in WIF format.
 
@@ -1561,8 +1561,6 @@ class ImportWalletMixin(object):
         if not 0 <= mixdepth <= self.max_mixdepth:
             raise WalletError("Mixdepth must be positive and at most {}."
                               "".format(self.max_mixdepth))
-        if key_type is not None and key_type not in self._ENGINES:
-            raise WalletError("Unsupported key type for imported keys.")
 
         privkey, key_type_wif = self._ENGINE.wif_to_privkey(wif)
         # FIXME: there is no established standard for encoding key type in wif
@@ -1570,10 +1568,8 @@ class ImportWalletMixin(object):
         #        key_type != key_type_wif:
         #    raise WalletError("Expected key type does not match WIF type.")
 
-        # default to wallet key type if not told otherwise
-        if key_type is None:
-            key_type = self.TYPE
-            #key_type = key_type_wif if key_type_wif is not None else self.TYPE
+        # default to wallet key type
+        key_type = self.TYPE
         engine = self._ENGINES[key_type]
 
         if engine.key_to_script(privkey) in self._script_map:

--- a/jmclient/jmclient/wallet_utils.py
+++ b/jmclient/jmclient/wallet_utils.py
@@ -997,6 +997,9 @@ def wallet_showseed(wallet):
 def wallet_importprivkey(wallet, mixdepth, key_type):
     jmprint("WARNING: This imported key will not be recoverable with your 12 "
           "word mnemonic phrase. Make sure you have backups.", "warning")
+    jmprint("WARNING: Make sure that the type of the public address previously "
+          "derived from this private key matches the wallet type you are "
+          "currently using.")
     jmprint("WARNING: Handling of raw ECDSA bitcoin private keys can lead to "
           "non-intuitive behaviour and loss of funds.\n  Recommended instead "
           "is to use the \'sweep\' feature of sendpayment.py.", "warning")
@@ -1009,7 +1012,7 @@ def wallet_importprivkey(wallet, mixdepth, key_type):
         # TODO is there any point in only accepting wif format? check what
         # other wallets do
         try:
-            path = wallet.import_private_key(mixdepth, wif, key_type=key_type)
+            path = wallet.import_private_key(mixdepth, wif)
         except WalletError as e:
             print("Failed to import key {}: {}".format(wif, e))
             import_failed += 1

--- a/jmclient/test/test_coinjoin.py
+++ b/jmclient/test/test_coinjoin.py
@@ -263,56 +263,6 @@ def test_coinjoin_mixdepth_wrap_maker(monkeypatch, tmpdir, setup_cj):
         assert balances[4] == 4 * 10**8 - cj_amount + cj_fee
 
 
-@pytest.mark.parametrize('wallet_cls,wallet_cls_sec', (
-    (SegwitLegacyWallet, LegacyWallet),
-    #(LegacyWallet, SegwitLegacyWallet)
-))
-def test_coinjoin_mixed_maker_addresses(monkeypatch, tmpdir, setup_cj,
-                                        wallet_cls, wallet_cls_sec):
-    set_commitment_file(str(tmpdir.join('commitments.json')))
-
-    MAKER_NUM = 2
-    wallet_services = make_wallets_to_list(make_wallets(
-        MAKER_NUM + 1,
-        wallet_structures=[[1, 0, 0, 0, 0]] * MAKER_NUM + [[3, 0, 0, 0, 0]],
-        mean_amt=1, wallet_cls=wallet_cls))
-    wallet_services_sec = make_wallets_to_list(make_wallets(
-        MAKER_NUM,
-        wallet_structures=[[1, 0, 0, 0, 0]] * MAKER_NUM,
-        mean_amt=1, wallet_cls=wallet_cls_sec))
-
-    for i in range(MAKER_NUM):
-        wif = wallet_services_sec[i].get_wif(0, False, 0)
-        wallet_services[i].wallet.import_private_key(0, wif,
-                            key_type=wallet_services_sec[i].wallet.TYPE)
-
-    jm_single().bc_interface.tickchain()
-    jm_single().bc_interface.tickchain()
-
-    sync_wallets(wallet_services, fast=False)
-
-    makers = [YieldGeneratorBasic(
-        wallet_services[i],
-        [0, 2000, 0, 'swabsoffer', 10**7]) for i in range(MAKER_NUM)]
-
-    orderbook = create_orderbook(makers)
-
-    cj_amount = int(1.1 * 10**8)
-    # mixdepth, amount, counterparties, dest_addr, waittime, rounding
-    schedule = [(0, cj_amount, MAKER_NUM, 'INTERNAL', 0, NO_ROUNDING)]
-    taker = create_taker(wallet_services[-1], schedule, monkeypatch)
-
-    active_orders, maker_data = init_coinjoin(taker, makers,
-                                              orderbook, cj_amount)
-
-    txdata = taker.receive_utxos(maker_data)
-    assert txdata[0], "taker.receive_utxos error"
-
-    taker_final_result = do_tx_signing(taker, makers, active_orders, txdata)
-    assert taker_final_result is not False
-    assert taker.on_finished_callback.status is not False
-
-
 @pytest.fixture(scope='module')
 def setup_cj():
     load_test_config()

--- a/jmclient/test/test_wallet.py
+++ b/jmclient/test/test_wallet.py
@@ -313,16 +313,13 @@ def test_import_key(setup_wallet):
     wallet = SegwitLegacyWallet(storage)
 
     wallet.import_private_key(
-        0, 'cRAGLvPmhpzJNgdMT4W2gVwEW3fusfaDqdQWM2vnWLgXKzCWKtcM',
-        cryptoengine.TYPE_P2SH_P2WPKH)
+        0, 'cRAGLvPmhpzJNgdMT4W2gVwEW3fusfaDqdQWM2vnWLgXKzCWKtcM')
     wallet.import_private_key(
-        1, 'cVqtSSoVxFyPqTRGfeESi31uCYfgTF4tGWRtGeVs84fzybiX5TPk',
-        cryptoengine.TYPE_P2PKH)
+        1, 'cVqtSSoVxFyPqTRGfeESi31uCYfgTF4tGWRtGeVs84fzybiX5TPk')
 
     with pytest.raises(WalletError):
         wallet.import_private_key(
-            1, 'cRAGLvPmhpzJNgdMT4W2gVwEW3fusfaDqdQWM2vnWLgXKzCWKtcM',
-            cryptoengine.TYPE_P2SH_P2WPKH)
+            1, 'cRAGLvPmhpzJNgdMT4W2gVwEW3fusfaDqdQWM2vnWLgXKzCWKtcM')
 
     # test persist imported keys
     wallet.save()
@@ -341,7 +338,7 @@ def test_import_key(setup_wallet):
 
     # verify imported addresses
     assert wallet.get_address_from_path(imported_paths_md0[0]) == '2MzY5yyonUY7zpHspg7jB7WQs1uJxKafQe4'
-    assert wallet.get_address_from_path(imported_paths_md1[0]) == 'mpCX9EbdXpcrKMtjEe1fqFhvzctkfzMYTX'
+    assert wallet.get_address_from_path(imported_paths_md1[0]) == '2MwbXnJrPP4rnwpgRhvNPP44J6tMokDexZB'
 
     # test remove key
     wallet.remove_imported_key(path=imported_paths_md0[0])
@@ -350,20 +347,17 @@ def test_import_key(setup_wallet):
     assert wallet.get_details(imported_paths_md1[0]) == (1, 'imported', 0)
 
 
-@pytest.mark.parametrize('wif,keytype,type_check', [
-    ['cVqtSSoVxFyPqTRGfeESi31uCYfgTF4tGWRtGeVs84fzybiX5TPk',
-     cryptoengine.TYPE_P2PKH, assert_not_segwit],
-    ['cRAGLvPmhpzJNgdMT4W2gVwEW3fusfaDqdQWM2vnWLgXKzCWKtcM',
-     cryptoengine.TYPE_P2SH_P2WPKH, assert_segwit]
+@pytest.mark.parametrize('wif, type_check', [
+    ['cRAGLvPmhpzJNgdMT4W2gVwEW3fusfaDqdQWM2vnWLgXKzCWKtcM', assert_segwit]
 ])
-def test_signing_imported(setup_wallet, wif, keytype, type_check):
+def test_signing_imported(setup_wallet, wif, type_check):
     jm_single().config.set('BLOCKCHAIN', 'network', 'testnet')
     storage = VolatileStorage()
     SegwitLegacyWallet.initialize(storage, get_network())
     wallet = SegwitLegacyWallet(storage)
 
     MIXDEPTH = 0
-    path = wallet.import_private_key(MIXDEPTH, wif, keytype)
+    path = wallet.import_private_key(MIXDEPTH, wif)
     utxo = fund_wallet_addr(wallet, wallet.get_address_from_path(path))
     # The dummy output is constructed as an unspendable p2sh:
     tx = btc.mktx([utxo],
@@ -619,8 +613,7 @@ def test_path_repr(setup_wallet):
 def test_path_repr_imported(setup_wallet):
     wallet = get_populated_wallet(num=0)
     path = wallet.import_private_key(
-        0, 'cRAGLvPmhpzJNgdMT4W2gVwEW3fusfaDqdQWM2vnWLgXKzCWKtcM',
-        cryptoengine.TYPE_P2SH_P2WPKH)
+        0, 'cRAGLvPmhpzJNgdMT4W2gVwEW3fusfaDqdQWM2vnWLgXKzCWKtcM')
     path_repr = wallet.get_path_repr(path)
     path_new = wallet.path_repr_to_path(path_repr)
 
@@ -708,13 +701,12 @@ def test_addr_script_conversion(setup_wallet):
 
 def test_imported_key_removed(setup_wallet):
     wif = 'cRAGLvPmhpzJNgdMT4W2gVwEW3fusfaDqdQWM2vnWLgXKzCWKtcM'
-    key_type = cryptoengine.TYPE_P2SH_P2WPKH
 
     storage = VolatileStorage()
     SegwitLegacyWallet.initialize(storage, get_network())
     wallet = SegwitLegacyWallet(storage)
 
-    path = wallet.import_private_key(1, wif, key_type)
+    path = wallet.import_private_key(1, wif)
     script = wallet.get_script_from_path(path)
     assert wallet.is_known_script(script)
 


### PR DESCRIPTION
This feature is too dangerous until we support descriptors.

We also drop the mixed maker addresses test that depends on this feature.

EDIT: I'll wait for this to be merged before publishing updates to #656 