### PR TITLE
Various wallet-tool history fixes and small improvements

### DIFF
--- a/jmclient/jmclient/wallet_utils.py
+++ b/jmclient/jmclient/wallet_utils.py
@@ -775,7 +775,7 @@ def wallet_fetch_history(wallet, options):
     def print_row(index, time, tx_type, amount, delta, balance, cj_n,
                   total_fees, utxo_count, mixdepth_src, mixdepth_dst, txid):
         data = [index, datetime.fromtimestamp(time).strftime("%Y-%m-%d %H:%M"),
-                tx_type, btc.sat_to_str(amount), btc.sat_to_str_p(delta),
+                tx_type, btc.sat_to_str(abs(amount)), btc.sat_to_str_p(delta),
                 btc.sat_to_str(balance), skip_n1(cj_n), sat_to_str_na(total_fees),
                 '% 3d' % utxo_count, skip_n1(mixdepth_src), skip_n1(mixdepth_dst)]
         if options.verbosity % 2 == 0: data += [txid]
@@ -787,7 +787,7 @@ def wallet_fetch_history(wallet, options):
             'utxo-count', 'mixdepth-from', 'mixdepth-to']
     if options.verbosity % 2 == 0: field_names += ['txid']
     if options.csv:
-        jmprint('Bumping verbosity level to 4 due to --csv flag', "debug")
+        #jmprint('Bumping verbosity level to 4 due to --csv flag', "debug")
         options.verbosity = 4
     if options.verbosity > 0: jmprint(s().join(field_names), "info")
     if options.verbosity <= 2: cj_batch = [0]*8 + [[]]*2
@@ -888,22 +888,33 @@ def wallet_fetch_history(wallet, options):
                 fees = 0
             delta_balance = our_output_value - our_input_value
             mixdepth_src = wallet.get_script_mixdepth(list(our_input_scripts)[0])
-        elif len(our_input_scripts) > 0 and len(our_output_scripts) == 2:
-            #payment to self
+        elif len(our_input_scripts) > 0 and len(our_output_scripts) == 2 and is_coinjoin:
             out_value = sum([output_script_values[a] for a in our_output_scripts])
-            if not is_coinjoin:
-                jmprint('this is wrong TODO handle non-coinjoin internal', "warning")
-            tx_type = 'cj internal'
             amount = cj_amount
             delta_balance = out_value - our_input_value
             mixdepth_src = wallet.get_script_mixdepth(list(our_input_scripts)[0])
+            tx_type = 'cj internal'
             cj_script = list(set([a for a, v in output_script_values.items()
                 if v == cj_amount]).intersection(our_output_scripts))[0]
             mixdepth_dst = wallet.get_script_mixdepth(cj_script)
+        elif len(our_input_scripts) > 0 and len(our_output_scripts) == len(output_script_values):
+            out_value = sum([output_script_values[a] for a in our_output_scripts])
+            amount = sum([output_script_values[a] for a in our_output_scripts])
+            delta_balance = out_value - our_input_value
+            mixdepth_src = wallet.get_script_mixdepth(list(our_input_scripts)[0])
+            tx_type = 'internal   '
+            mixdepth_dst = wallet.get_script_mixdepth(list(our_output_scripts)[0])
         else:
-            tx_type = 'unknown type'
-            jmprint('our utxos: ' + str(len(our_input_scripts)) \
-                  + ' in, ' + str(len(our_output_scripts)) + ' out')
+            tx_type = 'unknown    '
+            out_value = sum([output_script_values[a] for a in our_output_scripts])
+            amount = out_value
+            delta_balance = out_value - our_input_value
+            mixdepth_src = wallet.get_script_mixdepth(
+                list(our_input_scripts)[0])
+            mixdepth_dst = wallet.get_script_mixdepth(
+                list(our_output_scripts)[0])
+            #jmprint('our utxos: ' + str(len(our_input_scripts)) \
+            #      + ' in, ' + str(len(our_output_scripts)) + ' out')
 
         if is_confirmed:
             balance += delta_balance
