### PR TITLE
Allow PySide2 5.14.2, 5.15.3+, 6.1+

### DIFF
--- a/requirements/gui.txt
+++ b/requirements/gui.txt
@@ -1,6 +1,7 @@
 -r base.txt
 pywin32; platform_system == "Windows"
-PySide2==5.14.2
-PyQt5==5.14.2
+# https://bugreports.qt.io/browse/QTBUG-88688
+PySide2!=5.15.0,!=5.15.1,!=5.15.2,!=6.0
+PyQt5!=5.15.0,!=5.15.1,!=5.15.2,!=6.0
 qrcode[pil]
 https://github.com/sunu/qt5reactor/archive/58410aaead2185e9917ae9cac9c50fe7b70e4a60.zip#egg=qt5reactor


### PR DESCRIPTION
Issue #737 [seems to be fixed](https://bugreports.qt.io/browse/QTBUG-88688). This allows either 5.14.2*, 5.15.3+ or 6.1+.

Likely will not immediately solve #865, as there is only 5.15.2 available currently, but should not make it worse either. Removing pinning likely works because #737 does not happen on all Linux distros.