### PR TITLE
Strip whitespace from beginning and end of mnemonic on wallet recovery

### DIFF
--- a/jmclient/jmclient/wallet_utils.py
+++ b/jmclient/jmclient/wallet_utils.py
@@ -618,6 +618,7 @@ def wallet_generate_recover_bip39(method, walletspath, default_wallet_name,
                 return False
     elif method == 'recover':
         words, mnemonic_extension = enter_seed_callback()
+        words = words.strip()
         mnemonic_extension = mnemonic_extension and mnemonic_extension.strip()
         if not words:
             return False


### PR DESCRIPTION
Was requested by the user on Telegram.

> One thing, may be really minor and it does not matter for anyone else but it really annoyed me. 
When you restore your wallet with your 12 words; after your last word if you press space and click ok. It shows an error. It took me quiet a while to figure out that I should not press space bar after the last word. I tried electrum and blue wallet, both of them, it does not matter if you have space after the last word or not.