### PR TITLE
address complaints of flake8 in jmclient

### DIFF
--- a/jmclient/jmclient/commitment_utils.py
+++ b/jmclient/jmclient/commitment_utils.py
@@ -1,8 +1,7 @@
 
 import sys
-from jmbase import jmprint, utxostr_to_utxo
+from jmbase import jmprint, utxostr_to_utxo, utxo_to_utxostr, EXIT_FAILURE
 from jmclient import jm_single, BTCEngine, BTC_P2PKH, BTC_P2SH_P2WPKH, BTC_P2WPKH
-from jmbase.support import EXIT_FAILURE, utxostr_to_utxo, utxo_to_utxostr
 
 
 def quit(parser, errmsg): #pragma: no cover
@@ -20,7 +19,7 @@ def get_utxo_info(upriv, utxo_binary=False):
         u = u.strip()
         priv = priv.strip()
         success, utxo_bin = utxostr_to_utxo(u)
-        assert success, utxo
+        assert success, u
     except:
         #not sending data to stdout in case privkey info
         jmprint("Failed to parse utxo information for utxo", "error")

--- a/jmclient/jmclient/configure.py
+++ b/jmclient/jmclient/configure.py
@@ -2,7 +2,6 @@
 import io
 import logging
 import os
-import binascii
 import re
 import sys
 
@@ -540,20 +539,6 @@ _BURN_DESTINATION = "BURN"
 
 def is_burn_destination(destination):
     return destination == _BURN_DESTINATION
-
-def donation_address(reusable_donation_pubkey=None): #pragma: no cover
-    #Donation code currently disabled, so not tested.
-    if not reusable_donation_pubkey:
-        reusable_donation_pubkey = ('02be838257fbfddabaea03afbb9f16e852'
-                                    '9dfe2de921260a5c46036d97b5eacf2a')
-    sign_k = binascii.hexlify(os.urandom(32)).decode('ascii')
-    c = btc.sha256(btc.multiply(sign_k, reusable_donation_pubkey, True))
-    sender_pubkey = btc.add_pubkeys(
-        [reusable_donation_pubkey, btc.privtopub(c + '01', True)], True)
-    sender_address = btc.pubtoaddr(sender_pubkey, get_p2pk_vbyte())
-    log.debug('sending coins to ' + sender_address)
-    return sender_address, sign_k
-
 
 def remove_unwanted_default_settings(config):
     for section in config.sections():

--- a/jmclient/jmclient/cryptoengine.py
+++ b/jmclient/jmclient/cryptoengine.py
@@ -4,7 +4,7 @@ import struct
 
 import jmbitcoin as btc
 from jmbase import bintohex
-from .configure import get_network
+from .configure import get_network, jm_single
 
 
 #NOTE: before fidelity bonds and watchonly wallet, each of these types corresponded

--- a/jmclient/jmclient/maker.py
+++ b/jmclient/jmclient/maker.py
@@ -1,18 +1,15 @@
 #! /usr/bin/env python
 import base64
-import pprint
-import random
 import sys
 import abc
 
 import jmbitcoin as btc
-from jmbase import bintohex, hexbin, get_log, EXIT_SUCCESS, EXIT_FAILURE, stop_reactor
-from jmclient.wallet import estimate_tx_fee, compute_tx_locktime
+from jmbase import bintohex, hexbin, get_log, EXIT_FAILURE, stop_reactor
 from jmclient.wallet_service import WalletService
 from jmclient.configure import jm_single
-from jmclient.support import calc_cj_fee, select_one_utxo
+from jmclient.support import calc_cj_fee
 from jmclient.podle import verify_podle, PoDLE, PoDLEError
-from twisted.internet import task, reactor
+from twisted.internet import task
 from .cryptoengine import EngineError
 
 jlog = get_log()

--- a/jmclient/jmclient/payjoin.py
+++ b/jmclient/jmclient/payjoin.py
@@ -1,31 +1,18 @@
-from zope.interface import implementer
 from twisted.internet import reactor, task
-from twisted.web.http import UNAUTHORIZED, BAD_REQUEST, NOT_FOUND
-from twisted.web.client import (Agent, readBody, ResponseFailed,
-                                BrowserLikePolicyForHTTPS)
 from twisted.web.server import Site
