### PR TITLE
Bump python-bitcointx to v1.1.1.post0

### DIFF
--- a/jmbitcoin/setup.py
+++ b/jmbitcoin/setup.py
@@ -10,5 +10,5 @@ setup(name='joinmarketbitcoin',
       license='GPL',
       packages=['jmbitcoin'],
       python_requires='>=3.6',
-      install_requires=['coincurve', 'python-bitcointx>=1.1.0', 'pyaes', 'urldecode'],
+      install_requires=['coincurve', 'python-bitcointx>=1.1.1.post0', 'pyaes', 'urldecode'],
       zip_safe=False)


### PR DESCRIPTION
Should fix PSBT related incompatibilities with some wallets in BIP78 payjoin receiver.

Related - https://github.com/spesmilo/electrum/issues/6257 and https://github.com/zkSNACKs/WalletWasabi/pull/4427.