### PR TITLE
Fix signmessage to be Electrum-compatible

### DIFF
--- a/jmbitcoin/jmbitcoin/__init__.py
+++ b/jmbitcoin/jmbitcoin/__init__.py
@@ -27,10 +27,12 @@ from bitcointx.core import (x, b2x, b2lx, lx, COutPoint, CTxOut, CTxIn,
                             coins_to_satoshi, satoshi_to_coins)
 from bitcointx.core.key import KeyStore
 from bitcointx.wallet import (P2SHCoinAddress, P2SHCoinAddressError,
-                              P2WPKHCoinAddress, P2WPKHCoinAddressError)
+                              P2WPKHCoinAddress, P2WPKHCoinAddressError,
+                              CBitcoinKey)
 from bitcointx.core.script import (CScript, OP_0, SignatureHash, SIGHASH_ALL,
                                    SIGVERSION_WITNESS_V0, CScriptWitness)
 from bitcointx.core.psbt import (PartiallySignedTransaction, PSBT_Input,
                                  PSBT_Output)
+from bitcointx.signmessage import SignMessage
 from .blocks import get_transactions_in_block
 

--- a/jmclient/jmclient/cryptoengine.py
+++ b/jmclient/jmclient/cryptoengine.py
@@ -218,13 +218,19 @@ class BTCEngine(object):
     @staticmethod
     def sign_message(privkey, message):
         """
+        Note: only (currently) used for manual
+        signing of text messages by keys,
+        *not* used in Joinmarket communication protocol.
         args:
             privkey: bytes
             message: bytes
         returns:
             base64-encoded signature
         """
-        return btc.ecdsa_sign(message, privkey, True, False)
+        # note: only supported on mainnet
+        assert get_network() == "mainnet"
+        k = btc.CBitcoinKey(BTCEngine.privkey_to_wif(privkey))
+        return btc.SignMessage(k, btc.BitcoinMessage(message)).decode("ascii")
 
     @classmethod
     def script_to_address(cls, script):

--- a/jmclient/jmclient/wallet_utils.py
+++ b/jmclient/jmclient/wallet_utils.py
@@ -1052,7 +1052,17 @@ def wallet_dumpprivkey(wallet, hdpath):
     return wallet.get_wif_path(path)  # will raise exception on invalid path
 
 
-def wallet_signmessage(wallet, hdpath, message):
+def wallet_signmessage(wallet, hdpath, message, out_str=True):
+    """ Given a wallet, a BIP32 HD path (as can be output
+    from the display method) and a message string, returns
+    a base64 encoded signature along with the corresponding
+    address and message.
+    If `out_str` is True, returns human readable representation,
+    otherwise returns tuple of (signature, message, address).
+    """
+    if not get_network() == "mainnet":
+        return "Error: message signing is only supported on mainnet."
+
     msg = message.encode('utf-8')
 
     if not hdpath:
@@ -1062,8 +1072,12 @@ def wallet_signmessage(wallet, hdpath, message):
 
     path = wallet.path_repr_to_path(hdpath)
     sig = wallet.sign_message(msg, path)
-    retval = "Signature: {}\nTo verify this in Bitcoin Core".format(sig)
-    return retval + " use the RPC command 'verifymessage'"
+    addr = wallet.get_address_from_path(path)
+    if not out_str:
+        return (sig, message, addr)
+    return ("Signature: {}\nMessage: {}\nAddress: {}\n"
+    "To verify this in Electrum use Tools->Sign/verify "
+    "message.".format(sig, message, addr))
 
 def wallet_signpsbt(wallet_service, psbt):
     if not psbt:


### PR DESCRIPTION
Verification of message signatures against segwit addresses
is not currently functional/possible in Core, and additionally
the signing function used for messages in jmbitcoin, derived
from coincurve, was not compatible with Electrum either.
This commit uses the functionality in python-bitcointx's
signmessage module, and now the wallet method `signmessage`
creates signatures on messages against segwit addresses that
are verifiable in Electrum.