### PR TITLE
Payjoin receiver via daemon.

### DIFF
--- a/jmbase/jmbase/__init__.py
+++ b/jmbase/jmbase/__init__.py
@@ -7,9 +7,12 @@ from .support import (get_log, chunks, debug_silence, jmprint,
                       utxo_to_utxostr, EXIT_ARGERROR, EXIT_FAILURE,
                       EXIT_SUCCESS, hexbin, dictchanger, listchanger,
                       JM_WALLET_NAME_PREFIX, JM_APP_NAME,
-                      IndentedHelpFormatterWithNL, wrapped_urlparse)
+                      IndentedHelpFormatterWithNL, wrapped_urlparse,
+                      bdict_sdict_convert)
 from .proof_of_work import get_pow, verify_pow
-from .twisted_utils import stop_reactor, is_hs_uri, get_tor_agent, get_nontor_agent
+from .twisted_utils import (stop_reactor, is_hs_uri, get_tor_agent,
+                            get_nontor_agent, JMHiddenService,
+                            JMHTTPResource)
 from .bytesprod import BytesProducer
 from .commands import *
 

--- a/jmbase/jmbase/commands.py
+++ b/jmbase/jmbase/commands.py
@@ -284,6 +284,10 @@ class SNICKERReceivePowTarget(JMCommand):
 
 """ Payjoin-related commands
 """
+
+""" Sender-specific commands.
+"""
+
 class BIP78SenderInit(JMCommand):
     """ Initialization data for a BIP78 service.
     See documentation of `netconfig` in
@@ -309,10 +313,67 @@ class BIP78SenderReceiveProposal(JMCommand):
     """
     arguments = [(b'psbt', BigUnicode())]
 
-class BIP78ReceiverError(JMCommand):
+class BIP78SenderReceiveError(JMCommand):
     """ Sends a message from daemon to client
     indicating that the BIP78 receiver did not
     accept the request, or there was a network error.
     """
     arguments = [(b'errormsg', Unicode()),
                  (b'errorcode', Integer())]
+
+""" Receiver-specific commands
+"""
+
+class BIP78ReceiverInit(JMCommand):
+    """ Initialization data for a BIP78 hidden service.
+    """
+    arguments = [(b'netconfig', Unicode())]
+
+class BIP78ReceiverUp(JMCommand):
+    """ Returns onion hostname to client when
+    the hidden service has been brought up, indicating
+    readiness.
+    """
+    arguments = [(b'hostname', Unicode())]
+
+class BIP78ReceiverOriginalPSBT(JMCommand):
+    """ Sends the sender's original
+    payment PSBT, base64 encoded, and the request
+    parameters in the url, from the daemon to the client.
+    """
+    arguments = [(b'body', BigUnicode()),
+                 (b'params', Unicode())]
+
+class BIP78ReceiverSendProposal(JMCommand):
+    """ Receives a payjoin proposal PSBT from
+    the client, sent to the daemon.
+    """
+    arguments = [(b'psbt', BigUnicode())]
+
+class BIP78ReceiverSendError(JMCommand):
+    """ Sends a message from client to daemon
+    indicating that the BIP78 receiver did not
+    accept the request, to be forwarded to the sender.
+    """
+    arguments = [(b'errormsg', Unicode()),
+                 (b'errorcode', Unicode())]
+
+class BIP78ReceiverHiddenServiceShutdown(JMCommand):
+    """ Sends a message from the daemon to the
+    client when the hidden service has shut down.
+    """
+    arguments = []
+
+class BIP78ReceiverOnionSetupFailed(JMCommand):
+    """ Sends a message from the daemon to the
+    client when the hidden service setup failed
+    for the given reason.
+    """
+    arguments = [(b'reason', Unicode())]
+
+class BIP78InfoMsg(JMCommand):
+    """ Sends an info message to the client
+    from the daemon about current status at
+    network level.
+    """
+    arguments = [(b'infomsg', Unicode())]

--- a/jmbase/jmbase/support.py
+++ b/jmbase/jmbase/support.py
@@ -306,3 +306,21 @@ def wrapped_urlparse(url):
     if url.endswith(a) and not url.startswith(b):
         url = b + url
     return urlparse.urlparse(url)
+
+def bdict_sdict_convert(d, output_binary=False):
+    """ Useful for converting dicts from url parameter sets
+    to a form that can be handled by json dumps/loads.
+    This code only works if *all* keys in the dict
+    are binary strings, and all values are lists of same.
+    This code could be extended if needed.
+    If output_binary is True, the reverse operation is performed.
+    """
+    newd = {}
+    for k, v in d.items():
+        if output_binary:
+            newv = [a.encode("utf-8") for a in v]
+            newd[k.encode("utf-8")] = newv
+        else:
+            newv = [a.decode("utf-8") for a in v]
+            newd[k.decode("utf-8")] = newv
+    return newd

