### PR TITLE
update to darkscience tor address v3

### DIFF
--- a/jmclient/jmclient/configure.py
+++ b/jmclient/jmclient/configure.py
@@ -130,7 +130,7 @@ socks5_host = localhost
 socks5_port = 9050
 
 #for tor
-#host = darksci3bfoka7tw.onion
+#host = darkirc6tqgpnwd3blln3yfv5ckl47eg7llfxkmtovrv7c7iwohhb6ad.onion
 #socks5 = true
 
 [MESSAGING:server2]


### PR DESCRIPTION
darkscience actually already running a v3 address, just the [website ](https://www.darkscience.net/servers/) is~~n´t~~ updated ~~yet~~. You can try 
`darksci3bfoka7tw.onion` -> `darkirc6tqgpnwd3blln3yfv5ckl47eg7llfxkmtovrv7c7iwohhb6ad.onion`

And the tor version works reliably for me lately.

Verify yourself by:

`torsocks openssl s_client darkirc6tqgpnwd3blln3yfv5ckl47eg7llfxkmtovrv7c7iwohhb6ad.onion:6697`

> `:irc-eu-1.darkscience.net NOTICE * :*** Could not resolve your hostname: Malformed answer; using your IP address (127.0.0.1) instead.`

`openssl s_client irc-eu-1.darkscience.net:6697 | openssl x509 -fingerprint | grep Fingerprint`

```
depth=2 O = Digital Signature Trust Co., CN = DST Root CA X3
verify return:1
depth=1 C = US, O = Let's Encrypt, CN = R3
verify return:1
depth=0 CN = irc-eu-1.darkscience.net
verify return:1
SHA1 Fingerprint=97:88:24:3D:1B:25:55:61:D3:01:92:1A:5E:66:4D:47:07:23:B1:C4
```

compared same for:

`torsocks openssl s_client darkirc6tqgpnwd3blln3yfv5ckl47eg7llfxkmtovrv7c7iwohhb6ad.onion:6697 | openssl x509 -fingerprint | grep Fingerprint`

```
depth=2 O = Digital Signature Trust Co., CN = DST Root CA X3
verify return:1
depth=1 C = US, O = Let's Encrypt, CN = R3
verify return:1
depth=0 CN = irc-eu-1.darkscience.net
verify return:1
SHA1 Fingerprint=97:88:24:3D:1B:25:55:61:D3:01:92:1A:5E:66:4D:47:07:23:B1:C4
```

[consider donate satoshis @ darkscience IRC Network `1DarkSciVXqKZ87bYnA6qxo2FUCVVBa3Er`](https://https://donate.drk.sc)