@@ -925,7 +936,7 @@ def wallet_fetch_history(wallet, options):
                         cj_batch[7] += utxo_count
                         cj_batch[8] += [mixdepth_src]
                         cj_batch[9] += [mixdepth_dst]
-                    elif tx_type != 'unknown type':
+                    else:
                         if n > 0:
                             # print the previously-accumulated batch
                             print_row('N='+"%2d"%n, cj_batch[1]/n, 'cj batch   ',
@@ -937,8 +948,7 @@ def wallet_fetch_history(wallet, options):
                         print_row(index, blocktime, tx_type, amount,
                               delta_balance, balance, cj_n, fees, utxo_count,
                               mixdepth_src, mixdepth_dst, tx['txid'])
-                elif options.verbosity >= 5 or \
-                    (options.verbosity >= 3 and tx_type != 'unknown type'):
+                elif options.verbosity >= 3:
                     print_row(index, blocktime, tx_type, amount,
                           delta_balance, balance, cj_n, fees, utxo_count,
                           mixdepth_src, mixdepth_dst, tx['txid'])
@@ -959,6 +969,9 @@ def wallet_fetch_history(wallet, options):
                       cj_batch[3], cj_batch[4], cj_batch[5]/n, cj_batch[6],
                       cj_batch[7]/n, min(cj_batch[8]), max(cj_batch[9]), '...')
 
+    # don't display summaries if csv export
+    if options.csv:
+        return ''
 
     bestblockhash = jm_single().bc_interface.get_best_block_hash()
     now = jm_single().bc_interface.get_block_time(bestblockhash)


### PR DESCRIPTION
* Better handle non-standard (in JM context) transactions and try normal output also for "unknown". Fixes #839.
* Fully handles non-standard internal transactions, where all outputs go to JM wallet (previously didn't work if there was more than two outputs to our wallet).
* Rename "unknown type" to "unknown", for better alignment.
* Don't output summary and line about increasing verbosity for CSV, it makes it more valid CSV (only extra output now is "User data location: ..." line, but that's easy to filter out, as it is the first line).
* Output absolute value for "amount/btc" column. Improves alignment, and sign is already present in next "balance-change/btc" column.

Example below.

Testnet wallet with some manually crafted transactions (used Electrum to create them, all inputs and outputs were from / to same wallet), before:
```
tx# timestamp type amount/btc balance-change/btc balance/btc coinjoin-n total-fees utxo-count mixdepth-from mixdepth-to
"   0" "2021-06-04 20:07" "deposit    " "0.00500000" "+0.00500000" "0.00500000" " #" "N/A       " "  1" " #" " 0"
our utxos: 1 in, 3 out
this is wrong TODO handle non-coinjoin internal
"N= 1" "2021-06-04 21:41" "cj batch   " "0.00100000" "-0.00000200" "0.00499800" "1.0" "N/A       " "  4" " 0" " 0"
        2021-06-05 07:58 best block is 000000000000003806d395c49ffadda52a07f2583e8e978f2a01b0d4f7e5e009
total profit = -0.00000200 BTC
continuously compounded equivalent annual interest rate = -29.57414924985335 %
(as if yield generator was a bank account)
BUG ERROR: wallet balance (0.00499600) does not match balance from history (0.00499800)
```
After:
```
tx# timestamp type amount/btc balance-change/btc balance/btc coinjoin-n total-fees utxo-count mixdepth-from mixdepth-to
"   0" "2021-06-04 20:07" "deposit    " "0.00500000" "+0.00500000" "0.00500000" " #" "N/A       " "  1" " #" " 0"
"   1" "2021-06-04 20:16" "internal   " "0.00499800" "-0.00000200" "0.00499800" " 2" "N/A       " "  3" " 0" " 0"
"   2" "2021-06-04 21:41" "internal   " "0.00499400" "-0.00000200" "0.00499600" " 1" "N/A       " "  4" " 0" " 0"
        2021-06-05 08:38 best block is 0000000000000017ded6660eccf9fe57a05e9c5e397fd1c4df1e9e8b09e2dda1
total profit = 0.00000000 BTC
```