### PR TITLE
Handle push tx

### DIFF
--- a/jmbase/jmbase/commands.py
+++ b/jmbase/jmbase/commands.py
@@ -220,3 +220,11 @@ class JMTXReceived(JMCommand):
     arguments = [(b'nick', Unicode()),
                  (b'txhex', Unicode()),
                  (b'offer', Unicode())]
+
+class JMTXBroadcast(JMCommand):
+    """ Accept a bitcoin transaction
+    sent over the wire by a counterparty
+    and relay it to the client for network
+    broadcast.
+    """
+    arguments = [(b'txhex', Unicode())]

--- a/jmbase/test/test_commands.py
+++ b/jmbase/test/test_commands.py
@@ -111,7 +111,9 @@ class JMTestServerProtocol(JMBaseProtocol):
                                         hashlen=4,
                                         max_encoded=5,
                                         hostid="hostid2")
-        self.defaultCallbacks(d3)        
+        self.defaultCallbacks(d3)
+        d4 = self.callRemote(JMTXBroadcast, txhex="deadbeef")
+        self.defaultCallbacks(d4)
         return {'accepted': True}
             
 
@@ -215,6 +217,11 @@ class JMTestClientProtocol(JMBaseProtocol):
                             hostid=hostid)
         self.defaultCallbacks(d)
         return {'accepted': True}
+
+    @JMTXBroadcast.responder
+    def on_JM_TX_BROADCAST(self, txhex):
+        show_receipt("JMTXBROADCAST", txhex)
+        return {"accepted": True}
 
 class JMTestClientProtocolFactory(protocol.ClientFactory):
     protocol = JMTestClientProtocol

--- a/jmclient/jmclient/client_protocol.py
+++ b/jmclient/jmclient/client_protocol.py
@@ -301,6 +301,22 @@ class JMMakerClientProtocol(JMClientProtocol):
             self.defaultCallbacks(d)
         return {"accepted": True}
 
+    @commands.JMTXBroadcast.responder
+    def on_JM_TX_BROADCAST(self, txhex):
+        """ Makers have no issue broadcasting anything,
+        so only need to prevent crashes.
+        Note in particular we don't check the return value,
+        since the transaction being accepted or not is not
+        our (maker)'s concern.
+        """
+        try:
+            txbin = hextobin(txhex)
+            jm_single().bc_interface.pushtx(txbin)
+        except:
+            jlog.info("We received an invalid transaction broadcast "
+                      "request: " + txhex)
+        return {"accepted": True}
+
     def tx_match(self, txd):
         for k,v in self.finalized_offers.items():
             # Tx considered defined by its output set

--- a/jmclient/jmclient/configure.py
+++ b/jmclient/jmclient/configure.py
@@ -244,10 +244,12 @@ absurd_fee_per_kb = 350000
 # spends from unconfirmed inputs, which may then get malleated or double-spent!
 # other counterparties are likely to reject unconfirmed inputs... don't do it.
 
-# options: self, random-peer, not-self (note: currently, ONLY 'self' works).
-# self = broadcast transaction with your bitcoin node's ip
+# options: self, random-peer, not-self.
+# self = broadcast transaction with your own bitcoin node.
 # random-peer = everyone who took part in the coinjoin has a chance of broadcasting
 # not-self = never broadcast with your own ip
+# note: if your counterparties do not support it, you will fall back
+# to broadcasting via your own node.
 tx_broadcast = self
 
 # If makers do not respond while creating a coinjoin transaction,

--- a/jmclient/jmclient/taker.py
+++ b/jmclient/jmclient/taker.py
@@ -830,8 +830,7 @@ class Taker(object):
             self.on_finished_callback(False, fromtx=True)
         else:
             if nick_to_use:
-                # TODO option not currently functional
-                return (nick_to_use, self.latest_tx.serialize())
+                return (nick_to_use, bintohex(self.latest_tx.serialize()))
         #if push was not successful, return None
 
     def self_sign_and_push(self):

