### PR TITLE
Remove warning dialog when user erases destination address

### DIFF
--- a/scripts/joinmarket-qt.py
+++ b/scripts/joinmarket-qt.py
@@ -345,7 +345,7 @@ class SpendTab(QWidget):
 
         self.addressInput.setText(addr)
         valid, errmsg = validate_address(str(addr))
-        if not valid:
+        if not valid and len(addr) > 0:
             JMQtMessageBox(self,
                        "Bitcoin address not valid.\n" + errmsg,
                        mbtype='warn',


### PR DESCRIPTION
It sometimes happens that I want to edit the address input field. But when I delete the existing address text (intending to immediately replace it), I get a scary warning dialog.

That shouldn't happen; no address is a valid state for the addressInput. Not having entered an
address *is* an error once the user clicks the start button, but that is
handled by `validateSingleSend()`.