-from twisted.web.resource import Resource, ErrorPage
-from twisted.web.iweb import IPolicyForHTTPS
-from twisted.internet.ssl import CertificateOptions
-from twisted.internet.error import ConnectionRefusedError, ConnectionLost
+from twisted.web.resource import Resource
 from twisted.internet.endpoints import TCP4ClientEndpoint, UNIXClientEndpoint
-from twisted.web.http_headers import Headers
 import txtorcon
-from txtorcon.web import tor_agent
-from txtorcon.socks import HostUnreachableError
-import urllib.parse as urlparse
-from urllib.parse import urlencode
 import json
 import random
 from io import BytesIO
-from pprint import pformat
 from jmbase import bintohex, jmprint
 from .configure import get_log, jm_single
 import jmbitcoin as btc
-from .wallet import PSBTWalletMixin, SegwitLegacyWallet, SegwitWallet, estimate_tx_fee
+from .wallet import PSBTWalletMixin, SegwitLegacyWallet, SegwitWallet
 from .wallet_service import WalletService
 from .taker_utils import direct_send
-from jmclient import (RegtestBitcoinCoreInterface, select_one_utxo,
+from jmclient import (select_one_utxo,
                       process_shutdown, BIP78ClientProtocolFactory)
 
 """

--- a/jmclient/jmclient/taker_utils.py
+++ b/jmclient/jmclient/taker_utils.py
@@ -75,7 +75,6 @@ def direct_send(wallet_service, amount, mixdepth, destination, answeryes=False,
                 "small. Tip: use the coin control feature to freeze utxos")
             return
 
-    from pprint import pformat
     txtype = wallet_service.get_txtype()
     if amount == 0:
         utxos = wallet_service.get_utxos_by_mixdepth()[mixdepth]

--- a/jmclient/jmclient/wallet_service.py
+++ b/jmclient/jmclient/wallet_service.py
@@ -2,7 +2,6 @@
 
 import collections
 import time
-import ast
 import sys
 from decimal import Decimal
 from copy import deepcopy
@@ -10,14 +9,14 @@ from twisted.internet import reactor
 from twisted.internet import task
 from twisted.application.service import Service
 from numbers import Integral
+import jmbitcoin as btc
 from jmclient.configure import jm_single, get_log
 from jmclient.output import fmt_tx_data
 from jmclient.blockchaininterface import (INF_HEIGHT, BitcoinCoreInterface,
     BitcoinCoreNoHistoryInterface)
 from jmclient.wallet import FidelityBondMixin, BaseWallet
-from jmbase import stop_reactor
-from jmbase.support import jmprint, EXIT_SUCCESS, utxo_to_utxostr, hextobin
-
+from jmbase import (stop_reactor, hextobin, utxo_to_utxostr,
+                    jmprint, EXIT_SUCCESS)
 
 """Wallet service
 
@@ -636,7 +635,7 @@ class WalletService(Service):
             path = self.wallet.get_path(mixdepth, address_type, index)
             path_privkey, engine = self.wallet._get_key_from_path(path)
             path_pubkey = engine.privkey_to_pubkey(path_privkey)
-            path_pubkeyhash = btc.bin_hash160(path_pubkey)
+            path_pubkeyhash = btc.Hash160(path_pubkey)
             for burner_tx in burner_txes:
                 burner_pubkeyhash, gettx = burner_tx
                 if burner_pubkeyhash != path_pubkeyhash:
@@ -733,7 +732,7 @@ class WalletService(Service):
                     #otherwise there's no merkleproof or block index
                     if gettx["confirmations"] < 1:
                         continue
-                    script = binascii.unhexlify(txd["outs"][0]["script"])
+                    script = hextobin(txd["outs"][0]["script"])
                     if script[0] != 0x6a: #OP_RETURN
                         continue
                     pubkeyhash = script[2:]

--- a/jmclient/jmclient/wallet_utils.py
+++ b/jmclient/jmclient/wallet_utils.py
@@ -493,7 +493,7 @@ def wallet_display(wallet_service, showprivkey, displayall=False,
                     timelock = datetime.utcfromtimestamp(path[-1])
 
                     balance = sum([utxodata["value"] for utxo, utxodata in
-                        iteritems(utxos[m]) if path == utxodata["path"]])
+                        utxos[m].items() if path == utxodata["path"]])
                     status = timelock.strftime("%Y-%m-%d") + " [" + (
                         "LOCKED" if datetime.now() < timelock else "UNLOCKED") + "]"
                     privkey = ""

