### PR TITLE
Get rid of remaining direct rpc() calls outside blockchaininterface.py

### DIFF
--- a/jmclient/jmclient/payjoin.py
+++ b/jmclient/jmclient/payjoin.py
@@ -872,8 +872,8 @@ class PayjoinServer(Resource):
         # it is still safer to at least verify the validity of the signatures
         # at this stage, to ensure no misbehaviour with using inputs
         # that are not signed correctly:
-        res = jm_single().bc_interface.rpc('testmempoolaccept', [[bintohex(
-            self.manager.payment_tx.serialize())]])
+        res = jm_single().bc_interface.testmempoolaccept(bintohex(
+            self.manager.payment_tx.serialize()))
         if not res[0]["allowed"]:
             return self.bip78_error(request, "Proposed transaction was "
                                     "rejected from mempool.",

--- a/jmclient/jmclient/wallet_service.py
+++ b/jmclient/jmclient/wallet_service.py
@@ -484,7 +484,7 @@ class WalletService(Service):
         have been used in our Core wallet with the specific label
         for our JM wallet. This operation is generally immediate.
         """
-        agd = self.bci.rpc('listaddressgroupings', [])
+        agd = self.bci.listaddressgroupings()
         # flatten all groups into a single list; then, remove duplicates
         fagd = (tuple(item) for sublist in agd for item in sublist)
         # "deduplicated flattened address grouping data" = dfagd
@@ -647,7 +647,7 @@ class WalletService(Service):
                     jlog.warning("Merkle branch likely not available, use "
                         + "wallet-tool `addtxoutproof`")
                     merkle_branch = None
-                block_height = self.bci.rpc("getblockheader", [gettx["blockhash"]])["height"]
+                block_height = self.bci.get_block_height(gettx["blockhash"])
                 if merkle_branch:
                     assert self.bci.verify_tx_merkle_branch(txid, block_height, merkle_branch)
                 self.wallet.add_burner_output(path_repr, gettx["hex"], block_height,
@@ -729,12 +729,7 @@ class WalletService(Service):
         wallet_name = self.get_wallet_name()
         self.reset_utxos()
 
-        listunspent_args = []
-        if 'listunspent_args' in jm_single().config.options('POLICY'):
-            listunspent_args = ast.literal_eval(jm_single().config.get(
-                'POLICY', 'listunspent_args'))
-
-        unspent_list = self.bci.rpc('listunspent', listunspent_args)
+        unspent_list = self.bci.listunspent()
         # filter on label, but note (a) in certain circumstances (in-
         # wallet transfer) it is possible for the utxo to be labeled
         # with the external label, and (b) the wallet will know if it

--- a/jmclient/test/commontest.py
+++ b/jmclient/test/commontest.py
@@ -229,7 +229,7 @@ def ensure_bip65_activated():
     #on regtest bip65 activates on height 1351
     #https://github.com/bitcoin/bitcoin/blob/1d1f8bbf57118e01904448108a104e20f50d2544/src/chainparams.cpp#L262
     BIP65Height = 1351
-    current_height = jm_single().bc_interface.rpc("getblockchaininfo", [])["blocks"]
+    current_height = jm_single().bc_interface.get_current_block_height()
     until_bip65_activation = BIP65Height - current_height + 1
     if until_bip65_activation > 0:
         jm_single().bc_interface.tick_forward_chain(until_bip65_activation)

--- a/jmclient/test/test_psbt_wallet.py
+++ b/jmclient/test/test_psbt_wallet.py
@@ -231,8 +231,7 @@ def test_payjoin_workflow(setup_psbt_wallet, payment_amt, wallet_cls_sender,
     # don't want to push the tx right now, because of test structure
     # (in production code this isn't really needed, we will not
     # produce invalid payment transactions).
-    res = jm_single().bc_interface.rpc('testmempoolaccept',
-                                       [[bintohex(extracted_tx)]])
+    res = jm_single().bc_interface.testmempoolaccept(bintohex(extracted_tx))
     assert res[0]["allowed"], "Payment transaction was rejected from mempool."
 
     # *** STEP 2 ***

--- a/jmclient/test/test_tx_creation.py
+++ b/jmclient/test/test_tx_creation.py
@@ -143,7 +143,7 @@ def test_spend_freeze_script(setup_tx_creation):
     wallet_service = make_wallets(1, [[3, 0, 0, 0, 0]], 3)[0]['wallet']
     wallet_service.sync_wallet(fast=True)
 
-    mediantime = jm_single().bc_interface.rpc("getblockchaininfo", [])["mediantime"]
+    mediantime = jm_single().bc_interface.get_best_block_median_time()
 
     timeoffset_success_tests = [(2, False), (-60*60*24*30, True), (60*60*24*30, False)]
 

--- a/jmclient/test/test_wallet.py
+++ b/jmclient/test/test_wallet.py
@@ -755,7 +755,7 @@ def test_wallet_mixdepth_decrease(setup_wallet):
     assert max_mixdepth >= 1, "bad default value for mixdepth for this test"
     utxo = fund_wallet_addr(wallet, wallet.get_internal_addr(max_mixdepth), 1)
     bci = jm_single().bc_interface
-    unspent_list = bci.rpc('listunspent', [0])
+    unspent_list = bci.listunspent(0)
     # filter on label, but note (a) in certain circumstances (in-
     # wallet transfer) it is possible for the utxo to be labeled
     # with the external label, and (b) the wallet will know if it


### PR DESCRIPTION
Follow-up to #501.

Test suite passes and also did some manual testnet testing. Had error receiving payjoin from testnet.demo.btcpayserver.org, but that doesn't seem related. More testing is needed before merging.