### PR TITLE
prevent taker stall on some error conditions

### DIFF
--- a/jmclient/jmclient/taker.py
+++ b/jmclient/jmclient/taker.py
@@ -475,7 +475,7 @@ class Taker(object):
             # this is done with using the same estimate fee function and comparing
             # the totals; this ratio will correspond to the ratio of the feerates.
             num_ins = len([u for u in sum(self.utxos.values(), [])])
-            num_outs = len(self.outputs) + 2
+            num_outs = len(self.outputs) + 1
             new_total_fee = estimate_tx_fee(num_ins, num_outs,
                                     txtype=self.wallet_service.get_txtype())
             feeratio = self.total_txfee/new_total_fee


### PR DESCRIPTION
This commit fixed the problem described in https://github.com/JoinMarket-Org/joinmarket-clientserver/issues/901#issuecomment-860204641

The `Taker.receive_utxos()` method has been slightly refactored because it's way too long anyway. The existing logic remained mostly untouched with two exceptions:
* any inputs/outputs from makers are only added to the internal data structures after they have been verified, fixing the problem mentioned above
* ~~maker nicks from `self.nonrespondants` are always removed if we see an ioauth message from them (phase 1), not only after a successful verification. We are unlikely to see a valid ioauth message from some maker after they have tried to send us invalid data. For "phase 1" the contents of `self.nonrespondants` do not even appear to be checked anywhere so I'm not sure what the intended purpose was here but it sounds like it should be used to track how many responses are still expected?~~

Another weird part is the logic when to call `self.add_ignored_makers`. Right now this only happens in one single case when I would expect to ignore any makers that somehow provide invalid responses. Then however, `taker.utils.tumbler_taker_finished_update()` also ignores makers that are still in `self.nonrespondants` after something happend. Should the `Taker` or the `taker_utils` take care of deciding what makers to ignore?

The whole `Taker` class is quite messy because data about a specific coinjoin are all scattered across the `Taker` object somehow with very hard to grasp logic of when a specific attribute (or several attributes) of the `Taker` are modified or reset. Ideally this would be refactored into a dedicated coinjoin transaction object. But that's another day's story.