--- a/jmbase/jmbase/twisted_utils.py
+++ b/jmbase/jmbase/twisted_utils.py
@@ -4,7 +4,10 @@ from twisted.internet.error import ReactorNotRunning
 from twisted.internet import reactor
 from twisted.internet.endpoints import TCP4ClientEndpoint
 from twisted.web.client import Agent, BrowserLikePolicyForHTTPS
+import txtorcon
 from txtorcon.web import tor_agent
+from twisted.web.server import Site
+from twisted.web.resource import Resource
 from twisted.web.iweb import IPolicyForHTTPS
 from twisted.internet.ssl import CertificateOptions
 from .support import wrapped_urlparse
@@ -74,3 +77,94 @@ def get_nontor_agent(tls_whitelist=[]):
         agent = Agent(reactor,
                 contextFactory=WhitelistContextFactory(tls_whitelist))
     return agent
+
+class JMHiddenService(object):
+    """ Wrapper class around the actions needed to
+    create and serve on a hidden service; an object of
+    type Resource must be provided in the constructor,
+    which does the HTTP serving actions (GET, POST serving).
+    """
+    def __init__(self, resource, info_callback, error_callback,
+                 onion_hostname_callback, tor_control_host,
+                 tor_control_port, serving_port = None,
+                 shutdown_callback = None):
+        self.site = Site(resource)
+        self.site.displayTracebacks = False
+        self.info_callback = info_callback
+        self.error_callback = error_callback
+        # this has a separate callback for convenience, it should
+        # be passed the literal *.onion string (port is already
+        # known and is 80 by default)
+        self.onion_hostname_callback = onion_hostname_callback
+        self.shutdown_callback = shutdown_callback
+        if not serving_port:
+            self.port = 80
+        else:
+            self.port = serving_port
+        self.tor_control_host = tor_control_host
+        self.tor_control_port = tor_control_port
+        print("got these settings: ", self.port, self.site, self.tor_control_host, self.tor_control_port)
+
+    def start_tor(self):
+        """ This function executes the workflow
+        of starting the hidden service and returning its hostname
+        """
+        self.info_callback("Attempting to start onion service on port: {} "
+                           "...".format(self.port))
+        if str(self.tor_control_host).startswith('unix:'):
+            control_endpoint = UNIXClientEndpoint(reactor,
+                                    self.tor_control_host[5:])
+        else:
+            control_endpoint = TCP4ClientEndpoint(reactor,
+                            self.tor_control_host,self.tor_control_port)
+        d = txtorcon.connect(reactor, control_endpoint)
+        d.addCallback(self.create_onion_ep)
+        d.addErrback(self.setup_failed)
+        # TODO: add errbacks to the next two calls in
+        # the chain:
+        d.addCallback(self.onion_listen)
+        d.addCallback(self.print_host)
+
+    def setup_failed(self, arg):
+        # Note that actions based on this failure are deferred to callers:
+        self.error_callback("Setup failed: " + str(arg))
+
+    def create_onion_ep(self, t):
+        self.tor_connection = t
+        return t.create_onion_endpoint(self.port)
+
+    def onion_listen(self, onion_ep):
+        return onion_ep.listen(self.site)
+
+    def print_host(self, ep):
+        """ Callback fired once the HS is available;
+        we let the caller know the hidden service onion hostname,
+        which is not otherwise available to them:
+        """
+        # Note that ep,getHost().onion_port must return the same
+        # port as we chose in self.port; if not there is an error.
+        assert ep.getHost().onion_port == self.port
+        self.onion_hostname_callback(ep.getHost().onion_uri)
+
+    def shutdown(self):
+        self.tor_connection.protocol.transport.loseConnection()
+        self.info_callback("Hidden service shutdown complete")
+        if self.shutdown_callback:
+            self.shutdown_callback()
+
+class JMHTTPResource(Resource):
+    """ Object acting as HTTP serving resource
+    """
+    def __init__(self, info_callback, shutdown_callback):
+        self.info_callback = info_callback
+        self.shutdown_callback = shutdown_callback
+        super().__init__()
+
+    isLeaf = True
+
+    def render_GET(self, request):
+        """ by default we serve a simple string which can be used e.g.
+        to check if an ephemeral HS is upon Tor Browser; child classes
+        may override.
+        """
+        return "<html>Only for testing.</html>".encode("utf-8")

