### PR TITLE
Move YG settings to a config file

### DIFF
--- a/jmclient/jmclient/configure.py
+++ b/jmclient/jmclient/configure.py
@@ -306,6 +306,10 @@ accept_commitment_broadcasts = 1
 #and those you want to use in future), relative to the scripts directory.
 commit_file_location = cmtdata/commitments.json
 
+##############################
+# END OF ANTI-SNOOPING SETTINGS
+##############################
+
 [PAYJOIN]
 # for the majority of situations, the defaults
 # need not be altered - they will ensure you don't pay
@@ -349,6 +353,33 @@ tor_control_port = 9051
 # this feature is not yet implemented in code, but here for the
 # future:
 hidden_service_ssl = false
+
+[YIELDGENERATOR]
+# [string, 'reloffer' or 'absoffer'], which fee type to actually use
+ordertype = reloffer
+
+# [satoshis, any integer] / absolute offer fee you wish to receive for coinjoins (cj)
+cjfee_a = 500
+
+# [fraction, any str between 0-1] / relative offer fee you wish to receive based on a cj's amount
+cjfee_r = 0.00002
+
+# [fraction, 0-1] / variance around the average fee. Ex: 200 fee, 0.2 var = fee is btw 160-240
+cjfee_factor = 0.1
+
+# [satoshis, any integer] / the average transaction fee you're adding to coinjoin transactions
+txfee = 100
+
+# [fraction, 0-1] / variance around the average fee. Ex: 1000 fee, 0.2 var = fee is btw 800-1200
+txfee_factor = 0.3
+
+# [satoshis, any integer] / minimum size of your cj offer. Lower cj amounts will be disregarded
+minsize = 100000
+
+# [fraction, 0-1] / variance around all offer sizes. Ex: 500k minsize, 0.1 var = 450k-550k
+size_factor = 0.1
+
+gaplimit = 6
 """
 
 #This allows use of the jmclient package with a

--- a/jmclient/test/test_coinjoin.py
+++ b/jmclient/test/test_coinjoin.py
@@ -141,7 +141,7 @@ def test_simple_coinjoin(monkeypatch, tmpdir, setup_cj, wallet_cls):
 
     makers = [YieldGeneratorBasic(
         wallet_services[i],
-        [0, 2000, 0, absoffer_type_map[wallet_cls], 10**7]) for i in range(MAKER_NUM)]
+        [0, 2000, 0, absoffer_type_map[wallet_cls], 10**7, None, None, None]) for i in range(MAKER_NUM)]
     create_orders(makers)
 
     orderbook = create_orderbook(makers)
@@ -186,7 +186,7 @@ def test_coinjoin_mixdepth_wrap_taker(monkeypatch, tmpdir, setup_cj):
     cj_fee = 2000
     makers = [YieldGeneratorBasic(
         wallet_services[i],
-        [0, cj_fee, 0, absoffer_type_map[SegwitWallet], 10**7]) for i in range(MAKER_NUM)]
+        [0, cj_fee, 0, absoffer_type_map[SegwitWallet], 10**7, None, None, None]) for i in range(MAKER_NUM)]
     create_orders(makers)
 
     orderbook = create_orderbook(makers)
@@ -242,7 +242,7 @@ def test_coinjoin_mixdepth_wrap_maker(monkeypatch, tmpdir, setup_cj):
     cj_fee = 2000
     makers = [YieldGeneratorBasic(
         wallet_services[i],
-        [0, cj_fee, 0, absoffer_type_map[SegwitWallet], 10**7]) for i in range(MAKER_NUM)]
+        [0, cj_fee, 0, absoffer_type_map[SegwitWallet], 10**7, None, None, None]) for i in range(MAKER_NUM)]
     create_orders(makers)
     orderbook = create_orderbook(makers)
     assert len(orderbook) == MAKER_NUM

--- a/jmclient/test/test_yieldgenerator.py
+++ b/jmclient/test/test_yieldgenerator.py
@@ -49,7 +49,7 @@ def create_yg_basic(balances, txfee=0, cjfee_a=0, cjfee_r=0,
     will be set as given here."""
 
     wallet = CustomUtxoWallet(balances)
-    offerconfig = (txfee, cjfee_a, cjfee_r, ordertype, minsize)
+    offerconfig = (txfee, cjfee_a, cjfee_r, ordertype, minsize, None, None, None)
 
     yg = YieldGeneratorBasic(WalletService(wallet), offerconfig)
 

--- a/scripts/yield-generator-basic.py
+++ b/scripts/yield-generator-basic.py
@@ -3,20 +3,9 @@
 from jmbase import jmprint
 from jmclient import YieldGeneratorBasic, ygmain
 
-"""THESE SETTINGS CAN SIMPLY BE EDITED BY HAND IN THIS FILE:
-"""
-
-ordertype = 'reloffer' # [string, 'reloffer' or 'absoffer'], which fee type to actually use
-cjfee_a = 500 # [satoshis, any integer] / absolute offer fee you wish to receive for coinjoins (cj)
-cjfee_r = '0.00002' # [fraction, any str between 0-1] / relative offer fee you wish to receive based on a cj's amount
-txfee = 0 # [satoshis, any integer] / the transaction fee contribution you're adding to coinjoin transactions
-nickserv_password = ''
-minsize = 100000 # [satoshis, any integer] / minimum size of your cj offer. Lower cj amounts will be disregarded
-gaplimit = 6
+# YIELD GENERATOR SETTINGS ARE NOW IN YOUR joinmarket.cfg CONFIG FILE
+# (You can also use command line flags; see --help for this script).
 
 if __name__ == "__main__":
-    ygmain(YieldGeneratorBasic, txfee=txfee, cjfee_a=cjfee_a,
-           cjfee_r=cjfee_r, ordertype=ordertype,
-           nickserv_password=nickserv_password,
-           minsize=minsize, gaplimit=gaplimit)
+    ygmain(YieldGeneratorBasic, nickserv_password='')
     jmprint('done', "success")


### PR DESCRIPTION
Allow YG settings to be saved to yg.cfg config file (same location as the joinmarket.cfg file). The update will also create the cfg file with the default settings if the file does not exist.