### PR TITLE
Update tests to use 1/0 not True/False addr type

### DIFF
--- a/jmclient/jmclient/wallet_service.py
+++ b/jmclient/jmclient/wallet_service.py
@@ -14,7 +14,7 @@ from jmclient.configure import jm_single, get_log
 from jmclient.output import fmt_tx_data
 from jmclient.blockchaininterface import (INF_HEIGHT, BitcoinCoreInterface,
     BitcoinCoreNoHistoryInterface)
-from jmclient.wallet import FidelityBondMixin
+from jmclient.wallet import FidelityBondMixin, BaseWallet
 from jmbase import stop_reactor
 from jmbase.support import jmprint, EXIT_SUCCESS, utxo_to_utxostr, hextobin
 
@@ -867,7 +867,8 @@ class WalletService(Service):
 
         for md in range(self.max_mixdepth + 1):
             saved_indices[md] = [0, 0]
-            for address_type in (0, 1):
+            for address_type in (BaseWallet.ADDRESS_TYPE_EXTERNAL,
+                                 BaseWallet.ADDRESS_TYPE_INTERNAL):
                 next_unused = self.get_next_unused_index(md, address_type)
                 for index in range(next_unused):
                     addresses.add(self.get_addr(md, address_type, index))
@@ -904,7 +905,8 @@ class WalletService(Service):
         addresses = set()
 
         for md in range(self.max_mixdepth + 1):
-            for address_type in (1, 0):
+            for address_type in (BaseWallet.ADDRESS_TYPE_INTERNAL,
+                                 BaseWallet.ADDRESS_TYPE_EXTERNAL):
                 old_next = self.get_next_unused_index(md, address_type)
                 for index in range(gap_limit):
                     addresses.add(self.get_new_addr(md, address_type))

--- a/jmclient/jmclient/wallet_utils.py
+++ b/jmclient/jmclient/wallet_utils.py
@@ -11,7 +11,7 @@ from numbers import Integral
 from collections import Counter
 from itertools import islice
 from jmclient import (get_network, WALLET_IMPLEMENTATIONS, Storage, podle,
-    jm_single, BitcoinCoreInterface, WalletError,
+    jm_single, BitcoinCoreInterface, WalletError, BaseWallet,
     VolatileStorage, StoragePasswordError, is_segwit_mode, SegwitLegacyWallet,
     LegacyWallet, SegwitWallet, FidelityBondMixin, FidelityBondWatchonlyWallet,
     is_native_segwit_mode, load_program_config, add_base_options, check_regtest)
