### PR TITLE
Use mempoolminfee instead of minrelaytxfee as tx feerate floor

### DIFF
--- a/jmbitcoin/jmbitcoin/amount.py
+++ b/jmbitcoin/jmbitcoin/amount.py
@@ -60,4 +60,5 @@ def sat_to_str_p(sat):
 
 
 def fee_per_kb_to_str(feerate):
-    return str(feerate) + " sat/vkB (" + str(feerate / 1000) + " sat/vB)"
+    return (str(int(feerate)) + " sat/vkB (" +
+        '%.1f' % (int(feerate / 100) / 10) + " sat/vB)")

--- a/jmbitcoin/test/test_amounts.py
+++ b/jmbitcoin/test/test_amounts.py
@@ -112,3 +112,5 @@ def test_sat_to_str_p():
 
 def test_fee_per_kb_to_str():
     assert(btc.fee_per_kb_to_str(1000) == "1000 sat/vkB (1.0 sat/vB)")
+    assert(btc.fee_per_kb_to_str(1234) == "1234 sat/vkB (1.2 sat/vB)")
+    assert(btc.fee_per_kb_to_str(1999) == "1999 sat/vkB (1.9 sat/vB)")

--- a/jmclient/jmclient/taker_utils.py
+++ b/jmclient/jmclient/taker_utils.py
@@ -139,7 +139,7 @@ def direct_send(wallet_service, amount, mixdepth, destination, answeryes=False,
             #must use unix time as the transaction locktime
 
     #Now ready to construct transaction
-    log.info("Using a fee of : " + amount_to_str(fee_est) + ".")
+    log.info("Using a fee of: " + amount_to_str(fee_est) + ".")
     if amount != 0:
         log.info("Using a change value of: " + amount_to_str(changeval) + ".")
     tx = make_shuffled_tx(list(utxos.keys()), outs, 2, tx_locktime)


### PR DESCRIPTION
With the current state of mempool being constantly full, it is better to use `mempoolminfee` as a tx fee rate floor instead of `minrelaytxfee` (which is usually just 1 sat/vB), otherwise your local Bitcoin node may refuse to accept transaction if it's txfee is below certain value (I think it's around 3 sat/vB currently with default config). And this floor should be checked also when `estimatesmartfee` is used, as it can give you values below that.

Also improved feerate formatting (you don't want gazzilions of digits after decimal point, it's useless) and choosen tx feerate logging.