### PR TITLE
Bugfix: allow minsize dynamic update

### DIFF
--- a/jmclient/jmclient/yieldgenerator.py
+++ b/jmclient/jmclient/yieldgenerator.py
@@ -271,7 +271,7 @@ def ygmain(ygclass, txfee=1000, cjfee_a=200, cjfee_r=0.002, ordertype='reloffer'
     jlog.debug("Set the offer type string to: " + ordertype)
 
     maker = ygclass(wallet_service, [options.txfee, cjfee_a, cjfee_r,
-                             ordertype, options.minsize])
+                             ordertype, minsize])
     jlog.info('starting yield generator')
     clientfactory = JMClientProtocolFactory(maker, proto_type="MAKER")
 

--- a/scripts/yg-privacyenhanced.py
+++ b/scripts/yg-privacyenhanced.py
@@ -19,8 +19,8 @@ ordertype = 'reloffer'  # [string, 'reloffer' or 'absoffer'], which fee type to 
 cjfee_a = 500             # [satoshis, any integer] / absolute offer fee you wish to receive for coinjoins (cj)
 cjfee_r = '0.00002'       # [fraction, any str between 0-1] / relative offer fee you wish to receive based on a cj's amount
 cjfee_factor = 0.1        # [fraction, 0-1] / variance around the average fee. Ex: 200 fee, 0.2 var = fee is btw 160-240
-txfee = 100               # [satoshis, any integer] / the average transaction fee you're adding to coinjoin transactions
-txfee_factor = 0.3        # [fraction, 0-1] / variance around the average fee. Ex: 1000 fee, 0.2 var = fee is btw 800-1200
+txfee = 0                 # [satoshis, any integer] / the average transaction fee contribution you're adding to coinjoin transactions
+txfee_factor = 0.3        # [fraction, 0-1] / variance around the average fee contribution. Ex: 1000 fee, 0.2 var = fee is btw 800-1200
 minsize = 100000          # [satoshis, any integer] / minimum size of your cj offer. Lower cj amounts will be disregarded
 size_factor = 0.1         # [fraction, 0-1] / variance around all offer sizes. Ex: 500k minsize, 0.1 var = 450k-550k
 gaplimit = 6
@@ -47,7 +47,8 @@ class YieldGeneratorPrivacyEnhanced(YieldGeneratorBasic):
                             if b > self.minsize])
         if len(mix_balance) == 0:
             jlog.error('You do not have the minimum required amount of coins'
-                       ' to be a maker: ' + str(minsize))
+                       ' to be a maker: ' + str(self.minsize) + \
+                       '\nTry setting txfee to zero and/or lowering the minsize.')
             return []
         max_mix = max(mix_balance, key=mix_balance.get)
 

--- a/scripts/yield-generator-basic.py
+++ b/scripts/yield-generator-basic.py
@@ -9,7 +9,7 @@ from jmclient import YieldGeneratorBasic, ygmain
 ordertype = 'reloffer' # [string, 'reloffer' or 'absoffer'], which fee type to actually use
 cjfee_a = 500 # [satoshis, any integer] / absolute offer fee you wish to receive for coinjoins (cj)
 cjfee_r = '0.00002' # [fraction, any str between 0-1] / relative offer fee you wish to receive based on a cj's amount
-txfee = 100 # [satoshis, any integer] / the average transaction fee you're adding to coinjoin transactions
+txfee = 0 # [satoshis, any integer] / the transaction fee contribution you're adding to coinjoin transactions
 nickserv_password = ''
 minsize = 100000 # [satoshis, any integer] / minimum size of your cj offer. Lower cj amounts will be disregarded
 gaplimit = 6


### PR DESCRIPTION
Before this bugfix, the user-chosen minsize is passed
to the constructor of the YieldGenerator class unaltered,
even though it was dynamically updated to ensure 20% of
txfee profit in all cases (the wrong variable was passed).
This commit fixes that (`minsize` not `options.minsize`).