### PR TITLE
Choose maker offers based only on our wallet type

### DIFF
--- a/jmclient/jmclient/taker.py
+++ b/jmclient/jmclient/taker.py
@@ -250,12 +250,15 @@ class Taker(object):
         if sweep:
             self.orderbook = orderbook #offers choosing deferred to next step
         else:
-            if jm_single().config.get("POLICY", "segwit") == "false":
+            if self.wallet_service.get_txtype() == "p2pkh":
                 allowed_types = ["reloffer", "absoffer"]
-            elif jm_single().config.get("POLICY", "native") == "false":
+            elif self.wallet_service.get_txtype() == "p2sh-p2wpkh":
                 allowed_types = ["swreloffer", "swabsoffer"]
-            else:
+            elif self.wallet_service.get_txtype() == "p2wpkh":
                 allowed_types = ["sw0reloffer", "sw0absoffer"]
+            else:
+                jlog.error("Unrecognized wallet type, taker cannot continue.")
+                return False
             self.orderbook, self.total_cj_fee = choose_orders(
                 orderbook, self.cjamount, self.n_counterparties, self.order_chooser,
                 self.ignored_makers, allowed_types=allowed_types,
@@ -324,12 +327,15 @@ class Taker(object):
                                             txtype=self.wallet_service.get_txtype())
             jlog.debug("We have a fee estimate: "+str(self.total_txfee))
             total_value = sum([va['value'] for va in self.input_utxos.values()])
-            if jm_single().config.get("POLICY", "segwit") == "false":
+            if self.wallet_service.get_txtype() == "p2pkh":
                 allowed_types = ["reloffer", "absoffer"]
-            elif jm_single().config.get("POLICY", "native") == "false":
+            elif self.wallet_service.get_txtype() == "p2sh-p2wpkh":
                 allowed_types = ["swreloffer", "swabsoffer"]
-            else:
+            elif self.wallet_service.get_txtype() == "p2wpkh":
                 allowed_types = ["sw0reloffer", "sw0absoffer"]
+            else:
+                jlog.error("Unrecognized wallet type, taker cannot continue.")
+                return False
             self.orderbook, self.cjamount, self.total_cj_fee = choose_sweep_orders(
                 self.orderbook, total_value, self.total_txfee,
                 self.n_counterparties, self.order_chooser,

--- a/jmclient/test/test_coinjoin.py
+++ b/jmclient/test/test_coinjoin.py
@@ -21,6 +21,10 @@ import jmbitcoin as btc
 testdir = os.path.dirname(os.path.realpath(__file__))
 log = get_log()
 
+# map wallet types to offer types:
+absoffer_type_map = {LegacyWallet: "absoffer",
+                  SegwitLegacyWallet: "swabsoffer",
+                  SegwitWallet: "sw0absoffer"}
 
 def make_wallets_to_list(make_wallets_data):
     wallets = [None for x in range(len(make_wallets_data))]
@@ -137,7 +141,7 @@ def test_simple_coinjoin(monkeypatch, tmpdir, setup_cj, wallet_cls):
 
     makers = [YieldGeneratorBasic(
         wallet_services[i],
-        [0, 2000, 0, 'sw0absoffer', 10**7]) for i in range(MAKER_NUM)]
+        [0, 2000, 0, absoffer_type_map[wallet_cls], 10**7]) for i in range(MAKER_NUM)]
     create_orders(makers)
 
     orderbook = create_orderbook(makers)
@@ -182,7 +186,7 @@ def test_coinjoin_mixdepth_wrap_taker(monkeypatch, tmpdir, setup_cj):
     cj_fee = 2000
     makers = [YieldGeneratorBasic(
         wallet_services[i],
-        [0, cj_fee, 0, 'sw0absoffer', 10**7]) for i in range(MAKER_NUM)]
+        [0, cj_fee, 0, absoffer_type_map[SegwitWallet], 10**7]) for i in range(MAKER_NUM)]
     create_orders(makers)
 
     orderbook = create_orderbook(makers)
@@ -238,7 +242,7 @@ def test_coinjoin_mixdepth_wrap_maker(monkeypatch, tmpdir, setup_cj):
     cj_fee = 2000
     makers = [YieldGeneratorBasic(
         wallet_services[i],
-        [0, cj_fee, 0, 'sw0absoffer', 10**7]) for i in range(MAKER_NUM)]
+        [0, cj_fee, 0, absoffer_type_map[SegwitWallet], 10**7]) for i in range(MAKER_NUM)]
     create_orders(makers)
     orderbook = create_orderbook(makers)
     assert len(orderbook) == MAKER_NUM


### PR DESCRIPTION
Before this commit, the taker would choose offers from
the pit based on the setting of `native` in the `[POLICY]`
section of the config object; however this could lead to
users unwittingly choosing the wrong offer type, i.e. one
that is incompatible with their own wallets, which could
result in coinjoins with mixed address types.
This commit fixes that error by only selecting offers that
are compatible with the return value of `BaseWallet.get_txtype()`.