### PR TITLE
BIP78 input ordering correct for > 2 inputs

### DIFF
--- a/jmbase/jmbase/__init__.py
+++ b/jmbase/jmbase/__init__.py
@@ -8,7 +8,7 @@ from .support import (get_log, chunks, debug_silence, jmprint,
                       EXIT_SUCCESS, hexbin, dictchanger, listchanger,
                       JM_WALLET_NAME_PREFIX, JM_APP_NAME,
                       IndentedHelpFormatterWithNL, wrapped_urlparse,
-                      bdict_sdict_convert)
+                      bdict_sdict_convert, random_insert)
 from .proof_of_work import get_pow, verify_pow
 from .twisted_utils import (stop_reactor, is_hs_uri, get_tor_agent,
                             get_nontor_agent, JMHiddenService,

--- a/jmbase/jmbase/support.py
+++ b/jmbase/jmbase/support.py
@@ -1,6 +1,7 @@
 
 import logging, sys
 import binascii
+import random
 from getpass import getpass
 from os import path, environ
 from functools import wraps
@@ -324,3 +325,11 @@ def bdict_sdict_convert(d, output_binary=False):
             newv = [a.decode("utf-8") for a in v]
             newd[k.decode("utf-8")] = newv
     return newd
+
+def random_insert(old, new):
+    """ Insert elements of new at random indices in
+    the old list, without changing the ordering of the old list.
+    """
+    for n in new:
+        insertion_index = random.randint(0, len(old))
+        old[:] = old[:insertion_index] + [n] + old[insertion_index:]

--- a/jmbase/test/test_base_support.py
+++ b/jmbase/test/test_base_support.py
@@ -1,9 +1,32 @@
 #! /usr/bin/env python
+import pytest
+import copy
+from jmbase import random_insert
 
 def test_color_coded_logging():
     # TODO
     pass
 
-
-
-
+@pytest.mark.parametrize('list1, list2', [
+    [[1,2,3],[4,5,6]],
+    [["a", "b", "c", "d", "e", "f", "g"], [1,2]],
+])
+def test_random_insert(list1, list2):
+    l1 = len(list1)
+    l2 = len(list2)
+    # make a copy of the old version so we can
+    # check ordering:
+    old_list1 = copy.deepcopy(list1)
+    random_insert(list1, list2)
+    assert len(list1) == l1+l2
+    assert all([x in list1 for x in list2])
+    assert all([x in list1 for x in old_list1])
+    # check the order of every element in the original
+    # list is preserved:
+    for x, y in [(old_list1[i], old_list1[i+1]) for i in range(
+        len(old_list1)-1)]:
+        # no need to catch ValueError, it should never throw
+        # so that's a fail anyway.
+        i_x = list1.index(x)
+        i_y = list1.index(y)
+        assert i_y > i_x


### PR DESCRIPTION
Prior to this commit, the receiver code was assuming only
2 inputs always, when it decided how to change the input
ordering (randomly doing a reversal), but this is not correct
according to the BIP78 spec, which requires that the
receiver's inputs are *inserted* randomly, without changing
the ordering of the existing (sender) inputs. After this
commit, the BIP78 protocol is adhered to for any number of
inputs.