### PR TITLE
Bump coveragepy to fix pytest on python 3.8

### DIFF
--- a/requirements/testing.txt
+++ b/requirements/testing.txt
@@ -2,7 +2,7 @@
 # matplotlib
 # numpy
 pexpect
-coverage==4.0.3
+coverage==5.2.1
 pytest==5.3.5
 pytest-cov>=2.4.0,<2.6
 python-coveralls


### PR DESCRIPTION
Python 3.8 was not supported before coveragepy v5.0a4
https://github.com/nedbat/coveragepy/blob/master/CHANGES.rst#version-50a4-----2018-11-25


The bump is big, but tests are green