### PR TITLE
Require confirmed coins to receive payjoin

### DIFF
--- a/jmclient/jmclient/payjoin.py
+++ b/jmclient/jmclient/payjoin.py
@@ -394,7 +394,7 @@ class JMPayjoinManager(object):
         try:
             my_utxos = self.wallet_service.select_utxos(
                 self.mixdepth, jm_single().DUST_THRESHOLD,
-                select_fn=select_one_utxo)
+                select_fn=select_one_utxo, minconfs=1)
         except Exception as e:
             log.error("Failed to select coins, exception: " + repr(e))
             return False

--- a/scripts/joinmarket-qt.py
+++ b/scripts/joinmarket-qt.py
@@ -1566,9 +1566,10 @@ class JMMainWindow(QMainWindow):
                            "Wallet does not have mixdepth " + str(mixdepth),
                            mbtype='crit', title="Error")
             return False
-        if self.wallet_service.get_balance_by_mixdepth()[mixdepth] == 0:
+        if self.wallet_service.get_balance_by_mixdepth(minconfs=1)[mixdepth] == 0:
             JMQtMessageBox(self, "Mixdepth " + str(mixdepth) + \
-                           " has no coins.", mbtype='crit', title="Error")
+                           " has no confirmed coins.",
+                           mbtype='crit', title="Error")
             return False
         self.backend_receiver = JMBIP78ReceiverManager(self.wallet_service,
             mixdepth, amount, 80, self.receiver_bip78_dialog.info_update,

--- a/scripts/receive-payjoin.py
+++ b/scripts/receive-payjoin.py
@@ -64,9 +64,9 @@ def receive_payjoin_main():
     wallet_service.startService()
     # having enforced wallet sync, we can check if we have coins
     # to do payjoin in the mixdepth
-    if wallet_service.get_balance_by_mixdepth()[options.mixdepth] == 0:
+    if wallet_service.get_balance_by_mixdepth(minconfs=1)[options.mixdepth] == 0:
         jlog.error("Cannot do payjoin from mixdepth " + str(
-            options.mixdepth) + ", no coins. Shutting down.")
+            options.mixdepth) + ", no confirmed coins. Shutting down.")
         sys.exit(EXIT_ARGERROR)
     receiver_manager = JMBIP78ReceiverManager(wallet_service, options.mixdepth,
                                     bip78_amount, options.hsport)


### PR DESCRIPTION
Before this JM allowed to run payjoin receiver with only unconfirmed UTXO's in a mixdepth which ended up with payjoin failing if coins don't confirm before sender do request.