### PR TITLE
Remove unused key-type param for importprivkey

### DIFF
--- a/jmclient/jmclient/wallet.py
+++ b/jmclient/jmclient/wallet.py
@@ -1619,13 +1619,10 @@ class ImportWalletMixin(object):
         args:
             mixdepth: int, mixdepth to import key into
             wif: str, private key in WIF format
-            key_type: int, must match a TYPE_* constant of this module,
-                used to verify against the key type extracted from WIF
 
         raises:
             WalletError: if key's network does not match wallet network
             WalletError: if key is not compressed and type is not P2PKH
-            WalletError: if key_type does not match data from WIF
 
         returns:
             path of imported key

--- a/jmclient/jmclient/wallet_utils.py
+++ b/jmclient/jmclient/wallet_utils.py
@@ -95,30 +95,8 @@ The method is one of the following:
                       type='str',
                       dest='hd_path',
                       help='hd wallet path (e.g. m/0/0/0/000)')
-    parser.add_option('--key-type',  # note: keep in sync with map_key_type
-                      type='choice',
-                      choices=('standard', 'segwit-p2sh'),
-                      action='store',
-                      dest='key_type',
-                      default=None,
-                      help=("Key type when importing private keys.\n"
-                            "If your address starts with '1' use 'standard', "
-                            "if your address starts with '3' use 'segwit-p2sh'.\n"
-                            "Native segwit addresses (starting with 'bc') are "
-                            "not yet supported."))
 
     return parser
-
-
-def map_key_type(parser_key_choice):
-    if not parser_key_choice:
-        return parser_key_choice
-    if parser_key_choice == 'standard':
-        return TYPE_P2PKH
-    if parser_key_choice == 'segwit-p2sh':
-        return TYPE_P2SH_P2WPKH
-    raise Exception("Unknown key type choice '{}'.".format(parser_key_choice))
-
 
 """The classes in this module manage representations
 of wallet states; but they know nothing about Bitcoin,
@@ -1015,7 +993,7 @@ def wallet_showseed(wallet):
     return text
 
 
-def wallet_importprivkey(wallet, mixdepth, key_type):
+def wallet_importprivkey(wallet, mixdepth):
     jmprint("WARNING: This imported key will not be recoverable with your 12 "
           "word mnemonic phrase. Make sure you have backups.", "warning")
     jmprint("WARNING: Make sure that the type of the public address previously "
@@ -1553,8 +1531,7 @@ def wallet_tool_main(wallet_root_path):
         #note: must be interactive (security)
         if options.mixdepth is None:
             parser.error("You need to specify a mixdepth with -m")
-        wallet_importprivkey(wallet_service, options.mixdepth,
-                             map_key_type(options.key_type))
+        wallet_importprivkey(wallet_service, options.mixdepth)
         return "Key import completed."
     elif method == "signmessage":
         if len(args) < 3:


### PR DESCRIPTION
This removes any reference to the `key-type` parameter on the `importprivkey` wallet command from the code and from the help output. This parameter was already effectively being ignored, the key type would always default to the key type of the wallet. This brings the help info and the code comments in line with the existing functionality.

This PR removes the `key-type` parameter entirely rather than https://github.com/JoinMarket-Org/joinmarket-clientserver/pull/814 which implements  the missing functionality for it instead.