### PR TITLE
Log sendrawtransaction errors as warning not debug

### DIFF
--- a/jmclient/jmclient/blockchaininterface.py
+++ b/jmclient/jmclient/blockchaininterface.py
@@ -342,10 +342,10 @@ class BitcoinCoreInterface(BlockchainInterface):
         try:
             txid = self.rpc('sendrawtransaction', [txhex])
         except JsonRpcConnectionError as e:
-            log.debug('error pushing = ' + repr(e))
+            log.warning('error pushing = ' + repr(e))
             return False
         except JsonRpcError as e:
-            log.debug('error pushing = ' + str(e.code) + " " + str(e.message))
+            log.warning('error pushing = ' + str(e.code) + " " + str(e.message))
             return False
         return True
 


### PR DESCRIPTION
Before this change `sendrawtransaction` errors in `pushtx()` are logged as debug, not warning. But default `console_log_level` is `INFO`. This is important enough information for the user to change log level here.

Before:
```
Would you like to push to the network? (y/n):y
2020-09-09 23:54:26,199 [ERROR]  Transaction broadcast failed!
```
After:
```
Would you like to push to the network? (y/n):y
2020-09-09 23:54:26,198 [WARNING]  error pushing = -26 dust (code 64)
2020-09-09 23:54:26,199 [ERROR]  Transaction broadcast failed!
```

Somewhat related to #600.