@@ -452,9 +452,10 @@ def wallet_display(wallet_service, showprivkey, displayall=False,
     utxos = wallet_service.get_utxos_by_mixdepth(include_disabled=True)
     for m in range(wallet_service.mixdepth + 1):
         branchlist = []
-        for address_type in [0, 1]:
+        for address_type in [BaseWallet.ADDRESS_TYPE_EXTERNAL,
+                             BaseWallet.ADDRESS_TYPE_INTERNAL]:
             entrylist = []
-            if address_type == 0:
+            if address_type == BaseWallet.ADDRESS_TYPE_EXTERNAL:
                 # users would only want to hand out the xpub for externals
                 xpub_key = wallet_service.get_bip32_pub_export(m, address_type)
             else:

--- a/jmclient/test/commontest.py
+++ b/jmclient/test/commontest.py
@@ -10,7 +10,7 @@ from jmbase import (get_log, hextobin, bintohex, dictchanger)
 
 from jmclient import (
     jm_single, open_test_wallet_maybe, estimate_tx_fee,
-    BlockchainInterface, BIP32Wallet,
+    BlockchainInterface, BIP32Wallet, BaseWallet,
     SegwitWallet, WalletService, BTC_P2SH_P2WPKH)
 from jmbase.support import chunks
 import jmbitcoin as btc
@@ -146,8 +146,8 @@ def make_sign_and_push(ins_full,
     total = sum(x['value'] for x in ins_full.values())
     ins = list(ins_full.keys())
     #random output address and change addr
-    output_addr = wallet_service.get_new_addr(1, 1) if not output_addr else output_addr
-    change_addr = wallet_service.get_new_addr(0, 1) if not change_addr else change_addr
+    output_addr = wallet_service.get_new_addr(1, BaseWallet.ADDRESS_TYPE_INTERNAL) if not output_addr else output_addr
+    change_addr = wallet_service.get_new_addr(0, BaseWallet.ADDRESS_TYPE_INTERNAL) if not change_addr else change_addr
     fee_est = estimate_tx_fee(len(ins), 2) if estimate_fee else 10000
     outs = [{'value': amount,
              'address': output_addr}, {'value': total - amount - fee_est,
@@ -179,7 +179,7 @@ def make_wallets(n,
                  fixed_seeds=None,
                  wallet_cls=SegwitWallet,
                  mixdepths=5,
-                 populate_internal=False):
+                 populate_internal=BaseWallet.ADDRESS_TYPE_EXTERNAL):
     '''n: number of wallets to be created
        wallet_structure: array of n arrays , each subarray
        specifying the number of addresses to be populated with coins

--- a/jmclient/test/test_core_nohistory_sync.py
+++ b/jmclient/test/test_core_nohistory_sync.py
@@ -8,7 +8,7 @@ from commontest import create_wallet_for_sync
 import pytest
 from jmbase import get_log
 from jmclient import (load_test_config, SegwitLegacyWallet,
-                      SegwitWallet, jm_single)
+                      SegwitWallet, jm_single, BaseWallet)
 from jmbitcoin import select_chain_params
 
 log = get_log()
@@ -19,10 +19,11 @@ def test_fast_sync_unavailable(setup_sync):
     with pytest.raises(RuntimeError) as e_info:
         wallet_service.sync_wallet(fast=True)
 
-@pytest.mark.parametrize('internal, wallet_cls', [(False, SegwitLegacyWallet),
-                                                  (True, SegwitLegacyWallet),
-                                                  (False, SegwitWallet),
-                                                  (True, SegwitWallet)])
+@pytest.mark.parametrize('internal, wallet_cls',
+    [(BaseWallet.ADDRESS_TYPE_EXTERNAL, SegwitLegacyWallet),
+    (BaseWallet.ADDRESS_TYPE_INTERNAL, SegwitLegacyWallet),
+    (BaseWallet.ADDRESS_TYPE_EXTERNAL, SegwitWallet),
+    (BaseWallet.ADDRESS_TYPE_INTERNAL, SegwitWallet)])
 def test_sync(setup_sync, internal, wallet_cls):
     used_count = [1, 3, 6, 2, 23]
     wallet_service = create_wallet_for_sync(used_count, ['test_sync'],

--- a/jmclient/test/test_snicker.py
+++ b/jmclient/test/test_snicker.py
@@ -9,7 +9,7 @@ from commontest import make_wallets, dummy_accept_callback, dummy_info_callback
 import jmbitcoin as btc
 from jmbase import get_log, bintohex
 from jmclient import (load_test_config, estimate_tx_fee, SNICKERReceiver,
-                      direct_send, SegwitLegacyWallet)
+                      direct_send, SegwitLegacyWallet, BaseWallet)
 
 TEST_PROPOSALS_FILE = "test_proposals.txt"
 log = get_log()
@@ -41,7 +41,7 @@ def test_snicker_e2e(setup_snicker, nw, wallet_structures,
     wallet_r = wallets[0]['wallet']
     wallet_p = wallets[1]['wallet']
     # next, create a tx from the receiver wallet
-    our_destn_script = wallet_r.get_new_script(1, 1)
+    our_destn_script = wallet_r.get_new_script(1, BaseWallet.ADDRESS_TYPE_INTERNAL)
     tx = direct_send(wallet_r, btc.coins_to_satoshi(0.3), 0,
                      wallet_r.script_to_addr(our_destn_script),
                      accept_callback=dummy_accept_callback,
@@ -83,7 +83,7 @@ def test_snicker_e2e(setup_snicker, nw, wallet_structures,
     our_input_utxo = btc.CMutableTxOut(prop_utxo['value'],
                                        prop_utxo['script'])
     fee_est = estimate_tx_fee(len(tx.vin), 2)
-    change_spk = wallet_p.get_new_script(0, 1)
+    change_spk = wallet_p.get_new_script(0, BaseWallet.ADDRESS_TYPE_INTERNAL)
 
     encrypted_proposals = []
 

--- a/scripts/convert_old_wallet.py
+++ b/scripts/convert_old_wallet.py
@@ -7,7 +7,7 @@ from binascii import hexlify, unhexlify
 from collections import defaultdict
 from pyaes import AESModeOfOperationCBC, Decrypter
 from jmbase import JM_APP_NAME
-from jmclient import Storage, load_program_config, BTCEngine
+from jmclient import Storage, load_program_config, BTCEngine, BaseWallet
 from jmclient.wallet_utils import get_password, get_wallet_cls,\
     cli_get_wallet_passphrase_check, get_wallet_path
 
@@ -91,8 +91,10 @@ def new_wallet_from_data(data, file_name):
 
     if 'index_cache' in data:
         for md, indices in enumerate(data['index_cache']):
-            wallet.set_next_index(md, 0, indices[0], force=True)
-            wallet.set_next_index(md, 1, indices[1], force=True)
+            wallet.set_next_index(md, BaseWallet.ADDRESS_TYPE_EXTERNAL,
+                                  indices[0], force=True)
+            wallet.set_next_index(md, BaseWallet.ADDRESS_TYPE_INTERNAL,
+                                  indices[1], force=True)
 
     if 'imported' in data:
         for md in data['imported']:

--- a/test/common.py
+++ b/test/common.py
@@ -12,7 +12,7 @@ sys.path.insert(0, os.path.join(data_dir))
 
 from jmbase import get_log
 from jmclient import open_test_wallet_maybe, BIP32Wallet, SegwitWallet, \
-    estimate_tx_fee, jm_single, WalletService
+    estimate_tx_fee, jm_single, WalletService, BaseWallet
 import jmbitcoin as btc
 from jmbase import chunks
 
@@ -32,8 +32,8 @@ def make_sign_and_push(ins_full,
     total = sum(x['value'] for x in ins_full.values())
     ins = ins_full.keys()
     #random output address and change addr
-    output_addr = wallet_service.get_new_addr(1, 1) if not output_addr else output_addr
-    change_addr = wallet_service.get_new_addr(0, 1) if not change_addr else change_addr
+    output_addr = wallet_service.get_new_addr(1, BaseWallet.ADDRESS_TYPE_INTERNAL) if not output_addr else output_addr
+    change_addr = wallet_service.get_new_addr(0, BaseWallet.ADDRESS_TYPE_INTERNAL) if not change_addr else change_addr
     fee_est = estimate_tx_fee(len(ins), 2) if estimate_fee else 10000
     outs = [{'value': amount,
              'address': output_addr}, {'value': total - amount - fee_est,
@@ -106,7 +106,8 @@ def make_wallets(n,
                 amt = mean_amt - sdev_amt / 2.0 + deviation
                 if amt < 0: amt = 0.001
                 amt = float(Decimal(amt).quantize(Decimal(10)**-8))
-                jm_single().bc_interface.grab_coins(wallet_service.get_new_addr(j, 1), amt)
+                jm_single().bc_interface.grab_coins(wallet_service.get_new_addr(
+                    j, BaseWallet.ADDRESS_TYPE_INTERNAL), amt)
     return wallets
 
 

--- a/test/test_segwit.py
+++ b/test/test_segwit.py
@@ -7,7 +7,7 @@ from pprint import pformat
 import jmbitcoin as btc
 import pytest
 from jmbase import get_log, hextobin
-from jmclient import load_test_config, jm_single, LegacyWallet
+from jmclient import load_test_config, jm_single, LegacyWallet, BaseWallet
 log = get_log()
 
 
@@ -90,8 +90,10 @@ def test_spend_p2sh_p2wpkh_multi(setup_segwit, wallet_structure, in_amt, amount,
     FEE = 50000
     assert FEE < total_amt_in_sat - amount, "test broken, not enough funds"
 
-    cj_script = nsw_wallet_service.get_new_script(MIXDEPTH + 1, True)
-    change_script = nsw_wallet_service.get_new_script(MIXDEPTH, True)
+    cj_script = nsw_wallet_service.get_new_script(MIXDEPTH + 1,
+                                BaseWallet.ADDRESS_TYPE_INTERNAL)
+    change_script = nsw_wallet_service.get_new_script(MIXDEPTH,
+                                BaseWallet.ADDRESS_TYPE_INTERNAL)
     change_amt = total_amt_in_sat - amount - FEE
 
     tx_outs = [


### PR DESCRIPTION
Prior to this commit, several test functions were using
"True" to flag internal and "False" to flag external for
the HD branch for the wallet, but we now use 1/0, this
is changed. The tests passed both before and after this
change.