### PR TITLE
Pin cryptography module to v3.3.2

### DIFF
--- a/jmdaemon/setup.py
+++ b/jmdaemon/setup.py
@@ -9,6 +9,6 @@ setup(name='joinmarketdaemon',
       author_email='',
       license='GPL',
       packages=['jmdaemon'],
-      install_requires=['txtorcon', 'pyopenssl', 'libnacl', 'joinmarketbase==0.8.2dev'],
+      install_requires=['txtorcon', 'cryptography==3.3.2', 'pyopenssl', 'libnacl', 'joinmarketbase==0.8.2dev'],
       python_requires='>=3.6',
       zip_safe=False)


### PR DESCRIPTION
Newer versions instroduces Rust as a dependency, which causes problems for some people / platforms - https://github.com/pyca/cryptography/issues/5771 .