### PR TITLE
[WIP] Add jmwalletd and support wallet display RPC.

### DIFF
--- a/docs/JSON-RPC-API-using-jmwalletd.md
+++ b/docs/JSON-RPC-API-using-jmwalletd.md
@@ -1,0 +1,118 @@
+## JSON-RPC API for Joinmarket using jmwalletd.py
+
+### Introduction - how to start the server
+
+After installing Joinmarket as per the [INSTALL GUIDE](INSTALL.md), navigate to the `scripts/` directory as usual and start the server with:
+
+```
+(jmvenv) $python jmwalletd.py
+```
+
+which with defaults will start serving the RPC over HTTP on port 28183.
+
+This HTTP server does *NOT* currently support multiple sessions; it is intended as a manager/daemon for all the Joinmarket services for a single user.
+
+#### Rules about making requests
+
+Currently authentication is done by providing a cookie on first request, which must then be reused to keep the same session. The cookie is sent in an HTTP header with name `b'JMCookie'`. This is fine for an early testing stage, but will be improved/reworked, and that will be documented here.
+
+GET requests are used in case no content or parameters need to be provided with the request.
+
+POST requests are used in case content or parameters are to be provided with the request, and they are provided as utf-8 encoded serialized JSON, in the *body* of the POST request.
+
+Note that for some methods, it's particularly important to deal with the HTTP response asynchronously, since it can take some time for wallet synchronization, service startup etc. to occur.
+
+### Methods
+
+#### `createwallet`
+
+Make a new wallet. The variable "wallettype" should be "sw" for native segwit wallets (now the Joinmarket default), otherwise a segwit legacy wallet (BIP49) will be created.
+
+* HTTP Request type: POST
+* Route: `/wallet/create`
+* POST body contents: {"walletname": walletname, "password": password, "wallettype": wallettype}
+* Returns: on success, {"walletname": walletname, "already_loaded": False}
+
+(TODO some confusion over two different walletnames here, I need to check, but the wallet name sent by the caller will be used for the file name, I believe).
+
+#### `unlockwallet`
+
+Open an existing wallet using a password.
+
+* HTTP Request type: POST
+* Route: `/wallet/<string:walletname>/unlock`
+* POST body contents: {"password": password}
+* Returns: on success, {"walletname": walletname, "already_loaded": True}
+
+(see previous on walletname, same applies here).
+
+#### `lockwallet`
+
+Stops the wallet service for the current wallet; meaning it cannot then be accessed without re-authentication.
+
+* HTTP Request type: GET
+* Route: `/wallet/<string:walletname>/lock`
+* Returns: on success, {"walletname": walletname}
+
+(see previous on walletname, same applies here).
+
+#### `displaywallet`
+
+Get JSON representation of wallet contents for wallet named `walletname`:
+
+* HTTP Request type: GET
+* Route: `/wallet/<string:walletname>/display`
+* Returns: a JSON object which is the entire wallet contents, mixdepth by mixdepth.
+    - Example output from a signet wallet is given at the bottom of the document.
+
+#### `maker/start`
+
+Starts the yield generator/maker service for the given wallet, using the IRC and tor network connections
+in the backend (inside the process started with jmwalletd).
+See Joinmarket yield generator config defaults in `jmclient.configure` module for info on the data that must
+be specified in the POST body contents.
+
+* HTTP Request type: POST
+* Route: `/wallet/<string:walletname>/maker/start`
+* POST body contents: {"txfee", "cjfee_a", "cjfee_r", "ordertype", "minsize"]
+* Returns: on success, {"walletname": walletname}
+
+(see previous on walletname, same applies here).
+
+#### `maker/stop`
+
+Stops the yieldgenerator/maker service if currently running for the given wallet.
+
+* HTTP Request type: GET
+* Route: `/wallet/<string:walletname>/maker/start`
+* Returns: on success, {"walletname": walletname}
+
+(see previous on walletname, same applies here).
+
+#### `snicker/start`
+
+Starts the SNICKER service (see [here](SNICKER.md)) for the given wallet. Note that this requires
+no configuration for now, though that is likely to change. Also note this is not yet supported for
+mainnet.
+
+* HTTP Request type: GET
+* Route: `/wallet/<string:walletname>/snicker/start`
+* Returns: on success, {"walletname": walletname}
+
+(see previous on walletname, same applies here).
+
+#### `snicker/stop`
+
+Stops the snicker service if currently running for the given wallet.
+
+* HTTP Request type: GET
+* Route: `/wallet/<string:walletname>/snicker/start`
+* Returns: on success, {"walletname": walletname}
+
+(see previous on walletname, same applies here).
+
+##### Example wallet display JSON output from signet wallet
+
+```
+{'wallet_name': 'JM wallet', 'total_balance': '0.15842426', 'accounts': [{'account': '0', 'account_balance': '0.00861458', 'branches': [{'branch': "external addresses\tm/84'/1'/0'/0\ttpubDFGxEsV7NvVc4h2XL4QEppZt3CrDiCFksP97H6YbFPmCTKM6KMP2xUxW57gAu7bzDfB3YTqnMeKQaQRS5GJM3xMcrhbi5AGsQUd7p4PLMDV", 'balance': '0.00000000', 'entries': [{'hd_path': "m/84'/1'/0'/0/4", 'address': 'tb1qzugshsm85x6luegyjc6mk5zces2zqr0j8m4zkd', 'amount': '0.00000000', 'labels': 'new'}, {'hd_path': "m/84'/1'/0'/0/5", 'address': 'tb1qcwmdkg229ghmd8r3xgq4a9zxp459crws66n4ve', 'amount': '0.00000000', 'labels': 'new'}, {'hd_path': "m/84'/1'/0'/0/6", 'address': 'tb1q7lv6dwex3mhwp32vhku0fvpar9faar2lu595su', 'amount': '0.00000000', 'labels': 'new'}, {'hd_path': "m/84'/1'/0'/0/7", 'address': 'tb1qm42ltytvp22kj9efp995yu0r0r7x570d8j8crc', 'amount': '0.00000000', 'labels': 'new'}, {'hd_path': "m/84'/1'/0'/0/8", 'address': 'tb1qwvux8g0khuvvkla3zaqdslj6xpgwtq7jlvwmgu', 'amount': '0.00000000', 'labels': 'new'}, {'hd_path': "m/84'/1'/0'/0/9", 'address': 'tb1q3xr7l9nylsdlyqf9rkw0rg3f0yx6slguhtwpzp', 'amount': '0.00000000', 'labels': 'new'}]}, {'branch': "internal addresses\tm/84'/1'/0'/1\t", 'balance': '0.00861458', 'entries': [{'hd_path': "m/84'/1'/0'/1/7", 'address': 'tb1qjrzxkulgc5dnlyz0rjqj68zxgqjesqn839ue2w', 'amount': '0.00396839', 'labels': 'cj-out'}, {'hd_path': "m/84'/1'/0'/1/12", 'address': 'tb1qeqkk4te2t6gqt7jfgu8a9k4je2wwfw3d2m7gku', 'amount': '0.00464619', 'labels': 'non-cj-change'}]}]}, {'account': '1', 'account_balance': '0.09380968', 'branches': [{'branch': "external addresses\tm/84'/1'/1'/0\ttpubDE1TKa8tm3WWh4f9fV325BgYWX9i7WFMaQRd1C3tSFYU9RJEyE8w2Cw2KnhgXSKyjS4keeWAkc3iLEqp3pxUEG9T49RCtQiMpjuZM71FLpL", 'balance': '0.00000000', 'entries': [{'hd_path': "m/84'/1'/1'/0/0", 'address': 'tb1qd6qqg3uzk9sw88yhvpqpwt3tx5ls4hau3mwh3g', 'amount': '0.00000000', 'labels': 'new'}, {'hd_path': "m/84'/1'/1'/0/1", 'address': 'tb1qhkrmqn9e4ldzlwna8w5w9l5vaw978zlrl54hmh', 'amount': '0.00000000', 'labels': 'new'}, {'hd_path': "m/84'/1'/1'/0/2", 'address': 'tb1qp83afad8dl98w366vnvct0zc49qu33c2nfx386', 'amount': '0.00000000', 'labels': 'new'}, {'hd_path': "m/84'/1'/1'/0/3", 'address': 'tb1qjv0elh4kn5yaywajedgcrf93ujzz3m3q7ld7k3', 'amount': '0.00000000', 'labels': 'new'}, {'hd_path': "m/84'/1'/1'/0/4", 'address': 'tb1qk25u4ch7w0xylzh0krn4hefphe6xpyh0vc33sl', 'amount': '0.00000000', 'labels': 'new'}, {'hd_path': "m/84'/1'/1'/0/5", 'address': 'tb1qs3ep9nlypwn43swv75zwv6lgl3wgsmha20g87p', 'amount': '0.00000000', 'labels': 'new'}]}, {'branch': "internal addresses\tm/84'/1'/1'/1\t", 'balance': '0.09380968', 'entries': [{'hd_path': "m/84'/1'/1'/1/44", 'address': 'tb1qgmgpk22ueq9xk8f722aqjnuwd6s3jv58nwwan2', 'amount': '0.00009631', 'labels': 'non-cj-change'}, {'hd_path': "m/84'/1'/1'/1/49", 'address': 'tb1qjq86y8nzvafv5dsde93zf0emv7yrsphvupv69e', 'amount': '0.00013383', 'labels': 'non-cj-change'}, {'hd_path': "m/84'/1'/1'/1/54", 'address': 'tb1q7lvxk407xs38t24hfzy7vprp9t7tfsemv4rfym', 'amount': '0.00371951', 'labels': 'non-cj-change'}, {'hd_path': "m/84'/1'/1'/1/56", 'address': 'tb1qn2azshrkcg0d7py5apgfr0jh29nt9w2fmx9fyy', 'amount': '0.08986003', 'labels': 'non-cj-change'}]}, {'branch': 'Imported keys\tm/0\t', 'balance': '0.00000000', 'entries': [{'hd_path': 'imported/1/0', 'address': 'tb1q8znprh8c85za3mpwzn3qf9m0vwqzjkfu4qdncy', 'amount': '0.00000000', 'labels': 'empty'}, {'hd_path': 'imported/1/1', 'address': 'tb1qu4ajg3enea90xxtjuwcurj3d6lkqrud8p7w0yu', 'amount': '0.00000000', 'labels': 'empty'}, {'hd_path': 'imported/1/2', 'address': 'tb1qg7saqx69yalcqshfr8mjndy0gpx2umxrwqs823', 'amount': '0.00000000', 'labels': 'empty'}]}]}, {'account': '2', 'account_balance': '0.05600000', 'branches': [{'branch': "external addresses\tm/84'/1'/2'/0\ttpubDF8K7wXCrRXX1CQLVZGwMvEg9YEWF2VRpM1tjCwpMZDRRqKjpJ5YaeaDaLkqN1D7YM4pkX32FcCnosbhLQz2BgRiPNNdybWuvSBKp72mJsJ", 'balance': '0.00000000', 'entries': [{'hd_path': "m/84'/1'/2'/0/0", 'address': 'tb1qw95x9m84t6hqcun560vqfk3yc6ptl4g9arsty0', 'amount': '0.00000000', 'labels': 'new'}, {'hd_path': "m/84'/1'/2'/0/1", 'address': 'tb1qek4humez7rcwl53ly6uzr4mfwd0s2lu92e356q', 'amount': '0.00000000', 'labels': 'new'}, {'hd_path': "m/84'/1'/2'/0/2", 'address': 'tb1qxne4hyyeq2vrh0dfzs56th29qsymp9eq5pljdc', 'amount': '0.00000000', 'labels': 'new'}, {'hd_path': "m/84'/1'/2'/0/3", 'address': 'tb1qz3jk544j5vtwztznxfdwfgt8zcw77mjcut8vdz', 'amount': '0.00000000', 'labels': 'new'}, {'hd_path': "m/84'/1'/2'/0/4", 'address': 'tb1qg902humlsuc5s6aua6ew3d893hlgcxr05ntpyd', 'amount': '0.00000000', 'labels': 'new'}, {'hd_path': "m/84'/1'/2'/0/5", 'address': 'tb1qukz3l34ydy9snq8rkjaknk0ns04kfnlh34neqd', 'amount': '0.00000000', 'labels': 'new'}]}, {'branch': "internal addresses\tm/84'/1'/2'/1\t", 'balance': '0.05600000', 'entries': [{'hd_path': "m/84'/1'/2'/1/1", 'address': 'tb1qrtz5cwpneheg2v2v32wzc3h9yv0rzplxjtx9vc', 'amount': '0.00800000', 'labels': 'non-cj-change'}, {'hd_path': "m/84'/1'/2'/1/2", 'address': 'tb1qp4276g23y2w8g3367de25ustxkygjydmwk4fw2', 'amount': '0.00800000', 'labels': 'non-cj-change'}, {'hd_path': "m/84'/1'/2'/1/3", 'address': 'tb1qtqgvw445807tzcm8yhq6xgu3vmdfh66czx8jea', 'amount': '0.00800000', 'labels': 'non-cj-change'}, {'hd_path': "m/84'/1'/2'/1/4", 'address': 'tb1qxj7ulxdthe0dwxr5457p5d0w5u3jg7rwmc05pm', 'amount': '0.02400000', 'labels': 'non-cj-change'}, {'hd_path': "m/84'/1'/2'/1/5", 'address': 'tb1qv3kfe9ew42z0ldncgzmqcjznatsxz0vudvcjrv', 'amount': '0.00800000', 'labels': 'non-cj-change'}]}]}, {'account': '3', 'account_balance': '0.00000000', 'branches': [{'branch': "external addresses\tm/84'/1'/3'/0\ttpubDE9VN56aLW9BurCxHHGAWidSnVuU86ZsKPYQgxpTgkZxbogJYfj1vWJbtYip7WV5REcgmtjETb5eShXV8VUBzvCAMzuRm5Kv4ZGnnCiX6Jg", 'balance': '0.00000000', 'entries': [{'hd_path': "m/84'/1'/3'/0/0", 'address': 'tb1qp2w6ezmqn8nk9kc4gkpetgjj2mzqgp5x3hk86m', 'amount': '0.00000000', 'labels': 'new'}, {'hd_path': "m/84'/1'/3'/0/1", 'address': 'tb1qd0tt93aulqs508mtap5p8gls5z57fqa4ggnfx7', 'amount': '0.00000000', 'labels': 'new'}, {'hd_path': "m/84'/1'/3'/0/2", 'address': 'tb1qsp4hv46vgz4yjwt4p2wekh2gfmek7vgznrnd96', 'amount': '0.00000000', 'labels': 'new'}, {'hd_path': "m/84'/1'/3'/0/3", 'address': 'tb1qvs322uyrwh7a74dsxel0xcrgucm27c6dzdmj9j', 'amount': '0.00000000', 'labels': 'new'}, {'hd_path': "m/84'/1'/3'/0/4", 'address': 'tb1qnq9uk9azs9s7m5474ws7z7wxnwv3s3lxrtjter', 'amount': '0.00000000', 'labels': 'new'}, {'hd_path': "m/84'/1'/3'/0/5", 'address': 'tb1q5tlq36q6ps0m9zu6h08gd3azsgkgvm73sjcmxw', 'amount': '0.00000000', 'labels': 'new'}]}, {'branch': "internal addresses\tm/84'/1'/3'/1\t", 'balance': '0.00000000', 'entries': []}]}, {'account': '4', 'account_balance': '0.00000000', 'branches': [{'branch': "external addresses\tm/84'/1'/4'/0\ttpubDE6QfTimeNgCFSYuxPPaLc1Cp3VokAuJAusYoiGwWtVHVtQDsepf5dRAFNLWMwpBCgKDYkXdWGs2JspxXPokrtooPh7db5fniqYbdKGqD4F", 'balance': '0.00000000', 'entries': [{'hd_path': "m/84'/1'/4'/0/3", 'address': 'tb1qr2llfup6cnh27n77nm7egcyf9r7c0ykucrcu8k', 'amount': '0.00000000', 'labels': 'new'}, {'hd_path': "m/84'/1'/4'/0/4", 'address': 'tb1qahqjnd2y8j770l2m4kpf4fyfve9425c0zdumms', 'amount': '0.00000000', 'labels': 'new'}, {'hd_path': "m/84'/1'/4'/0/5", 'address': 'tb1q0jm0cxwcm2g60489fvtmeeaf7mzg658t8f8fk4', 'amount': '0.00000000', 'labels': 'new'}, {'hd_path': "m/84'/1'/4'/0/6", 'address': 'tb1qtpm5putpkzmrmecden0yytuuk4n9emhvxwqu8m', 'amount': '0.00000000', 'labels': 'new'}, {'hd_path': "m/84'/1'/4'/0/7", 'address': 'tb1qn60fc04pmprn9wpzkt0dnt80awu0rpy99w376g', 'amount': '0.00000000', 'labels': 'new'}, {'hd_path': "m/84'/1'/4'/0/8", 'address': 'tb1qakvrpp2hd3a3303zx7w2shmvfc7tqk28pwa9sj', 'amount': '0.00000000', 'labels': 'new'}]}, {'branch': "internal addresses\tm/84'/1'/4'/1\t", 'balance': '0.00000000', 'entries': []}]}]}
+```

