### PR TITLE
add the community Telegram channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,8 @@ Instructions for developers for testing [here](docs/TESTING.md). If you want to 
 
 + Twitter: https://twitter.com/joinmarket
 
++ Telegram: https://t.me/joinmarketorg
+
 ### Support JoinMarket and bitcoin privacy
 
 Donate to help make JoinMarket even better: [Obtain a bitcoin address here](https://bitcoinprivacy.me/joinmarket-donations)


### PR DESCRIPTION
https://t.me/joinmarketorg has 185 members now with good engagement.
Admins include @kristapsk and me 
![image](https://user-images.githubusercontent.com/43343391/111900012-f002b900-8a27-11eb-85bb-e66e09e7e42b.png)

Telegram needs a phone number to register, but connecting through a proxy (including Tor) is well supported in the desktop app:
![image](https://user-images.githubusercontent.com/43343391/111900042-1cb6d080-8a28-11eb-9c5b-247ec65e59c8.png)

As discussed with @chris-belcher on IRC it wouldd make sense to add it to the readme.