### PR TITLE
Never self-broadcast with not-self

### DIFF
--- a/jmclient/jmclient/configure.py
+++ b/jmclient/jmclient/configure.py
@@ -244,12 +244,20 @@ absurd_fee_per_kb = 350000
 # spends from unconfirmed inputs, which may then get malleated or double-spent!
 # other counterparties are likely to reject unconfirmed inputs... don't do it.
 
-# options: self, random-peer, not-self.
+# tx_broadcast: options: self, random-peer, not-self.
+#
 # self = broadcast transaction with your own bitcoin node.
+#
 # random-peer = everyone who took part in the coinjoin has a chance of broadcasting
-# not-self = never broadcast with your own ip
 # note: if your counterparties do not support it, you will fall back
 # to broadcasting via your own node.
+#
+# not-self = never broadcast with your own bitcoin node.
+# note: in this case if your counterparties do not broadcast for you, you
+# will have to broadcast the tx manually (you can take the tx hex from the log
+# or terminal) via some other channel. It is not recommended to choose this
+# option when running schedules/tumbler.
+
 tx_broadcast = self
 
 # If makers do not respond while creating a coinjoin transaction,

--- a/jmclient/jmclient/taker.py
+++ b/jmclient/jmclient/taker.py
@@ -796,9 +796,11 @@ class Taker(object):
             self.wallet_service.register_callbacks([self.unconfirm_callback],
                                                    txid, "unconfirmed")
             if jm_single().config.get('POLICY', 'tx_broadcast') == "not-self":
+                warnmsg = ("You have chosen not to broadcast from your own "
+                          "node. The transaction is NOT broadcast.")
+                self.taker_info_callback("ABORT", warnmsg + "\nSee log for details.")
                 # warning is arguably not correct but it will stand out more:
-                jlog.warn("You have chosen not to broadcast from your own "
-                          "node. The transaction is NOT broadcast:")
+                jlog.warn(warnmsg)
                 jlog.info(btc.human_readable_transaction(tx))
                 return
             if not self.push_ourselves():

--- a/jmclient/jmclient/taker.py
+++ b/jmclient/jmclient/taker.py
@@ -795,6 +795,12 @@ class Taker(object):
             # in Taker.push():
             self.wallet_service.register_callbacks([self.unconfirm_callback],
                                                    txid, "unconfirmed")
+            if jm_single().config.get('POLICY', 'tx_broadcast') == "not-self":
+                # warning is arguably not correct but it will stand out more:
+                jlog.warn("You have chosen not to broadcast from your own "
+                          "node. The transaction is NOT broadcast:")
+                jlog.info(btc.human_readable_transaction(tx))
+                return
             if not self.push_ourselves():
                 jlog.error("Failed to broadcast transaction: ")
                 jlog.info(btc.human_readable_transaction(tx))


### PR DESCRIPTION
The handle_unbroadcast_transaction fallback in Taker
is useful because Makers may not cooperate in broadcasting
a transaction, but it is only appropriate for the
random-peer option of `tx_broadcast`; for not-self the
user has chosen to avoid using their own IP, so this
commit simply abandons the attempt to broadcast the
transaction in that case.
The comments added to the config emphasize the problematic
aspect of this, which is that the tx may need to be
manually broadcast via another channel.