### PR TITLE
Fix bugs in utxo parsing in add-utxo.py

### DIFF
--- a/jmclient/jmclient/commitment_utils.py
+++ b/jmclient/jmclient/commitment_utils.py
@@ -9,15 +9,17 @@ def quit(parser, errmsg): #pragma: no cover
     parser.error(errmsg)
     sys.exit(EXIT_FAILURE)
 
-def get_utxo_info(upriv):
+def get_utxo_info(upriv, utxo_binary=False):
     """Verify that the input string parses correctly as (utxo, priv)
-    and return that.
+    and return that. If `utxo_binary` is true, the first element of
+    that return tuple is the standard internal form
+    (txid-in-binary, index-as-int).
     """
     try:
         u, priv = upriv.split(',')
         u = u.strip()
         priv = priv.strip()
-        success, utxo = utxostr_to_utxo(u)
+        success, utxo_bin = utxostr_to_utxo(u)
         assert success, utxo
     except:
         #not sending data to stdout in case privkey info
@@ -30,7 +32,8 @@ def get_utxo_info(upriv):
     except:
         jmprint("failed to parse privkey, make sure it's WIF compressed format.", "error")
         raise
-    return u, priv
+    utxo_to_return = utxo_bin if utxo_binary else u
+    return utxo_to_return, priv
     
 def validate_utxo_data(utxo_datas, retrieve=False, utxo_address_type="p2wpkh"):
     """For each (utxo, privkey), first


### PR DESCRIPTION
Fixes #743. The utility function `get_utxo_info`
tests the validity of the utxo string and the private
key, so there is no need to repeat this test; but we
need to add utxo data in binary format, so an option
is included to return it in this form.
The 4 ways of adding external commitments were tested
as all working after this commit: read in from json,
read in from file (csv format), read in from command
line and read from wallet.