--- a/jmbase/jmbase/commands.py
+++ b/jmbase/jmbase/commands.py
@@ -67,6 +67,13 @@ class JMMsgSignatureVerify(JMCommand):
                  (b'fullmsg', Unicode()),
                  (b'hostid', Unicode())]
 
+class JMShutdown(JMCommand):
+    """ Requests shutdown of the current
+    message channel connections (to be used
+    when the client is shutting down).
+    """
+    arguments = []
+
 """TAKER specific commands
 """
 

--- a/jmclient/jmclient/__init__.py
+++ b/jmclient/jmclient/__init__.py
@@ -61,7 +61,7 @@ from .maker import Maker
 from .yieldgenerator import YieldGenerator, YieldGeneratorBasic, ygmain, \
      YieldGeneratorService
 from .snicker_receiver import SNICKERError, SNICKERReceiver, SNICKERReceiverService
-from .payjoin import (parse_payjoin_setup, send_payjoin, PayjoinServer,
+from .payjoin import (parse_payjoin_setup, send_payjoin,
                       JMBIP78ReceiverManager)
 # Set default logging handler to avoid "No handler found" warnings.
 

--- a/jmclient/jmclient/__init__.py
+++ b/jmclient/jmclient/__init__.py
@@ -30,7 +30,8 @@ from .blockchaininterface import (BlockchainInterface,
 from .snicker_receiver import SNICKERError, SNICKERReceiver
 from .client_protocol import (JMTakerClientProtocol, JMClientProtocolFactory,
                               start_reactor, SNICKERClientProtocolFactory,
-                              BIP78ClientProtocolFactory)
+                              BIP78ClientProtocolFactory,
+                              get_daemon_serving_params)
 from .podle import (set_commitment_file, get_commitment_file,
                     add_external_commitments,
                     PoDLE, generate_podle, get_podle_commitments,
@@ -58,7 +59,8 @@ from .wallet_utils import (
 from .wallet_service import WalletService
 from .maker import Maker
 from .yieldgenerator import YieldGenerator, YieldGeneratorBasic, ygmain
-from .payjoin import (parse_payjoin_setup, send_payjoin,
+from .snicker_receiver import SNICKERError, SNICKERReceiver, SNICKERReceiverService
+from .payjoin import (parse_payjoin_setup, send_payjoin, PayjoinServer,
                       JMBIP78ReceiverManager)
 # Set default logging handler to avoid "No handler found" warnings.
 

--- a/jmclient/jmclient/__init__.py
+++ b/jmclient/jmclient/__init__.py
@@ -58,7 +58,8 @@ from .wallet_utils import (
     wallet_change_passphrase)
 from .wallet_service import WalletService
 from .maker import Maker
-from .yieldgenerator import YieldGenerator, YieldGeneratorBasic, ygmain
+from .yieldgenerator import YieldGenerator, YieldGeneratorBasic, ygmain, \
+     YieldGeneratorService
 from .snicker_receiver import SNICKERError, SNICKERReceiver, SNICKERReceiverService
 from .payjoin import (parse_payjoin_setup, send_payjoin, PayjoinServer,
                       JMBIP78ReceiverManager)

--- a/jmclient/jmclient/client_protocol.py
+++ b/jmclient/jmclient/client_protocol.py
@@ -871,15 +871,15 @@ def start_reactor(host, port, factory=None, snickerfactory=None,
     # starts in jmclient.payjoin:
         if usessl:
             if factory:
-            reactor.connectSSL(host, jmcport, factory, ClientContextFactory())
+                reactor.connectSSL(host, jmcport, factory, ClientContextFactory())
             if snickerfactory:
-            reactor.connectSSL(host, snickerport, snickerfactory,
+                reactor.connectSSL(host, snickerport, snickerfactory,
                                ClientContextFactory())
         else:
             if factory:
-            reactor.connectTCP(host, jmcport, factory)
+                reactor.connectTCP(host, jmcport, factory)
             if snickerfactory:
-            reactor.connectTCP(host, snickerport, snickerfactory)
+                reactor.connectTCP(host, snickerport, snickerfactory)
     if rs:
         if not gui:
             reactor.run(installSignalHandlers=ish)

--- a/jmclient/jmclient/client_protocol.py
+++ b/jmclient/jmclient/client_protocol.py
@@ -20,6 +20,15 @@ from jmclient import (jm_single, get_irc_mchannels,
                       SNICKERReceiver, process_shutdown)
 import jmbitcoin as btc
 
+# module level variable representing the port
+# on which the daemon is running.
+# note that this var is only set if we are running
+# client+daemon in one process.
+daemon_serving_port = -1
+daemon_serving_host = ""
+
+def get_daemon_serving_params():
+    return (daemon_serving_host, daemon_serving_port)
 
 jlog = get_log()
 
@@ -787,9 +796,9 @@ def start_reactor(host, port, factory=None, snickerfactory=None,
     #(Cannot start the reactor in tests)
     #Not used in prod (twisted logging):
     #startLogging(stdout)
-    usessl = True if jm_single().config.get("DAEMON",
-                                            "use_ssl") != 'false' else False
-
+    global daemon_serving_host
+    global daemon_serving_port
+    usessl = True if jm_single().config.get("DAEMON", "use_ssl") != 'false' else False
     jmcport, snickerport, bip78port = [port]*3
     if daemon:
         try:
@@ -828,6 +837,9 @@ def start_reactor(host, port, factory=None, snickerfactory=None,
                         sys.exit(EXIT_FAILURE)
                     p[0] += 1
             return p[0]
+
+        daemon_serving_port = port
+        daemon_serving_host = host
 
         if jm_coinjoin:
             # TODO either re-apply this port incrementing logic

--- a/jmclient/jmclient/client_protocol.py
+++ b/jmclient/jmclient/client_protocol.py
@@ -848,13 +848,13 @@ def start_reactor(host, port, factory=None, snickerfactory=None,
 
     # Note the reactor.connect*** entries do not include BIP78 which
     # starts in jmclient.payjoin:
-    if usessl:
+        if usessl:
         if factory:
             reactor.connectSSL(host, jmcport, factory, ClientContextFactory())
         if snickerfactory:
             reactor.connectSSL(host, snickerport, snickerfactory,
                            ClientContextFactory())
-    else:
+        else:
         if factory:
             reactor.connectTCP(host, jmcport, factory)
         if snickerfactory:

--- a/jmclient/jmclient/client_protocol.py
+++ b/jmclient/jmclient/client_protocol.py
@@ -870,15 +870,15 @@ def start_reactor(host, port, factory=None, snickerfactory=None,
     # Note the reactor.connect*** entries do not include BIP78 which
     # starts in jmclient.payjoin:
         if usessl:
-        if factory:
+            if factory:
             reactor.connectSSL(host, jmcport, factory, ClientContextFactory())
-        if snickerfactory:
+            if snickerfactory:
             reactor.connectSSL(host, snickerport, snickerfactory,
-                           ClientContextFactory())
+                               ClientContextFactory())
         else:
-        if factory:
+            if factory:
             reactor.connectTCP(host, jmcport, factory)
-        if snickerfactory:
+            if snickerfactory:
             reactor.connectTCP(host, snickerport, snickerfactory)
     if rs:
         if not gui:

--- a/jmclient/jmclient/client_protocol.py
+++ b/jmclient/jmclient/client_protocol.py
@@ -376,6 +376,15 @@ class JMClientProtocol(BaseClientProtocol):
                             txhex=txhex)
         self.defaultCallbacks(d)
 
+    def request_mc_shutdown(self):
+        """ To ensure that lingering message channel
+        connections are shut down when the client itself
+        is shutting down.
+        """
+        d = self.callRemote(commands.JMShutdown)
+        self.defaultCallbacks(d)
+        return {'accepted': True}
+
 class JMMakerClientProtocol(JMClientProtocol):
     def __init__(self, factory, maker, nick_priv=None):
         self.factory = factory

--- a/jmclient/jmclient/snicker_receiver.py
+++ b/jmclient/jmclient/snicker_receiver.py
@@ -7,7 +7,6 @@ import jmbitcoin as btc
 from jmclient.configure import jm_single
 from jmbase import (get_log, utxo_to_utxostr,
                     hextobin, bintohex)
-from twisted.application.service import Service
 
 jlog = get_log()
 

--- a/jmdaemon/jmdaemon/daemon_protocol.py
+++ b/jmdaemon/jmdaemon/daemon_protocol.py
@@ -585,6 +585,12 @@ class JMDaemonServerProtocol(amp.AMP, OrderbookWatch):
             self.mcc.on_verified_privmsg(nick, fullmsg, hostid)
         return {'accepted': True}
 
+    @JMShutdown.responder
+    def on_JM_SHUTDOWN(self):
+        self.mc_shutdown()
+        self.jm_state = 0
+        return {'accepted': True}
+
     """Taker specific responders
     """
 

--- a/scripts/jmwalletd.py
+++ b/scripts/jmwalletd.py
@@ -21,7 +21,8 @@ from jmclient import Maker, jm_single, load_program_config, \
     WalletService, add_base_options, get_wallet_path, direct_send, \
     open_test_wallet_maybe, wallet_display, SegwitLegacyWallet, \
     SegwitWallet, get_daemon_serving_params, YieldGeneratorService, \
-    SNICKERReceiverService, SNICKERReceiver, create_wallet, StorageError
+    SNICKERReceiverService, SNICKERReceiver, create_wallet, \
+    StorageError, StoragePasswordError
 from jmbase.support import EXIT_ARGERROR, EXIT_FAILURE
 
 jlog = get_log()

--- a/scripts/jmwalletd.py
+++ b/scripts/jmwalletd.py
@@ -235,6 +235,7 @@ class JMWalletDaemon(Service):
             raise BackendNotReady()
 
         self.services["maker"] = YieldGeneratorService(self.wallet_service,
+                                daemon_serving_host, daemon_serving_port,
                                 [config_json[x] for x in ["txfee", "cjfee_a",
                                 "cjfee_r", "ordertype", "minsize"]])
         self.services["maker"].startService()

--- a/scripts/jmwalletd.py
+++ b/scripts/jmwalletd.py
@@ -1,0 +1,127 @@
+#! /usr/bin/env python
+
+import datetime
+import os
+import time
+import abc
+import json
+from io import BytesIO
+from twisted.python.log import startLogging
+from twisted.internet import endpoints, reactor, ssl
+from twisted.web.server import Site
+from klein import Klein
+
+from optparse import OptionParser
+from jmbase import get_log
+from jmclient import Maker, jm_single, load_program_config, \
+    JMClientProtocolFactory, start_reactor, calc_cj_fee, \
+    WalletService, add_base_options, get_wallet_path, open_test_wallet_maybe, wallet_display
+from jmbase.support import EXIT_ARGERROR, EXIT_FAILURE
+
+jlog = get_log()
+
+def get_ssl_context(cert_directory):
+    """Construct an SSL context factory from the user's privatekey/cert.
+    TODO:
+    Currently just hardcoded for tests.
+    """
+    return ssl.DefaultOpenSSLContextFactory(os.path.join(cert_directory, "key.pem"),
+                                            os.path.join(cert_directory, "cert.pem"))
+
+def response(request, succeed=True, status=200, **kwargs):
+    """
+    Build the response body as JSON and set the proper content-type
+    header.
+    """
+    request.setHeader('Content-Type', 'application/json')
+    request.setHeader('Access-Control-Allow-Origin', '*')
+    request.setResponseCode(status)
+    return json.dumps(
+        [{'succeed': succeed, 'status': status, **kwargs}])
+
+def start_REST_server(port):
+    app = Klein()
+    reactor.listenSSL(port, Site(app.resource()), contextFactory=get_ssl_context("."))
+    return app
+
+def jmwalletd_main():
+    import sys
+    wallet_service = None
+    parser = OptionParser(usage='usage: %prog [options] [wallet file]')
+    parser.add_option('-p', '--port', action='store', type='int',
+                      dest='port', default=28183,
+                      help='the port over which to serve RPC')
+    # TODO: remove the non-relevant base options:
+    add_base_options(parser)
+
+    (options, args) = parser.parse_args()
+
+    load_program_config(config_path=options.datadir)
+
+    app = start_REST_server(options.port)
+
+    @app.route('/wallet/<string:walletname>/display', methods=['GET'])
+    def displaywallet(request, walletname):
+        print(request)
+        nonlocal wallet_service
+        if not wallet_service:
+            #todo return a specific error
+            print('called display but no wallet loaded.')
+        else:
+            walletinfo = wallet_display(wallet_service, False, jsonified=True)
+            return response(request, walletname=walletname, walletinfo=walletinfo)
+
+    # handling CORS preflight:
+    #@app.route('/', branch=True, methods=['OPTIONS'])
+    @app.route('/wallet/<string:walletname>/unlock', methods=['OPTIONS'])
+    def preflight(request, walletname):
+        print(request)
+        request.setHeader("Access-Control-Allow-Origin", "*")
+        request.setHeader("Access-Control-Allow-Methods", "POST")
+        request.setHeader("Access-Control-Allow-Headers", "Content-Type")
+
+    @app.route('/wallet/<string:walletname>/display', methods=['OPTIONS'])
+    def preflight2(request, walletname):
+        print(request)
+        request.setHeader("Access-Control-Allow-Origin", "*")
+        request.setHeader("Access-Control-Allow-Methods", "GET")
+        request.setHeader("Access-Control-Allow-Headers", "Content-Type")
+
+    @app.route('/wallet/<string:walletname>/unlock', methods=['POST'])
+    def unlockwallet(request, walletname):
+        print(request)
+        assert isinstance(request.content, BytesIO)
+        passwordjson = request.content.read().decode("utf-8")
+        password = json.loads(passwordjson)["password"]
+        nonlocal wallet_service
+        if wallet_service is None:
+            wallet_path = get_wallet_path(walletname, None)
+            wallet = open_test_wallet_maybe(
+                    wallet_path, walletname, 4,
+                    password=password.encode("utf-8"),
+                    ask_for_password=False)
+            wallet_service = WalletService(wallet)
+            while not wallet_service.synced:
+                wallet_service.sync_wallet(fast=True)
+            wallet_service.startService()
+            return response(request, walletname=walletname, already_loaded=False)
+        else:
+            print('wallet was already unlocked.')
+            return response(request, walletname=walletname, already_loaded=True)
+
+    if jm_single().bc_interface is None:
+        jlog.error("Running jmwallet-daemon requires configured " +
+                   "blockchain source.")
+        sys.exit(EXIT_FAILURE)
+    jlog.info("Starting jmwalletd")
+
+    nodaemon = jm_single().config.getint("DAEMON", "no_daemon")
+    daemon = True if nodaemon == 1 else False
+    if jm_single().config.get("BLOCKCHAIN", "network") in ["regtest", "testnet"]:
+        startLogging(sys.stdout)
+    start_reactor(jm_single().config.get("DAEMON", "daemon_host"),
+                  jm_single().config.getint("DAEMON", "daemon_port"),
+                  None, daemon=daemon)
+
+if __name__ == "__main__":
+    jmwalletd_main()

--- a/scripts/jmwalletd.py
+++ b/scripts/jmwalletd.py
@@ -9,6 +9,7 @@ from io import BytesIO
 from twisted.python.log import startLogging
 from twisted.internet import endpoints, reactor, ssl
 from twisted.web.server import Site
+from twisted.application.service import Service
 from klein import Klein
 
 from optparse import OptionParser
@@ -19,10 +20,6 @@ from jmclient import Maker, jm_single, load_program_config, \
 from jmbase.support import EXIT_ARGERROR, EXIT_FAILURE
 
 jlog = get_log()
-
-# only serving single concurrent user for now; cookie global:
-cookie = None
-wallet_service = None
 
 # for debugging; twisted.web.server.Request objects do not easily serialize:
 def print_req(request):
@@ -59,56 +56,60 @@ def response(request, succeed=True, status=200, **kwargs):
     return json.dumps(
         [{'succeed': succeed, 'status': status, **kwargs}])
 
-def check_cookie(request):
-    request_cookie = request.getHeader(b"JMCookie")
-    if cookie != request_cookie:
-        print("Invalid cookie: ", request_cookie)
-        raise NotAuthorized()
 
-def start_REST_server(port):
+
+class JMWalletDaemon(Service):
     app = Klein()
-    reactor.listenSSL(port, Site(app.resource()), contextFactory=get_ssl_context("."))
-    return app
+    def __init__(self, port, wallet_service=None):
+        # only serving single concurrent user for now;
+        # cookie tracks that single user's state.
+        self.cookie = None
+        self.port = port
+        self.wallet_service = wallet_service
 
-def jmwalletd_main():
-    import sys
-    parser = OptionParser(usage='usage: %prog [options] [wallet file]')
-    parser.add_option('-p', '--port', action='store', type='int',
-                      dest='port', default=28183,
-                      help='the port over which to serve RPC')
-    # TODO: remove the non-relevant base options:
-    add_base_options(parser)
+    def startService(self):
+        """ Encapsulates start up actions.
+        Here starting the TLS server.
+        """
+        super().startService()
+        reactor.listenSSL(self.port, Site(self.app.resource()),
+                          contextFactory=get_ssl_context("."))
 
-    (options, args) = parser.parse_args()
-
-    load_program_config(config_path=options.datadir)
-
-    app = start_REST_server(options.port)
+    def stopService(self):
+        """ Encapsulates shut down actions.
+        """
+        super().stopService()
 
     @app.handle_errors(NotAuthorized)
-    def not_authorized(request, failure):
+    def not_authorized(self, request, failure):
         request.setResponseCode(401)
         return "Invalid credentials."
 
     @app.handle_errors(NoWalletFound)
-    def no_wallet_found(request, failure):
+    def no_wallet_found(self, request, failure):
         request.setResponseCode(404)
         return "No wallet loaded."
 
+    def check_cookie(self, request):
+        request_cookie = request.getHeader(b"JMCookie")
+        if self.cookie != request_cookie:
+            print("Invalid cookie: ", request_cookie)
+            raise NotAuthorized()
+
     @app.route('/wallet/<string:walletname>/display', methods=['GET'])
-    def displaywallet(request, walletname):
+    def displaywallet(self, request, walletname):
         print_req(request)
-        check_cookie(request)
-        if not wallet_service:
+        self.check_cookie(request)
+        if not self.wallet_service:
             print("called display but no wallet loaded")
             raise NoWalletFound()
         else:
-            walletinfo = wallet_display(wallet_service, False, jsonified=True)
+            walletinfo = wallet_display(self.wallet_service, False, jsonified=True)
             return response(request, walletname=walletname, walletinfo=walletinfo)
 
     # handling CORS preflight for any route:
     @app.route('/', branch=True, methods=['OPTIONS'])
-    def preflight(request):
+    def preflight(self, request):
         print_req(request)
         request.setHeader("Access-Control-Allow-Origin", "*")
         request.setHeader("Access-Control-Allow-Methods", "POST")
@@ -117,29 +118,25 @@ def jmwalletd_main():
         request.setHeader("Access-Control-Allow-Headers", "Content-Type, JMCookie")
 
     @app.route('/wallet/<string:walletname>/lock', methods=['GET'])
-    def lockwallet(request, walletname):
-        global wallet_service
+    def lockwallet(self, request, walletname):
         print_req(request)
-        check_cookie(request)
-        if not wallet_service:
+        self.check_cookie(request)
+        if not self.wallet_service:
             print("called lock but no wallet loaded")
             raise NoWalletFound()
         else:
-            wallet_service.stopService()
-            # reset local reference to null
-            wallet_service = None
+            self.wallet_service.stopService()
+            self.wallet_service = None
             # success status implicit:
             return response(request, walletname=walletname)
 
     @app.route('/wallet/<string:walletname>/unlock', methods=['POST'])
-    def unlockwallet(request, walletname):
-        global wallet_service
-        global cookie
+    def unlockwallet(self, request, walletname):
         print_req(request)
         assert isinstance(request.content, BytesIO)
         auth_json = json.loads(request.content.read().decode("utf-8"))
         password = auth_json["password"]
-        if wallet_service is None:
+        if self.wallet_service is None:
             wallet_path = get_wallet_path(walletname, None)
             try:
                 wallet = open_test_wallet_maybe(
@@ -157,18 +154,18 @@ def jmwalletd_main():
             # yet support multiple). This is maintained for as long as the
             # daemon is active (i.e. no expiry currently implemented),
             # or until the user switches to a new wallet.
-            cookie = request.getHeader(b"JMCookie")
-            if cookie is None:
+            self.cookie = request.getHeader(b"JMCookie")
+            if self.cookie is None:
                 # TODO different error class? this could mislead:
                 raise NotAuthorized()
 
             # the daemon blocks here until the wallet synchronization
             # from the blockchain interface completes; currently this is
             # fine as long as the client handles the response asynchronously:
-            wallet_service = WalletService(wallet)
-            while not wallet_service.synced:
-                wallet_service.sync_wallet(fast=True)
-            wallet_service.startService()
+            self.wallet_service = WalletService(wallet)
+            while not self.wallet_service.synced:
+                self.wallet_service.sync_wallet(fast=True)
+            self.wallet_service.startService()
             # now that the WalletService instance is active and ready to
             # respond to requests, we return the status to the client:
             return response(request, walletname=walletname, already_loaded=False)
@@ -176,11 +173,27 @@ def jmwalletd_main():
             print('wallet was already unlocked.')
             return response(request, walletname=walletname, already_loaded=True)
 
+def jmwalletd_main():
+    import sys
+    parser = OptionParser(usage='usage: %prog [options] [wallet file]')
+    parser.add_option('-p', '--port', action='store', type='int',
+                      dest='port', default=28183,
+                      help='the port over which to serve RPC')
+    # TODO: remove the non-relevant base options:
+    add_base_options(parser)
+
+    (options, args) = parser.parse_args()
+
+    load_program_config(config_path=options.datadir)
+
     if jm_single().bc_interface is None:
         jlog.error("Running jmwallet-daemon requires configured " +
                    "blockchain source.")
         sys.exit(EXIT_FAILURE)
     jlog.info("Starting jmwalletd")
+
+    jm_wallet_daemon = JMWalletDaemon(options.port)
+    jm_wallet_daemon.startService()
 
     nodaemon = jm_single().config.getint("DAEMON", "no_daemon")
     daemon = True if nodaemon == 1 else False

--- a/scripts/jmwalletd.py
+++ b/scripts/jmwalletd.py
@@ -1,14 +1,11 @@
 #! /usr/bin/env python
 
-import datetime
 import os
-import time
-import abc
 import json
 import atexit
 from io import BytesIO
 from twisted.python.log import startLogging
-from twisted.internet import endpoints, reactor, ssl, task
+from twisted.internet import reactor, ssl
 from twisted.web.server import Site
 from twisted.application.service import Service
 from klein import Klein
@@ -16,14 +13,14 @@ from klein import Klein
 from optparse import OptionParser
 from jmbase import get_log
 from jmbitcoin import human_readable_transaction
-from jmclient import Maker, jm_single, load_program_config, \
-    JMClientProtocolFactory, start_reactor, calc_cj_fee, \
+from jmclient import jm_single, load_program_config, \
+    start_reactor, \
     WalletService, add_base_options, get_wallet_path, direct_send, \
     open_test_wallet_maybe, wallet_display, SegwitLegacyWallet, \
     SegwitWallet, get_daemon_serving_params, YieldGeneratorService, \
     SNICKERReceiverService, SNICKERReceiver, create_wallet, \
     StorageError, StoragePasswordError
-from jmbase.support import EXIT_ARGERROR, EXIT_FAILURE
+from jmbase.support import EXIT_FAILURE
 
 jlog = get_log()
 


### PR DESCRIPTION
Just a first start in a basic form only suitable for testing.

Uses Klein to provide HTTP server support. The server is TLS and if you want to test it you must add `key.pem` and `cert.pem` into the `scripts/` directory.

 provides `/wallet/walletname/unlock` for which the password is provided in POST, and `/wallet/walletname/display` providing the full `jmclient.wallet_utils.WalletView` serialization in a new json format.
Note the `preflight`/`preflight2` methods are for CORS, obviously that is not a final form.

Apart from filling out the API, the most important outstanding issue is state/session management; we provide an unlock but have no access control linking the unlocking action with future permissible actions.

This code is an illustration of what is meant by [this](https://gist.github.com/AdamISZ/f062c7453c6973a8287897fe506b9d19) gist, also see [this](https://github.com/Joinmarket-Org/jmcontrolcenter) new repo for an Angular client for this RPC server.