--- a/jmclient/test/commontest.py
+++ b/jmclient/test/commontest.py
@@ -2,7 +2,6 @@
 '''Some helper functions for testing'''
 
 import os
-import binascii
 import random
 from decimal import Decimal
 
@@ -37,10 +36,6 @@ class DummyBlockchainInterface(BlockchainInterface):
         self.fake_query_results = None
         self.qusfail = False
         self.cbh = 1
-
-    def get_current_block_height(self):
-        self.cbh += 1
-        return self.cbh
 
     def rpc(self, a, b):
         return None

--- a/jmclient/test/test_configure.py
+++ b/jmclient/test/test_configure.py
@@ -1,7 +1,6 @@
 '''test configure module.'''
 
 import pytest
-import struct
 from jmclient import load_test_config, jm_single, get_irc_mchannels
 from jmclient.configure import (get_config_irc_channel,
                                 get_blockchain_interface_instance)

--- a/jmclient/test/test_payjoin.py
+++ b/jmclient/test/test_payjoin.py
@@ -4,8 +4,6 @@ Test doing payjoins over tcp client/server
 """
 
 import os
-import sys
-import pytest
 from twisted.internet import reactor
 from twisted.web.server import Site
 from twisted.web.client import readBody
@@ -17,15 +15,13 @@ from urllib.parse import urlencode
 from jmbase import get_log, jmprint, BytesProducer
 from jmbitcoin import (CCoinAddress, encode_bip21_uri,
                        amount_to_btc, amount_to_sat)
-from jmclient import cryptoengine
 from jmclient import (load_test_config, jm_single,
-                      SegwitLegacyWallet, SegwitWallet,
-                      PayjoinServer, parse_payjoin_setup,
-                      send_payjoin)
+                      SegwitLegacyWallet,
+                      PayjoinServer, parse_payjoin_setup)
 from jmclient.payjoin import make_payjoin_request_params, make_payment_psbt
 from jmclient.payjoin import process_payjoin_proposal_from_server
 from commontest import make_wallets
-from test_coinjoin import make_wallets_to_list, create_orderbook, sync_wallets
+from test_coinjoin import make_wallets_to_list, sync_wallets
 
 testdir = os.path.dirname(os.path.realpath(__file__))
 log = get_log()

--- a/jmclient/test/test_snicker.py
+++ b/jmclient/test/test_snicker.py
@@ -3,13 +3,12 @@
    wallets as defined in jmclient.wallet.'''
 
 import pytest
-import os
 
 from commontest import make_wallets, dummy_accept_callback, dummy_info_callback
 import jmbitcoin as btc
 from jmbase import get_log, bintohex
 from jmclient import (load_test_config, estimate_tx_fee, SNICKERReceiver,
-                      direct_send, SegwitLegacyWallet, BaseWallet)
+                      direct_send, BaseWallet)
 
 log = get_log()
 

--- a/jmclient/test/test_wallet.py
+++ b/jmclient/test/test_wallet.py
@@ -12,7 +12,7 @@ from jmclient import load_test_config, jm_single, BaseWallet, \
     SegwitLegacyWallet,BIP32Wallet, BIP49Wallet, LegacyWallet,\
     VolatileStorage, get_network, cryptoengine, WalletError,\
     SegwitWallet, WalletService, SegwitLegacyWalletFidelityBonds,\
-    BTC_P2PKH, BTC_P2SH_P2WPKH, create_wallet, open_test_wallet_maybe, \
+    create_wallet, open_test_wallet_maybe, \
     FidelityBondMixin, FidelityBondWatchonlyWallet, wallet_gettimelockaddress
 from test_blockchaininterface import sync_test_wallet
 

--- a/jmclient/test/test_walletutils.py
+++ b/jmclient/test/test_walletutils.py
@@ -1,4 +1,4 @@
-import pytest
+
 from jmclient.wallet_utils import bip32pathparse, WalletView, \
     WalletViewAccount, WalletViewBranch, WalletViewEntry
 


### PR DESCRIPTION
First of 4 (probably) PRs to address flake8.

@chris-belcher please take a look at the change in `wallet_service.py` and also (not addressed here but just above that change from `binascii.unhexlify` to `hextobin`) there is an issue with the use of the return value of `BitcoinCoreInterface.get_deser_from_gettransaction` (it's not the same object type as before). I don't know why I didn't pick this up during that huge rebase (apart from the word 'huge', of course) at the time. I think we're going to find a couple more things like this when we go through it.