### PR TITLE
Bugfix: correct check of receiver inputs in BIP78

### DIFF
--- a/jmclient/jmclient/payjoin.py
+++ b/jmclient/jmclient/payjoin.py
@@ -295,8 +295,10 @@ class JMPayjoinManager(object):
             for j, inp2 in enumerate(ourins):
                 if (inp.prevout.hash, inp.prevout.n) == inp2:
                     found[j] += 1
-                else:
-                    receiver_input_indices.append(i)
+                    break
+            else:
+                receiver_input_indices.append(i)
+        assert len(receiver_input_indices) + len(ourins) == len(in_psbt.unsigned_tx.vin)
 
         if any([f != 1 for f in found]):
             return (False, "Receiver proposed PSBT does not contain our inputs.")


### PR DESCRIPTION
Before this commit, the check of receiver inputs in the
proposed PSBT from the receiver was erroneously failing,
if the number of sender inputs was greater than 1, because
the list of receiver input indices was not populated correctly
before the check. This commit fixes this bug.