### PR TITLE
Remove /shutdown from ob-watcher

### DIFF
--- a/scripts/obwatch/ob-watcher.py
+++ b/scripts/obwatch/ob-watcher.py
@@ -45,8 +45,6 @@ swoffers = list(filter(lambda x: x[0:2] == 'sw', offername_list))
 pkoffers = list(filter(lambda x: x[0:2] != 'sw', offername_list))
 filtered_offername_list = swoffers
 
-shutdownform = '<form action="shutdown" method="post"><input type="submit" value="Shutdown" /></form>'
-shutdownpage = '<html><body><center><h1>Successfully Shut down</h1></center></body></html>'
 toggleSWform = '<form action="toggleSW" method="post"><input type="submit" value="Toggle non-segwit" /></form>'
 refresh_orderbook_form = '<form action="refreshorderbook" method="post"><input type="submit" value="Check for timed-out counterparties" /></form>'
 sorted_units = ('BTC', 'mBTC', '&#956;BTC', 'satoshi')
@@ -348,18 +346,10 @@ class OrderbookPageRequestHeader(http.server.SimpleHTTPRequestHandler):
 
     def do_POST(self):
         global filtered_offername_list
-        pages = ['/shutdown', '/refreshorderbook', '/toggleSW']
+        pages = ['/refreshorderbook', '/toggleSW']
         if self.path not in pages:
             return
-        if self.path == '/shutdown':
-            self.taker.msgchan.shutdown()
-            self.send_response(200)
-            self.send_header('Content-Type', 'text/html')
-            self.send_header('Content-Length', len(shutdownpage))
-            self.end_headers()
-            self.wfile.write(shutdownpage)
-            self.base_server.__shutdown_request = True
-        elif self.path == '/refreshorderbook':
+        if self.path == '/refreshorderbook':
             self.taker.msgchan.request_orderbook()
             time.sleep(5)
             self.path = '/'


### PR DESCRIPTION
1) It is bad, people run public orderbooks;
2) It is broken anyway, both by throwing exception and then reconnecting
   to IRC servers instead of shutdown;
3) Same can be achieved locally by killing / restarting ob-watcher.py,
   if somebody wants such functionality from web interface, some access
   control needs to be introduced.