--- a/jmclient/jmclient/wallet_service.py
+++ b/jmclient/jmclient/wallet_service.py
@@ -377,6 +377,7 @@ class WalletService(Service):
         """ Intended to be a deferred Task to be scheduled some
         set time after the callback was registered. "all" type
         callbacks do not expire and are not included.
+        If the callback was previously called, return True, otherwise False.
         """
         assert cbtype in ["unconfirmed", "confirmed"]
         if txinfo in self.callbacks[cbtype]:
@@ -389,8 +390,10 @@ class WalletService(Service):
                 # this never occurs, although their presence should
                 # not cause a functional error.
                 jlog.info("Timed out: " + msg)
-                # if callback is not in the list, it was already
-                # processed and so do nothing.
+                return False
+            # if callback is not in the list, it was already
+            # processed and so do nothing.
+        return True
 
     def log_new_tx(self, removed_utxos, added_utxos, txid):
         """ Changes to the wallet are logged at INFO level by

--- a/jmdaemon/jmdaemon/daemon_protocol.py
+++ b/jmdaemon/jmdaemon/daemon_protocol.py
@@ -9,6 +9,7 @@ from .protocol import (COMMAND_PREFIX, ORDER_KEYS, NICK_HASH_LENGTH,
                        COMMITMENT_PREFIXES)
 from .irc import IRCMessageChannel
 
+from jmbase import hextobin
 from jmbase.commands import *
 from twisted.protocols import amp
 from twisted.internet import reactor, ssl
@@ -432,9 +433,16 @@ class JMDaemonServerProtocol(amp.AMP, OrderbookWatch):
 
     @maker_only
     def on_push_tx(self, nick, txhex):
-        """Not yet implemented; ignore rather than raise.
+        """Broadcast unquestioningly, except checking
+        hex format.
 	"""
-        log.msg('received pushtx message, ignoring, TODO')
+        try:
+            dummy = hextobin(txhex)
+        except:
+            return
+        d = self.callRemote(JMTXBroadcast,
+                            txhex=txhex)
+        self.defaultCallbacks(d)
 
     @maker_only
     def on_seen_tx(self, nick, txhex):


### PR DESCRIPTION
See the commit notes for some detailed commentary on what is in this change. In summary:

#368 amongst other places raised the point that we have not implemented non-self broadcast of transactions in this repository. The previous behaviour was simply for Takers to send `!push` and for Makers to silently ignore the message (basically). That is fixed here; both `random-peer` and `not-self` are now made available.

#536 introduced a bug such that the Taker in trying to send the `!push` (i.e. if the user selected `[POLICY] tx_broadcast = not-self` or random-peer, a binary/hex conversion error was triggered causing the Taker to crash.

First, the bin/hex bug is fixed.

Second, note in particular the `twisted.protocols.amp.AMP` commands: `JMPushTx` already existed, and sent a txhex from a taker client to the daemon, who then transferred it to a counterparty. But the other side of the conversation is now implemented here: `JMTXBroadcast` is sent from the maker daemon to client, triggering the broadcast.

The second commit, https://github.com/JoinMarket-Org/joinmarket-clientserver/commit/fd955c5e2ba3e34e5f4640b82fa5b411a7e5f185 , addresses the problem raised in the last sentence of the first commit:

Currently, no makers actually do anything when sent a txhex with a `!push` message; they just silently ignore it. So this won't work for Takers who are waiting for an unconfirmed-callback to be triggered. Here we add a fallback mechanism that is triggered after `[TIMEOUT] unconfirm_timeout_sec` seconds, which notices that the callback was not triggered and goes ahead and pushes locally. Clearly any takers which run this new code will be talking overwhelmingly to makers without the code, who will silently ignore their `!push` requests, so this behaviour seems fine.

Passes test suite, also did a range of tests under different behaviours on command line with tumbler and sendpayment. More testing would be appreciated.