### PR TITLE
Handle None return from _rpc() in get_transaction()

### DIFF
--- a/jmclient/jmclient/blockchaininterface.py
+++ b/jmclient/jmclient/blockchaininterface.py
@@ -341,6 +341,9 @@ class BitcoinCoreInterface(BlockchainInterface):
                 log.warn("Failed gettransaction call; unexpected error:")
                 log.warn(str(e))
                 return None
+        if res is None:
+            # happens in case of rpc connection failure:
+            return None
         if "confirmations" not in res:
             log.warning("Malformed gettx result: " + str(res))
             return None


### PR DESCRIPTION
Before this commit, if an RPC connection failure occurred,
while the program is shutting down, it could raise an Exception
in the BitcoinCoreInterface.get_transaction() call triggered
by the WalletService.transaction_monitor loop. This commit
prevents that.