### PR TITLE
Drop support for pre-0.17 Bitcoin Core

### DIFF
--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -117,9 +117,11 @@ Before starting, note you need either (a) Bitcoin Core installed on Windows or (
 If (a), then note the following two points:
 
 ##### Installing Bitcoin Core
-If you haven't done so yet, install Bitcoin Core as described [here](https://bitcoin.org/en/full-node#windows-10). After starting it for the first time, it will start the Initial Block Download. JoinMarket cannot be used until this is finished. More information on that can be found [here](https://bitcoin.org/en/full-node#initial-block-downloadibd).
+
+If you haven't done so yet, install Bitcoin Core, version 0.18 or newer, as described [here](https://bitcoin.org/en/full-node#windows-10). After starting it for the first time, it will start the Initial Block Download. JoinMarket cannot be used until this is finished. More information on that can be found [here](https://bitcoin.org/en/full-node#initial-block-downloadibd).
 
 ##### Configuring Bitcoin Core
+
 Bitcoin Core needs to be configured to allow JoinMarket to connect to it. From the `Settings` menu choose `Options` and click `Open Configuration File`. Add `server=1`, save and close the file. After that restart Bitcoin Core.
 
 There are currently two choices for installing on Windows; one, directly installing on Windows, requiring the manual addition of a libsodium dependency, or, two, using Ubuntu via the WSL mechanism (which may require additional setup to make the Qt GUI work).

--- a/docs/PAYJOIN.md
+++ b/docs/PAYJOIN.md
@@ -39,7 +39,7 @@ So just skip those sections if you already know it.
 
 ### Preparatory step: configuring for Bitcoin Core.
 
-Joinmarket currently requires a Bitcoin Core full node, although it can be pruned.
+Joinmarket currently requires a Bitcoin Core full node, version 0.18 or newer, although it can be pruned.
 
 First thing to do: in `scripts/`, run:
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -1,6 +1,6 @@
 ### Test instructions (for developers):
 
-Work in your `jmvenv` virtualenv as for all Joinmarket work. Make sure to have [bitcoind](https://bitcoin.org/en/full-node) 0.17 or newer installed. Also need miniircd installed to the root (i.e. in your `joinmarket-clientserver` directory):
+Work in your `jmvenv` virtualenv as for all Joinmarket work. Make sure to have [bitcoind](https://bitcoin.org/en/full-node) 0.18 or newer installed. Also need miniircd installed to the root (i.e. in your `joinmarket-clientserver` directory):
 
     (jmvenv)$ cd /path/to/joinmarket-clientserver
     (jmvenv)$ git clone https://github.com/Joinmarket-Org/miniircd


### PR DESCRIPTION
Simplifies code, resolves #452.

I would like also drop official support for versions older than 0.18 (still support 0.17 at first, but put 0.18 as a requirement in docs), as 0.18 is minimum required for [wallet no history sync](https://github.com/JoinMarket-Org/joinmarket-clientserver/pull/444). In future that would allow [some more optimizations](https://github.com/JoinMarket-Org/joinmarket-clientserver/pull/462). Asked it [here](https://github.com/JoinMarket-Org/joinmarket-clientserver/issues/452#issuecomment-742166828), want to hear some comments about that. In any case, these would be changes on top of this anyway.

Tested by running test suite with 0.17.1 (where 4 of  tests of `jmclient/test/test_core_nohistory_sync.py` fail as expected) and 0.20.1.

