### PR TITLE
Fix unused key-type param for importprivkey

### DIFF
--- a/jmclient/jmclient/wallet.py
+++ b/jmclient/jmclient/wallet.py
@@ -1612,20 +1612,18 @@ class ImportWalletMixin(object):
         if write:
             storage.save()
 
-    def import_private_key(self, mixdepth, wif):
+    def import_private_key(self, mixdepth, wif, key_type=None):
         """
         Import a private key in WIF format.
 
         args:
             mixdepth: int, mixdepth to import key into
             wif: str, private key in WIF format
-            key_type: int, must match a TYPE_* constant of this module,
-                used to verify against the key type extracted from WIF
+            key_type: int, must match a TYPE_* constant of this module
 
         raises:
             WalletError: if key's network does not match wallet network
             WalletError: if key is not compressed and type is not P2PKH
-            WalletError: if key_type does not match data from WIF
 
         returns:
             path of imported key
@@ -1641,7 +1639,8 @@ class ImportWalletMixin(object):
         #    raise WalletError("Expected key type does not match WIF type.")
 
         # default to wallet key type
-        key_type = self.TYPE
+        if key_type is None:
+            key_type = self.TYPE
         engine = self._ENGINES[key_type]
 
         if engine.key_to_script(privkey) in self._script_map:

--- a/jmclient/jmclient/wallet_utils.py
+++ b/jmclient/jmclient/wallet_utils.py
@@ -97,15 +97,14 @@ The method is one of the following:
                       help='hd wallet path (e.g. m/0/0/0/000)')
     parser.add_option('--key-type',  # note: keep in sync with map_key_type
                       type='choice',
-                      choices=('standard', 'segwit-p2sh'),
+                      choices=('standard', 'segwit-p2sh', 'segwit'),
                       action='store',
                       dest='key_type',
                       default=None,
                       help=("Key type when importing private keys.\n"
                             "If your address starts with '1' use 'standard', "
-                            "if your address starts with '3' use 'segwit-p2sh'.\n"
-                            "Native segwit addresses (starting with 'bc') are "
-                            "not yet supported."))
+                            "If your address starts with '3' use 'segwit-p2sh'.\n"
+                            "If your address starts with 'bc' use 'segwit'."))
 
     return parser
 
@@ -117,6 +116,8 @@ def map_key_type(parser_key_choice):
         return TYPE_P2PKH
     if parser_key_choice == 'segwit-p2sh':
         return TYPE_P2SH_P2WPKH
+    if parser_key_choice == 'segwit':
+        return TYPE_P2WPKH
     raise Exception("Unknown key type choice '{}'.".format(parser_key_choice))
 
 
@@ -1006,7 +1007,7 @@ def wallet_importprivkey(wallet, mixdepth, key_type):
     jmprint("WARNING: This imported key will not be recoverable with your 12 "
           "word mnemonic phrase. Make sure you have backups.", "warning")
     jmprint("WARNING: Make sure that the type of the public address previously "
-          "derived from this private key matches the wallet type you are "
+          "derived from this private key matches the wallet or key type you are "
           "currently using.", "warning")
     jmprint("WARNING: Handling of raw ECDSA bitcoin private keys can lead to "
           "non-intuitive behaviour and loss of funds.\n  Recommended instead "
@@ -1020,7 +1021,7 @@ def wallet_importprivkey(wallet, mixdepth, key_type):
         # TODO is there any point in only accepting wif format? check what
         # other wallets do
         try:
-            path = wallet.import_private_key(mixdepth, wif)
+            path = wallet.import_private_key(mixdepth, wif, key_type)
         except WalletError as e:
             print("Failed to import key {}: {}".format(wif, e))
             import_failed += 1


### PR DESCRIPTION
This enables the previously ignored `key-type` parameter on the `imprortprivkey` wallet command. Prior to this change, `key-type` was simply ignored and the wallet would attempt to import the private key using whatever key type the wallet was using (either native segwit or wrapped segwit-p2sh). Now, the user can specify the format for the imported private key, and an address/key can be imported into a wallet using a different key type.

I've tested this by importing a p2sh segwit address (starting with 3) into a native segwit wallet (starting with bc1). I was able to import the address without an issue, the balance showed up in my wallet summary and I was able to use the imported key.