### PR TITLE
Fix relfee cjfee display issues caused by the use of float in ob-watcher.py

### DIFF
--- a/scripts/obwatch/ob-watcher.py
+++ b/scripts/obwatch/ob-watcher.py
@@ -81,7 +81,7 @@ def cjfee_display(cjfee, order, btc_unit, rel_unit):
     if order['ordertype'] in ['absoffer', 'swabsoffer']:
         return satoshi_to_unit(cjfee, order, btc_unit, rel_unit)
     elif order['ordertype'] in ['reloffer', 'swreloffer']:
-        return str(float(cjfee) * rel_unit_to_factor[rel_unit]) + rel_unit
+        return str(Decimal(cjfee) * rel_unit_to_factor[rel_unit]) + rel_unit
 
 
 def satoshi_to_unit(sat, order, btc_unit, rel_unit):
@@ -148,7 +148,7 @@ class OrderbookPageRequestHeader(http.server.SimpleHTTPRequestHandler):
             o = dict(row)
             if 'cjfee' in o:
                 o['cjfee'] = int(o['cjfee']) if o['ordertype']\
-                             == 'swabsoffer' else float(o['cjfee'])
+                             == 'swabsoffer' else str(Decimal(o['cjfee']))
             result.append(o)
         return result
 


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/4500994/95403357-b1b28b00-091a-11eb-923f-fe8d939c0260.png)

After:
![image](https://user-images.githubusercontent.com/4500994/95403375-c131d400-091a-11eb-8932-c831390e8328.png)
