### PR TITLE
Fix finalization check of PSBT Inputs

### DIFF
--- a/jmclient/jmclient/payjoin.py
+++ b/jmclient/jmclient/payjoin.py
@@ -693,7 +693,8 @@ def process_payjoin_proposal_from_server(response_body, manager):
                     if (inp.prevout.hash, inp.prevout.n) == (
                         inp2.prevout.hash, inp2.prevout.n):
                         payjoin_proposal_psbt.set_utxo(
-                            manager.initial_psbt.inputs[j].utxo, i)
+                            manager.initial_psbt.inputs[j].utxo, i,
+                            force_witness_utxo=True)
     signresultandpsbt, err = manager.wallet_service.sign_psbt(
         payjoin_proposal_psbt.serialize(), with_sign_result=True)
     if err:

--- a/jmclient/test/test_psbt_wallet.py
+++ b/jmclient/test/test_psbt_wallet.py
@@ -52,7 +52,8 @@ def test_create_and_sign_psbt_with_legacy(setup_psbt_wallet):
     tx2 = bitcoin.mktx(list(utxos.keys()), outs)
     spent_outs = wallet_service.witness_utxos_to_psbt_utxos(my_utxos)
     spent_outs.append(tx)
-    new_psbt = wallet_service.create_psbt_from_tx(tx2, spent_outs)
+    new_psbt = wallet_service.create_psbt_from_tx(tx2, spent_outs,
+                                                  force_witness_utxo=False)
     signed_psbt_and_signresult, err = wallet_service.sign_psbt(
         new_psbt.serialize(), with_sign_result=True)
     assert err is None
@@ -119,13 +120,16 @@ def test_create_psbt_and_sign(setup_psbt_wallet, unowned_utxo, wallet_cls):
 
     if wallet_cls != LegacyWallet:
         spent_outs = wallet_service.witness_utxos_to_psbt_utxos(utxos)
+        force_witness_utxo=True
     else:
         spent_outs = fulltxs
         # the extra input is segwit:
         if unowned_utxo:
             spent_outs.extend(
                 wallet_service.witness_utxos_to_psbt_utxos(u_utxos))
-    newpsbt = wallet_service.create_psbt_from_tx(tx, spent_outs)
+        force_witness_utxo=False
+    newpsbt = wallet_service.create_psbt_from_tx(tx, spent_outs,
+                            force_witness_utxo=force_witness_utxo)
     # see note above
     if unowned_utxo:
         newpsbt.inputs[-1].redeem_script = redeem_script


### PR DESCRIPTION
This addresses a second bug with the same root origin as the previous incompatibility bug with Wasabi as sender and Joinmarket as receiver.

Because the PSBTs generated by Wasabi use a NONWITNESS_UTXO field in the finalized PSBT, and the earlier Joinmarket code assumed all-segwit and all-WITNESS_UTXO, the initial finalized PSBT was rejected by JM. This fixes this (after the update to python-bitcointx to support proper parsing of this PSBT format). Tested as successfully returning `"sw"` from a call to `PSBTWalletMixin.check_finalized_input_type()` with the first input of this test PSBT (thanks @kristapsk for test data):

```
cHNidP8BAHEBAAAAAf5h7wfohIiz7mec4bu1pgIzSQyl2WXtn6lEV4T3j8OuAAAAAAD/////AqCGAQAAAAAAFgAUBjegjdQa1atsuFy/fUTLTZAL1JU9BgAAAAAAABYAFFDpxd8Jfr+nGBUMHkk/vumO0eoQAAAAAAABAR+ejwEAAAAAABYAFElcvvohsHe14YxjkNWtxBZIqYitAQD9cgEBAAAAAAECsRUrYzm2lIrpb4aWXGTCFD+AOYmmX1SEY+EK+XoiEQgAAAAAAP////+MnI05eoQvOKyfr6rGjlsR3lpV7QxZhbjkOJ4hFy9P0AEAAAAA/////wKejwEAAAAAABYAFElcvvohsHe14YxjkNWtxBZIqYitno8BAAAAAAAWABSjlrOorhbW+4kPAsyp5dK0jiMZpwJHMEQCIEq6eKorDcRNryahgf9dSbXNDF189IpgCS30sO8O+Rq1AiB0+61nCPYUOZGjF1PbZqPJaj53aX+A0lPN94RsVj16rAEhAoRJr5SAugyyzsyal4EwdWxTkZojg1Zo1u0iMlRnb5l0AkcwRAIgEQa+jK8Tx8EYbz0BtPv+sWTAW05UCnvo7jnpz4K8RHkCICp9h32SZEbcCowUWWq/oTf6vZabZ6ZEfabpafYEv+hRASEC72+ds8r1uwY9Len7FIQEvxl1L4rNkq+1Tt8RkMn/KkYAAAAAAQhrAkcwRAIgF5sXG1ltRnxXZ26YVw3+FiPKWYQg96PMtRcCfpYhehYCIGjI9ekMY8UD65F1et8r0u4uGZJ1YbINyMXWIeREVpuHASECXgVy93A4N3u9JETR1FHSRh64cGwjUjDe3NuPGOHaukYAAAA=
```

Please continue to report any similar bugs preventing interoperability.