### PR TITLE
Fix SNICKER client-daemon setup

### DIFF
--- a/jmclient/jmclient/client_protocol.py
+++ b/jmclient/jmclient/client_protocol.py
@@ -821,9 +821,9 @@ def start_reactor(host, port, factory=None, snickerfactory=None,
             jmcport = start_daemon_on_port(port_a, dfactory, "Joinmarket", 0)
         # (See above) For now these other two are just on ports that are 1K offsets.
         if snickerfactory:
-            snickerport = start_daemon_on_port(port_a, sdfactory, "SNICKER", 1000)
+            snickerport = start_daemon_on_port(port_a, sdfactory, "SNICKER", 1000) - 1000
         if bip78:
-            bip78port = start_daemon_on_port(port_a, bip78factory, "BIP78", 2000)
+            start_daemon_on_port(port_a, bip78factory, "BIP78", 2000)
 
         # if the port had to be incremented due to conflict above, we should update
         # it in the config var so e.g. bip78 connections choose the port we actually

--- a/scripts/snicker/create-snicker-proposal.py
+++ b/scripts/snicker/create-snicker-proposal.py
@@ -172,7 +172,8 @@ def main():
     snicker_pf = SNICKERClientProtocolFactory(snicker_client, servers)
     start_reactor(jm_single().config.get("DAEMON", "daemon_host"),
                       jm_single().config.getint("DAEMON", "daemon_port"),
-                      None, snickerfactory=snicker_pf,
+                      snickerfactory=snicker_pf,
+                      jm_coinjoin=False,
                       daemon=daemon)
 
 class SNICKERPostingClient(object):


### PR DESCRIPTION
This commit fixes two minor bugs encountered in
running create-snicker-proposal.py. First, the
port for AMP connections was not correct (by
convention it is now the Joinmarket proto main port
minus 1000), second in the above mentioned script,
the reactor startup client side was not disabling
the Joinmarket protocol, as it should.