### PR TITLE
Qt: Clear single send form after successful send

### DIFF
--- a/scripts/joinmarket-qt.py
+++ b/scripts/joinmarket-qt.py
@@ -694,6 +694,7 @@ class SpendTab(QWidget):
             return False
 
     def infoDirectSend(self, msg):
+        self.clearFields(None)
         JMQtMessageBox(self, msg, title="Success")
 
     def errorDirectSend(self, msg):
@@ -961,6 +962,7 @@ class SpendTab(QWidget):
             mainWindow.statusBar().showMessage(
                 "Transaction seen on network: " + self.taker.txid)
             if self.spendstate.typestate == 'single':
+                self.clearFields(None)
                 JMQtMessageBox(self, "Transaction broadcast OK. You can safely \n"
                                "shut down if you don't want to wait.",
                                title="Success")


### PR DESCRIPTION
Helps to avoid accidental sending twice to the same recipient and also clears fields for the user who needed to do it manually if doing more than one send in a single JoinMarketQt session.