### PR TITLE
Wait for bitcoind to start instead of hardcoded sleep in tests.

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -115,13 +115,12 @@ def setup(request):
     bitcoin_args = ["-regtest", "-daemon", "-conf=" + bitcoin_conf]
 
     btc_proc = subprocess.call([bitcoin_path + "bitcoind"] + bitcoin_args)
-    time.sleep(4)
-    #generate blocks; segwit activates around block 500-600
     root_cmd = [bitcoin_path + "bitcoin-cli", "-regtest",
                        "-rpcuser=" + bitcoin_rpcusername,
                        "-rpcpassword=" + bitcoin_rpcpassword]
     # Bitcoin Core v0.21+ does not create default wallet
-    local_command(root_cmd + ["createwallet", "jm-test-wallet"])
+    local_command(root_cmd + ["-rpcwait"] +
+        ["createwallet", "jm-test-wallet"])
     local_command(root_cmd + ["loadwallet", "jm-test-wallet"])
     for i in range(2):
         cpe = local_command(root_cmd + ["-rpcwallet=jm-test-wallet"] +


### PR DESCRIPTION
`sleep(4)` is often not enough on slower machines.