### PR TITLE
Allow any case for scheme part of BIP21 URI as per spec

### DIFF
--- a/jmbitcoin/jmbitcoin/bip21.py
+++ b/jmbitcoin/jmbitcoin/bip21.py
@@ -11,7 +11,7 @@ import re
 
 def is_bip21_uri(uri):
     parsed = urlparse(uri)
-    return parsed.scheme == 'bitcoin' and parsed.path != ''
+    return parsed.scheme.lower() == 'bitcoin' and parsed.path != ''
 
 
 def is_bip21_amount_str(amount):

--- a/jmbitcoin/test/test_bip21.py
+++ b/jmbitcoin/test/test_bip21.py
@@ -26,6 +26,10 @@ def test_bip21_decode():
 
     assert(btc.decode_bip21_uri('bitcoin:175tWpb8K1S7NmH4Zx6rewF9WQrcZv245W'
         )['address'] == '175tWpb8K1S7NmH4Zx6rewF9WQrcZv245W')
+    assert(btc.decode_bip21_uri('BITCOIN:175tWpb8K1S7NmH4Zx6rewF9WQrcZv245W'
+        )['address'] == '175tWpb8K1S7NmH4Zx6rewF9WQrcZv245W')
+    assert(btc.decode_bip21_uri('BitCoin:175tWpb8K1S7NmH4Zx6rewF9WQrcZv245W'
+        )['address'] == '175tWpb8K1S7NmH4Zx6rewF9WQrcZv245W')
 
     parsed = btc.decode_bip21_uri(
         'bitcoin:175tWpb8K1S7NmH4Zx6rewF9WQrcZv245W?label=Luke-Jr')


### PR DESCRIPTION
https://github.com/btcpayserver/btcpayserver/issues/2110

[BIP21](https://github.com/bitcoin/bips/blob/master/bip-0021.mediawiki) states that scheme part of URI must be case insensitive:

> The scheme component ("bitcoin:") is case-insensitive, and implementations must accept any combination of uppercase and lowercase letters. The rest of the URI is case-sensitive, including the query parameter keys.

We required `bitcoin:` part to be lowercase, this is a fix for that.