### PR TITLE
Possible fix for first failed case of #901

### DIFF
--- a/jmclient/jmclient/taker.py
+++ b/jmclient/jmclient/taker.py
@@ -435,7 +435,9 @@ class Taker(object):
                 fmt = ('ERROR counterparty requires sub-dust change. nick={}'
                        ' totalin={:d} cjamount={:d} change={:d}').format
                 jlog.warn(fmt(nick, total_input, self.cjamount, change_amount))
-                jlog.warn("Invalid change, too small, nick= " + nick)
+                jlog.warn("Invalid change, too small, nick= " + nick + " Disregard of these counterparty utxos.")
+                # this counterparty utxos must be removed.
+                del self.utxos[nick]
                 continue
 
             self.outputs.append({'address': change_addr,


### PR DESCRIPTION
I compared the inputs of the makers that failed, with the inputs of the build and signed transaction. 
It points out, the inputs from the makers that caused errors wasn't removed from the transaction.  As @undeath showed previously.
But the counterparties outputs from the join got removed. (not appended to tx)
The Built tx have been sending to counterparties from taker. But not to the two error makers.
This results of the still included inputs utxos to never have signed and failed.
Disregard of these counterparty utxos as possible fix for first failed case of #901