--- a/jmclient/jmclient/__init__.py
+++ b/jmclient/jmclient/__init__.py
@@ -57,7 +57,7 @@ from .wallet_utils import (
 from .wallet_service import WalletService
 from .maker import Maker
 from .yieldgenerator import YieldGenerator, YieldGeneratorBasic, ygmain
-from .payjoin import (parse_payjoin_setup, send_payjoin, PayjoinServer,
+from .payjoin import (parse_payjoin_setup, send_payjoin,
                       JMBIP78ReceiverManager)
 # Set default logging handler to avoid "No handler found" warnings.
 

--- a/jmdaemon/jmdaemon/daemon_protocol.py
+++ b/jmdaemon/jmdaemon/daemon_protocol.py
@@ -9,17 +9,19 @@ from .protocol import (COMMAND_PREFIX, ORDER_KEYS, NICK_HASH_LENGTH,
                        COMMITMENT_PREFIXES)
 from .irc import IRCMessageChannel
 
-from jmbase import (hextobin, is_hs_uri, get_tor_agent,
-                    get_nontor_agent, BytesProducer, wrapped_urlparse)
+from jmbase import (hextobin, is_hs_uri, get_tor_agent, JMHiddenService,
+                    get_nontor_agent, BytesProducer, wrapped_urlparse,
+                    bintohex, bdict_sdict_convert, JMHTTPResource)
 from jmbase.commands import *
 from twisted.protocols import amp
-from twisted.internet import reactor, ssl
+from twisted.internet import reactor, ssl, task
 from twisted.internet.protocol import ServerFactory
 from twisted.internet.error import (ConnectionLost, ConnectionAborted,
                                     ConnectionClosed, ConnectionDone,
                                     ConnectionRefusedError)
 from twisted.web.http_headers import Headers
 from twisted.web.client import ResponseFailed, readBody
+from twisted.web import server
 from txtorcon.socks import HostUnreachableError
 from twisted.python import log
 import urllib.parse as urlparse
@@ -27,6 +29,7 @@ from urllib.parse import urlencode
 import json
 import threading
 import os
+from io import BytesIO
 import copy
 from functools import wraps
 from numbers import Integral
@@ -93,6 +96,67 @@ def check_utxo_blacklist(commitment, persist=False):
 
 class JMProtocolError(Exception):
     pass
+
+class BIP78ReceiverResource(JMHTTPResource):
+
+    def __init__(self, info_callback, shutdown_callback, post_request_handler):
+        """ The POST request handling callback has function signature:
+	args: (request-body-content-in-bytes,)
+	returns: (errormsg, errcode, httpcode, response-in-bytes)
+	If the request was successful, errormsg should be true and response
+	should be in bytes, to be sent in the return value of render_POST().
+	"""
+        self.post_request_handler = post_request_handler
+        super().__init__(info_callback, shutdown_callback)
+
+    def bip78_error(self, request, error_meaning,
+                    error_code="unavailable", http_code=400):
+        """
+        See https://github.com/bitcoin/bips/blob/master/bip-0078.mediawiki#receivers-well-known-errors
+
+        We return, to the sender, stringified json in the body as per the above.
+        """
+        request.setResponseCode(http_code)
+        request.setHeader(b"content-type", b"text/html; charset=utf-8")
+        print("Returning an error: " + str(
+            error_code) + ": " + str(error_meaning))
+        if error_code in ["original-psbt-rejected", "version-unsupported"]:
+            # if there is a negotiation failure in the first step, we cannot
+            # know whether the sender client sent a valid non-payjoin or not,
+            # hence the warning below is somewhat ambiguous:
+            print("Negotiation failure. Payment has not yet been made,"
+                     " check wallet.")
+            # shutdown now but wait until response is sent.
+            task.deferLater(reactor, 2.0, self.end_failure)
+        return json.dumps({"errorCode": error_code,
+                           "message": error_meaning}).encode("utf-8")
+
+    def render_POST(self, request):
+        """ The sender will use POST to send the initial
+        payment transaction.
+        """
+        print("The server got this POST request: ")
+        # unfortunately the twisted Request object is not
+        # easily serialized:
+        print(request)
+        print(request.method)
+        print(request.uri)
+        print(request.args)
+        sender_parameters = request.args
+        print(request.path)
+        # defer logging of raw request content:
+        proposed_tx = request.content
+        if not isinstance(proposed_tx, BytesIO):
+            return self.bip78_error(request, "invalid psbt format",
+                                    "original-psbt-rejected")
+        payment_psbt_base64 = proposed_tx.read().decode("utf-8")
+        reactor.callLater(0.0, self.post_request_handler, request,
+                      payment_psbt_base64, sender_parameters)
+        return server.NOT_DONE_YET
+
+    def end_failure(self):
+        self.info_callback("Shutting down, payjoin negotiation failed.")
+        self.shutdown_callback()
 
 class HTTPPassThrough(amp.AMP):
     """ This class supports passing through
@@ -183,7 +247,7 @@ class HTTPPassThrough(amp.AMP):
             failure.trap(ResponseFailed, ConnectionRefusedError,
                          HostUnreachableError, ConnectionLost)
             log.msg(failure.value)
-            self.callRemote(BIP78ReceiverError,
+            self.callRemote(BIP78SenderReceiveError,
                             errormsg="failure to connect",
                             errorcode=10000)
         d.addErrback(noResponse)
@@ -206,6 +270,80 @@ class HTTPPassThrough(amp.AMP):
         d.addErrback(self.defaultErrback)
 
 class BIP78ServerProtocol(HTTPPassThrough):
+    @BIP78ReceiverInit.responder
+    def on_BIP78_RECEIVER_INIT(self, netconfig):
+        netconfig = json.loads(netconfig)
+        self.serving_port = int(netconfig["port"])
+        self.tor_control_host = netconfig["tor_control_host"]
+        self.tor_control_port = int(netconfig["tor_control_port"])
+        self.bip78_rr = BIP78ReceiverResource(self.info_callback,
+                                              self.shutdown_callback,
+                                              self.post_request_handler)
+        self.hs = JMHiddenService(self.bip78_rr,
+                                  self.info_callback,
+                                  self.setup_error_callback,
+                                  self.onion_hostname_callback,
+                                  self.tor_control_host,
+                                  self.tor_control_port,
+                                  self.serving_port,
+                                  self.shutdown_callback)
+        # this call will start bringing up the HS; when it's finished,
+        # it will fire the `onion_hostname_callback`, or if it fails,
+        # it'll fire the `setup_error_callback`.
+        self.hs.start_tor()
+        return {"accepted": True}
+
+    def setup_error_callback(self, errormsg):
+        d = self.callRemote(BIP78ReceiverOnionSetupFailed,
+                            reason=errormsg)
+        self.defaultCallbacks(d)
+
+    def shutdown_callback(self):
+        d = self.callRemote(BIP78ReceiverHiddenServiceShutdown)
+        self.defaultCallbacks(d)
+
+    def info_callback(self, msg):
+        """ Informational messages are all passed
+	to the client. TODO makes sense to log locally
+	too, in case daemon is isolated?.
+	"""
+        d = self.callRemote(BIP78InfoMsg, infomsg=msg)
+        self.defaultCallbacks(d)
+
+    def onion_hostname_callback(self, hostname):
+        """ On successful start of HS, we pass hostname
+	to client, who can use this to build the full URI.
+	"""
+        d = self.callRemote(BIP78ReceiverUp,
+                            hostname=hostname)
+        self.defaultCallbacks(d)
+
+    def post_request_handler(self, request, body, params):
+        """ Fired when a sender has sent a POST request
+	to our hidden service. Argument `body` should be a base64
+        string and params should be a dict.
+	"""
+        self.post_request = request
+        d = self.callRemote(BIP78ReceiverOriginalPSBT, body=body,
+                            params=json.dumps(bdict_sdict_convert(params)))
+        self.defaultCallbacks(d)
+
+    @BIP78ReceiverSendProposal.responder
+    def on_BIP78_RECEIVER_SEND_PROPOSAL(self, psbt):
+        content = psbt.encode("utf-8")
+        self.post_request.setHeader(b"content-length",
+                        ("%d" % len(content)))
+        self.post_request.write(content)
+        self.post_request.finish()
+        return {"accepted": True}
+
+    @BIP78ReceiverSendError.responder
+    def on_BIP78_RECEIVER_SEND_ERROR(self, errormsg, errorcode):
+        self.post_request.write(self.bip78_rr.bip78_error(
+            self.post_request, errormsg, errorcode))
+        self.post_request.finish()
+        return {"accepted": True}
+
     @BIP78SenderInit.responder
     def on_BIP78_SENDER_INIT(self, netconfig):
         self.on_INIT(netconfig)
@@ -231,7 +369,7 @@ class BIP78ServerProtocol(HTTPPassThrough):
         d.addCallback(self.process_receiver_psbt)
 
     def process_receiver_errormsg(self, response, errorcode):
-        d = self.callRemote(BIP78ReceiverError,
+        d = self.callRemote(BIP78SenderReceiveError,
                             errormsg=response.decode("utf-8"),
                             errorcode=errorcode)
         self.defaultCallbacks(d)


### PR DESCRIPTION
This completes the task of enabling
network isolation by running the receiver
side using a hidden service in the daemon,
and communicating over AMP, as is already
the case for the sender.