### PR TITLE
Check for file existence before trying sha256_verify

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -144,7 +144,7 @@ dep_get ()
     pkg_name="$1" pkg_hash="$2" pkg_url="$3"
 
     pushd cache
-    if ! sha256_verify "${pkg_hash}" "${pkg_name}"; then
+    if [ ! -f "${pkg_name}" ] || ! sha256_verify "${pkg_hash}" "${pkg_name}"; then
         http_get "${pkg_url}/${pkg_name}" "${pkg_name}"
     fi
     if ! sha256_verify "${pkg_hash}" "${pkg_name}"; then

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -46,7 +46,7 @@ run_jm_tests ()
     export C_INCLUDE_PATH="${C_INCLUDE_PATH}:${VIRTUAL_ENV}/include"
 
     pushd "${jm_source}"
-    if ! sha256_verify 'ce3a4ddc777343645ccd06ca36233b5777e218ee89d887ef529ece86a917fc33' 'miniircd.tar.gz'; then
+    if [ ! -f 'miniircd.tar.gz' ] || ! sha256_verify 'ce3a4ddc777343645ccd06ca36233b5777e218ee89d887ef529ece86a917fc33' 'miniircd.tar.gz'; then
         http_get "https://github.com/JoinMarket-Org/miniircd/archive/master.tar.gz" "miniircd.tar.gz"
     fi
     if [[ ! -x ${jm_source}/miniircd/miniircd ]]; then


### PR DESCRIPTION
Gets rid of unnecessary errors in output when doing initial install without cached dependency downloads.
```
sha256sum: 0d9540b13ffcd7cd44cc361b8744b93d88aa76ba.tar.gz: No such file or directory
0d9540b13ffcd7cd44cc361b8744b93d88aa76ba.tar.gz: FAILED open or read
sha256sum: WARNING: 1 listed file could not be read
```