### PR TITLE
Don't request privkey for ephemeral onion from Tor

### DIFF
--- a/jmbase/jmbase/twisted_utils.py
+++ b/jmbase/jmbase/twisted_utils.py
@@ -131,7 +131,7 @@ class JMHiddenService(object):
 
     def create_onion_ep(self, t):
         self.tor_connection = t
-        return t.create_onion_endpoint(self.port)
+        return t.create_onion_endpoint(self.port, private_key=txtorcon.DISCARD)
 
     def onion_listen(self, onion_ep):
         return onion_ep.listen(self.site)


### PR DESCRIPTION
Prior to this commit, the Tor control request `ADD_ONION`
did not specify that the private key need not be returned.
After this commit we add the flag `DiscardPK` by specifying
the argument private_key=txtorcon.DISCARD to the call to
`create_onion_endpoint`, so that the private key is not
returned. The private key is not needed, so this is better.