### PR TITLE
Fix tests for Bitcoin Core v0.21+

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -120,11 +120,16 @@ def setup(request):
     root_cmd = [bitcoin_path + "bitcoin-cli", "-regtest",
                        "-rpcuser=" + bitcoin_rpcusername,
                        "-rpcpassword=" + bitcoin_rpcpassword]
+    # Bitcoin Core v0.21+ does not create default wallet
+    local_command(root_cmd + ["createwallet", "jm-test-wallet"])
+    local_command(root_cmd + ["loadwallet", "jm-test-wallet"])
     for i in range(2):
-        cpe = local_command(root_cmd + ["getnewaddress"])
+        cpe = local_command(root_cmd + ["-rpcwallet=jm-test-wallet"] +
+            ["getnewaddress"])
         if cpe.returncode == 0:
             destn_addr = cpe.stdout[:-1].decode('utf-8')
-            local_command(root_cmd + ["generatetoaddress", "301", destn_addr])
+            local_command(root_cmd + ["-rpcwallet=jm-test-wallet"] +
+                ["generatetoaddress", "301", destn_addr])
         else:
             pytest.exit("Cannot setup tests, bitcoin-cli failing.\n" +
                 str(cpe.stdout))

--- a/test/regtest_joinmarket.cfg
+++ b/test/regtest_joinmarket.cfg
@@ -13,6 +13,7 @@ rpc_port = 18443
 rpc_user = bitcoinrpc
 rpc_password = 123456abcdef
 network = testnet
+rpc_wallet_file = jm-test-wallet
 
 [MESSAGING:server1]
 host = localhost


### PR DESCRIPTION
Bitcoin Core v0.21+ doesn't create default wallet.