### PR TITLE
PySide2 version pinned to 5.14.2

### DIFF
--- a/requirements/gui.txt
+++ b/requirements/gui.txt
@@ -1,6 +1,6 @@
 -r base.txt
 pywin32; platform_system == "Windows"
-PySide2
+PySide2==5.14.2
 PyQt5==5.14.2
 qrcode[pil]
 https://github.com/sunu/qt5reactor/archive/58410aaead2185e9917ae9cac9c50fe7b70e4a60.zip#egg=qt5reactor


### PR DESCRIPTION
Fixes #737. Before this commit, startup of
Joinmarket-Qt does not necessarily work "out
of the box" due to changes in PyQt 5.15 that
create external dependencies on shared libraries,
see comments on the Issue for details.
While we had formerly pinned PyQt 5.14, it is
in fact necessary to also pin the version of
PySide2 to the same 5.14.2 to remove the
problem.