### PR TITLE
Allow schedule files without payment arguments.

### DIFF
--- a/jmclient/jmclient/cli_options.py
+++ b/jmclient/jmclient/cli_options.py
@@ -448,7 +448,8 @@ def get_sendpayment_parser():
     parser = OptionParser(
         usage=
         'usage: %prog [options] wallet_file amount destination\n' +
-        '       %prog [options] wallet_file bitcoin_uri',
+        '       %prog [options] wallet_file bitcoin_uri\n' +
+        '       %prog [options] wallet_file',
         description='Sends a single payment from a given mixing depth of your '
         +
         'wallet to an given address using coinjoin and then switches off. '

--- a/scripts/sendpayment.py
+++ b/scripts/sendpayment.py
@@ -116,8 +116,9 @@ def main():
         schedule = [[options.mixdepth, amount, options.makercount,
                      destaddr, 0.0, NO_ROUNDING, 0]]
     else:
-        if btc.is_bip21_uri(args[1]):
-            parser.error("Schedule files are not compatible with bip21 uris.")
+        if len(args) > 1:
+            parser.error("Schedule files are not compatible with "
+                         "payment destination/amount arguments.")
             sys.exit(EXIT_ARGERROR)
         result, schedule = get_schedule(options.schedule)
         if not result:


### PR DESCRIPTION
Fixes #778. Prior to this commit, attempting to run
sendpayment with a schedule specified with -S would
fail due to a bug. This is now fixed, and the
sendpayment help message now accurately reflects the
facts that no arguments other than the wallet name are
needed in case -S is used.