### PR TITLE
ob-watcher: Use relative links

### DIFF
--- a/scripts/obwatch/orderbook.html
+++ b/scripts/obwatch/orderbook.html
@@ -78,14 +78,14 @@
 		<nav class="navbar navbar-inverse navbar-fixed-top">
 	      <div class="container">
 	        <div class="navbar-header">
-	        	<a class="navbar-brand" href="/">Join Market</a>
+	        	<a class="navbar-brand" href=".">Join Market</a>
 	        </div>
 	        <div id="navbar" class="collapse navbar-collapse">
 	          <ul class="nav navbar-nav">
-	            <li class="active"><a href="/">Orders</a></li>
-	            <li><a href="/ordersize">Size Distribution</a></li>
-	            <li><a href="/depth">Depth</a></li>
-	            <li><a href="/orderbook.json">Export orders</a></li>
+	            <li class="active"><a href=".">Orders</a></li>
+	            <li><a href="ordersize">Size Distribution</a></li>
+	            <li><a href="depth">Depth</a></li>
+	            <li><a href="orderbook.json">Export orders</a></li>
 	            <li><a target="_blank" href="https://github.com/JoinMarket-Org/joinmarket-clientserver/releases">New segwit version</a></li>
 	          </ul>
 	        </div><!--/.nav-collapse -->


### PR DESCRIPTION
Copy of commit message:
Using relative links instead of root-relative links allows hosting ob-watcher with an arbitrary URL path prefix, like 'orderbook' (https://example.com/orderbook).