### PR TITLE
jm-qt: Clarify error message: "0" is a valid input to `numCPInput`

### DIFF
--- a/scripts/joinmarket-qt.py
+++ b/scripts/joinmarket-qt.py
@@ -1102,7 +1102,7 @@ class SpendTab(QWidget):
         if len(self.numCPInput.text()) == 0:
             JMQtMessageBox(
                 self,
-                "Non-zero number of counterparties must be provided.",
+                "Number of counterparties must be provided. Enter '0' to do a direct send instead of a CoinJoin.",
                 mbtype='warn', title="Error")
             return False
         if len(self.mixdepthInput.text()) == 0:


### PR DESCRIPTION
This PR changes two things about `validateSingleSend()` in joinmarket-qt.py:

1. The string in the message box popped when `len(self.numCPInput.text()) == 0` is changed to clarify that '0' is an acceptable input. The problem here is that *nothing* was provided, not that whatever provided must be non-zero.
2. Adds an extra message box that pops when the user enters a negative number of counterparties. This case is already caught below with `if makercount < jm_single().config.getint("POLICY", "minimum_makers")`, but that's not a great UX. IMO it's better just to check explicitly for negative values in `validateSingleSend()` and give a more appropriate error message.

I feel pretty strongly about (1) but if there's disagreement about (2) I'm fine to remove it; I doubt an earnest user would ever think to try a negative number and that case is already sufficiently guarded.