### PR TITLE
Add link to orderbook.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ If you are running Joinmarket-Qt, you can instead use the [walkthrough](docs/JOI
 
 If you used the old version of Joinmarket, the notes in the [scripts readme](scripts/README.md) help to understand what has and hasn't changed about the scripts.
 
+If you are looking for the available makers, run the [orderbook](docs/orderbook.md).
+
 ### PayJoin
 
 If you want to use the PayJoin feature to pay/receive money to/from another Joinmarket wallet user, read [this guide](docs/PAYJOIN.md).


### PR DESCRIPTION
This is the continuation of #716, now that we have a doc file for the orderbook I think we should advertise it somewhere.
Joinmarket is, as the name suggest, a market and an orderbook is a fundamental part of a market.

Under `Usage` seems a natural fit, as the orderbook should be one of the use cases of the repo, and gives it max visibility, but I don't have strong opinion if you have a better place (I thought about the `USAGE.md` file but I'm not sure where to put it there).