### PR TITLE
ob-watcher.py: gracefully exit on old python versions

### DIFF
--- a/scripts/obwatch/ob-watcher.py
+++ b/scripts/obwatch/ob-watcher.py
@@ -17,6 +17,10 @@ from decimal import Decimal
 from optparse import OptionParser
 from twisted.internet import reactor
 
+if sys.version_info < (3, 7):
+    print("ERROR: this script requires at least python 3.7")
+    exit(1)
+
 from jmbase.support import EXIT_FAILURE
 
 from jmbase import get_log


### PR DESCRIPTION
Print a useful warning message when running ob-watcher.py with an old python version instead of crashing with a non-obvious error exception trace.

fixes #849