### PR TITLE
Refactor: use term "passphrase" instead of "password" for JM wallets everywhere, for consistency

### DIFF
--- a/jmbase/jmbase/__init__.py
+++ b/jmbase/jmbase/__init__.py
@@ -1,6 +1,6 @@
 
 from .support import (get_log, chunks, debug_silence, jmprint,
-                      joinmarket_alert, core_alert, get_password,
+                      joinmarket_alert, core_alert, get_passphrase,
                       set_logging_level, set_logging_color,
                       lookup_appdata_folder, bintohex, bintolehex,
                       hextobin, lehextobin, utxostr_to_utxo,

--- a/jmbase/jmbase/support.py
+++ b/jmbase/jmbase/support.py
@@ -205,11 +205,11 @@ def set_logging_color(colored=False):
 def chunks(d, n):
     return [d[x:x + n] for x in range(0, len(d), n)]
 
-def get_password(msg): #pragma: no cover
-    password = getpass(msg)
-    if not isinstance(password, bytes):
-        password = password.encode('utf-8')
-    return password
+def get_passphrase(msg): #pragma: no cover
+    passphrase = getpass(msg)
+    if not isinstance(passphrase, bytes):
+        passphrase = passphrase.encode('utf-8')
+    return passphrase
 
 def lookup_appdata_folder(appname):
     """ Given an appname as a string,

--- a/jmclient/jmclient/__init__.py
+++ b/jmclient/jmclient/__init__.py
@@ -17,7 +17,7 @@ from .wallet import (Mnemonic, estimate_tx_fee, WalletError, BaseWallet, ImportW
                      FidelityBondWatchonlyWallet, SegwitLegacyWalletFidelityBonds,
                      UTXOManager, WALLET_IMPLEMENTATIONS, compute_tx_locktime)
 from .storage import (Argon2Hash, Storage, StorageError, RetryableStorageError,
-                      StoragePasswordError, VolatileStorage)
+                      StoragePassphraseError, VolatileStorage)
 from .cryptoengine import (BTCEngine, BTC_P2PKH, BTC_P2SH_P2WPKH, BTC_P2WPKH, EngineError,
                            TYPE_P2PKH, TYPE_P2SH_P2WPKH, TYPE_P2WPKH, detect_script_type)
 from .configure import (load_test_config, process_shutdown,

--- a/jmclient/jmclient/cli_options.py
+++ b/jmclient/jmclient/cli_options.py
@@ -42,11 +42,12 @@ def add_base_options(parser):
                       default=False,
                       help=('choose to do detailed wallet sync, '
                             'used for recovering on new Core instance.'))
+    # keep "wallet-password-stdin" (not passphrase) to not break compatibility
     parser.add_option('--wallet-password-stdin',
                       action='store_true',
                       default=False,
                       dest='wallet_password_stdin',
-                      help='Read wallet password from stdin')
+                      help='Read wallet passphrase (password) from stdin')
     parser.add_option('--version',
                       action='callback',
                       callback=print_jm_version,

--- a/jmclient/jmclient/wallet.py
+++ b/jmclient/jmclient/wallet.py
@@ -872,10 +872,10 @@ class BaseWallet(object):
         raise NotImplementedError()
 
     def check_wallet_passphrase(self, passphrase):
-        return self._storage.check_password(passphrase)
+        return self._storage.check_passphrase(passphrase)
 
     def change_wallet_passphrase(self, passphrase):
-        self._storage.change_password(passphrase)
+        self._storage.change_passphrase(passphrase)
 
     def yield_imported_paths(self, mixdepth):
         """

--- a/jmclient/jmclient/wallet_utils.py
+++ b/jmclient/jmclient/wallet_utils.py
@@ -12,11 +12,11 @@ from collections import Counter
 from itertools import islice
 from jmclient import (get_network, WALLET_IMPLEMENTATIONS, Storage, podle,
     jm_single, BitcoinCoreInterface, WalletError, BaseWallet,
-    VolatileStorage, StoragePasswordError, is_segwit_mode, SegwitLegacyWallet,
+    VolatileStorage, StoragePassphraseError, is_segwit_mode, SegwitLegacyWallet,
     LegacyWallet, SegwitWallet, FidelityBondMixin, FidelityBondWatchonlyWallet,
     is_native_segwit_mode, load_program_config, add_base_options, check_regtest)
 from jmclient.wallet_service import WalletService
-from jmbase.support import (get_password, jmprint, EXIT_FAILURE,
+from jmbase.support import (get_passphrase, jmprint, EXIT_FAILURE,
                             EXIT_ARGERROR, utxo_to_utxostr, hextobin, bintohex,
                             IndentedHelpFormatterWithNL)
 
@@ -549,12 +549,12 @@ def wallet_display(wallet_service, showprivkey, displayall=False,
         return walletview
 
 def cli_get_wallet_passphrase_check():
-    password = get_password("Enter new passphrase to encrypt wallet: ")
-    password2 = get_password("Reenter new passphrase to encrypt wallet: ")
-    if password != password2:
-        jmprint('ERROR. Passwords did not match', "error")
+    passphrase = get_passphrase("Enter new passphrase to encrypt wallet: ")
+    passphrase2 = get_passphrase("Reenter new passphrase to encrypt wallet: ")
+    if passphrase != passphrase2:
+        jmprint('ERROR. Passphrases did not match', "error")
         return False
-    return password
+    return passphrase
 
 def cli_get_wallet_file_name(defaultname="wallet.jmdat"):
     return input('Input wallet file name (default: ' + defaultname + '): ')
@@ -597,7 +597,7 @@ def cli_do_support_fidelity_bonds():
         return True
 
 def wallet_generate_recover_bip39(method, walletspath, default_wallet_name,
-        display_seed_callback, enter_seed_callback, enter_wallet_password_callback,
+        display_seed_callback, enter_seed_callback, enter_wallet_passphrase_callback,
         enter_wallet_file_name_callback, enter_if_use_seed_extension,
         enter_seed_extension_callback, enter_do_support_fidelity_bonds, mixdepth=DEFAULT_MIXDEPTH):
     entropy = None
@@ -621,8 +621,8 @@ def wallet_generate_recover_bip39(method, walletspath, default_wallet_name,
         raise Exception("unknown method for wallet creation: '{}'"
                         .format(method))
 
-    password = enter_wallet_password_callback()
-    if not password:
+    passphrase = enter_wallet_passphrase_callback()
+    if not passphrase:
         return False
 
     wallet_name = enter_wallet_file_name_callback()
@@ -640,7 +640,7 @@ def wallet_generate_recover_bip39(method, walletspath, default_wallet_name,
     support_fidelity_bonds = False
     wallet_cls = get_wallet_cls(get_configured_wallet_type(support_fidelity_bonds))
 
-    wallet = create_wallet(wallet_path, password, mixdepth, wallet_cls,
+    wallet = create_wallet(wallet_path, passphrase, mixdepth, wallet_cls,
                            entropy=entropy,
                            entropy_extension=mnemonic_extension)
     mnemonic, mnext = wallet.get_mnemonic_words()
@@ -672,8 +672,8 @@ def wallet_generate_recover(method, walletspath,
         raise Exception("unknown method for wallet creation: '{}'"
                         .format(method))
 
-    password = cli_get_wallet_passphrase_check()
-    if not password:
+    passphrase = cli_get_wallet_passphrase_check()
+    if not passphrase:
         return ""
 
     wallet_name = cli_get_wallet_file_name()
@@ -681,7 +681,7 @@ def wallet_generate_recover(method, walletspath,
         wallet_name = default_wallet_name
     wallet_path = os.path.join(walletspath, wallet_name)
 
-    wallet = create_wallet(wallet_path, password, mixdepth,
+    wallet = create_wallet(wallet_path, passphrase, mixdepth,
                            wallet_cls=LegacyWallet, entropy=entropy)
     jmprint("Write down and safely store this wallet recovery seed\n\n{}\n"
           .format(wallet.get_mnemonic_words()[0]), "important")
@@ -1270,8 +1270,8 @@ def wallet_createwatchonly(wallet_root_path, master_pub_key):
 
     wallet_path = os.path.join(wallet_root_path, wallet_name)
 
-    password = cli_get_wallet_passphrase_check()
-    if not password:
+    passphrase = cli_get_wallet_passphrase_check()
+    if not passphrase:
         return ""
 
     entropy = FidelityBondMixin.get_xpub_from_fidelity_bond_master_pub_key(master_pub_key)
@@ -1280,7 +1280,7 @@ def wallet_createwatchonly(wallet_root_path, master_pub_key):
         return ""
     entropy = entropy.encode()
 
-    wallet = create_wallet(wallet_path, password,
+    wallet = create_wallet(wallet_path, passphrase,
         max_mixdepth=FidelityBondMixin.FIDELITY_BOND_MIXDEPTH,
         wallet_cls=FidelityBondWatchonlyWallet, entropy=entropy)
     return "Done"
@@ -1309,8 +1309,8 @@ def get_wallet_cls(wtype):
                           "".format(wtype))
     return cls
 
-def create_wallet(path, password, max_mixdepth, wallet_cls, **kwargs):
-    storage = Storage(path, password, create=True)
+def create_wallet(path, passphrase, max_mixdepth, wallet_cls, **kwargs):
+    storage = Storage(path, passphrase, create=True)
     wallet_cls.initialize(storage, get_network(), max_mixdepth=max_mixdepth,
                           **kwargs)
     storage.save()
@@ -1352,32 +1352,32 @@ def open_test_wallet_maybe(path, seed, max_mixdepth,
             #wallet instantiation insists on no unexpected kwargs,
             #but Qt caller opens both test and mainnet with same args,
             #hence these checks/deletes of unwanted args for tests.
-            if 'ask_for_password' in kwargs:
-                del kwargs['ask_for_password']
-            if 'password' in kwargs:
-                del kwargs['password']
+            if 'ask_for_passphrase' in kwargs:
+                del kwargs['ask_for_passphrase']
+            if 'passphrase' in kwargs:
+                del kwargs['passphrase']
             if 'read_only' in kwargs:
                 del kwargs['read_only']
             return test_wallet_cls(storage, **kwargs)
 
     if wallet_password_stdin is True:
         stdin = sys.stdin.read()
-        password = stdin.encode('utf-8')
-        return open_wallet(path, ask_for_password=False, password=password, mixdepth=max_mixdepth, **kwargs)
+        passphrase = stdin.encode('utf-8')
+        return open_wallet(path, ask_for_passphrase=False, passphrase=passphrase, mixdepth=max_mixdepth, **kwargs)
 
     return open_wallet(path, mixdepth=max_mixdepth, **kwargs)
 
 
-def open_wallet(path, ask_for_password=True, password=None, read_only=False,
+def open_wallet(path, ask_for_passphrase=True, passphrase=None, read_only=False,
                 **kwargs):
     """
     Open the wallet file at path and return the corresponding wallet object.
 
     params:
         path: str, full path to wallet file
-        ask_for_password: bool, if False password is assumed unset and user
+        ask_for_passphrase: bool, if False, passphrase is assumed unset and user
             will not be asked to type it
-        password: password for storage, ignored if ask_for_password is True
+        passphrase: passphrase for storage, ignored if ask_for_passphrase is True
         read_only: bool, if True, open wallet in read-only mode
         kwargs: additional options to pass to wallet's init method
 
@@ -1393,14 +1393,14 @@ def open_wallet(path, ask_for_password=True, password=None, read_only=False,
                         "you need to convert it using the conversion script "
                         "at `scripts/convert_old_wallet.py`".format(path))
 
-    if ask_for_password and Storage.is_encrypted_storage_file(path):
+    if ask_for_passphrase and Storage.is_encrypted_storage_file(path):
         while True:
             try:
-                # do not try empty password, assume unencrypted on empty password
-                pwd = get_password("Enter passphrase to decrypt wallet: ") or None
-                storage = Storage(path, password=pwd, read_only=read_only)
-            except StoragePasswordError:
-                jmprint("Wrong password, try again.", "warning")
+                # do not try empty passphrase, assume unencrypted on empty passphrase
+                pwd = get_passphrase("Enter passphrase to decrypt wallet: ") or None
+                storage = Storage(path, passphrase=pwd, read_only=read_only)
+            except StoragePassphraseError:
+                jmprint("Wrong passphrase, try again.", "warning")
                 continue
             except Exception as e:
                 jmprint("Failed to load wallet, error message: " + repr(e),
@@ -1408,7 +1408,7 @@ def open_wallet(path, ask_for_password=True, password=None, read_only=False,
                 raise e
             break
     else:
-        storage = Storage(path, password, read_only=read_only)
+        storage = Storage(path, passphrase, read_only=read_only)
 
     wallet_cls = get_wallet_cls_from_storage(storage)
     wallet = wallet_cls(storage, **kwargs)

--- a/jmclient/test/test_storage.py
+++ b/jmclient/test/test_storage.py
@@ -25,7 +25,7 @@ class MockStorage(storage.Storage):
 
 
 def test_storage():
-    s = MockStorage(None, 'nonexistant', b'password', create=True)
+    s = MockStorage(None, 'nonexistant', b'passphrase', create=True)
     assert s.file_data.startswith(s.MAGIC_ENC)
     assert s.locked
     assert s.is_encrypted()
@@ -40,19 +40,19 @@ def test_storage():
     enc_data = s.file_data
 
     old_data = s.file_data
-    s.change_password(b'newpass')
+    s.change_passphrase(b'newpass')
     assert s.is_encrypted()
     assert not s.was_changed()
     assert s.file_data != old_data
 
     old_data = s.file_data
-    s.change_password(None)
+    s.change_passphrase(None)
     assert not s.is_encrypted()
     assert not s.was_changed()
     assert s.file_data != old_data
     assert s.file_data.startswith(s.MAGIC_UNENC)
 
-    s2 = MockStorage(enc_data, __file__, b'password')
+    s2 = MockStorage(enc_data, __file__, b'passphrase')
     assert s2.locked
     assert s2.is_encrypted()
     assert not s2.was_changed()
@@ -61,29 +61,29 @@ def test_storage():
 
 def test_storage_invalid():
     with pytest.raises(storage.StorageError):
-        MockStorage(None, 'nonexistant', b'password')
+        MockStorage(None, 'nonexistant', b'passphrase')
         pytest.fail("File does not exist")
 
-    s = MockStorage(None, 'nonexistant', b'password', create=True)
+    s = MockStorage(None, 'nonexistant', b'passphrase', create=True)
     with pytest.raises(storage.StorageError):
         MockStorage(s.file_data, __file__, b'wrongpass')
-        pytest.fail("Wrong password")
+        pytest.fail("Wrong passphrase")
 
     with pytest.raises(storage.StorageError):
         MockStorage(s.file_data, __file__)
-        pytest.fail("No password")
+        pytest.fail("No passphrase")
 
     with pytest.raises(storage.StorageError):
         MockStorage(b'garbagefile', __file__)
         pytest.fail("Non-wallet file, unencrypted")
 
     with pytest.raises(storage.StorageError):
-        MockStorage(b'garbagefile', __file__, b'password')
+        MockStorage(b'garbagefile', __file__, b'passphrase')
         pytest.fail("Non-wallet file, encrypted")
 
 def test_storage_readonly():
-    s = MockStorage(None, 'nonexistant', b'password', create=True)
-    s = MockStorage(s.file_data, __file__, b'password', read_only=True)
+    s = MockStorage(None, 'nonexistant', b'passphrase', create=True)
+    s = MockStorage(s.file_data, __file__, b'passphrase', read_only=True)
     s.data[b'mydata'] = b'test'
 
     assert not s.locked
@@ -93,7 +93,7 @@ def test_storage_readonly():
         s.save()
 
     with pytest.raises(storage.StorageError):
-        s.change_password(b'newpass')
+        s.change_passphrase(b'newpass')
 
 
 def test_storage_lock(tmpdir):

--- a/jmclient/test/test_wallet.py
+++ b/jmclient/test/test_wallet.py
@@ -821,24 +821,24 @@ def test_watchonly_wallet(setup_wallet):
         assert script == watchonly_script
     assert burn_pubkey == watchonly_burn_pubkey
 
-@pytest.mark.parametrize('password, wallet_cls', [
+@pytest.mark.parametrize('passphrase, wallet_cls', [
     ["hunter2", SegwitLegacyWallet],
     ["hunter2", SegwitWallet],
 ])
-def test_create_wallet(setup_wallet, password, wallet_cls):
+def test_create_wallet(setup_wallet, passphrase, wallet_cls):
     wallet_name = test_create_wallet_filename
-    password = password.encode("utf-8")
+    passphrase = passphrase.encode("utf-8")
     # test mainnet (we are not transacting)
     btc.select_chain_params("bitcoin")
-    wallet = create_wallet(wallet_name, password, 4, wallet_cls)
+    wallet = create_wallet(wallet_name, passphrase, 4, wallet_cls)
     mnemonic = wallet.get_mnemonic_words()[0]
     firstkey = wallet.get_key_from_addr(wallet.get_addr(0,0,0))
     print("Created mnemonic, firstkey: ", mnemonic, firstkey)
     wallet.close()
-    # ensure that the wallet file created is openable with the password,
+    # ensure that the wallet file created is openable with the passphrase,
     # and has the parameters that were claimed on creation:
     new_wallet = open_test_wallet_maybe(wallet_name, "", 4,
-                        password=password, ask_for_password=False)
+                        passphrase=passphrase, ask_for_passphrase=False)
     assert new_wallet.get_mnemonic_words()[0] == mnemonic
     assert new_wallet.get_key_from_addr(
         new_wallet.get_addr(0,0,0)) == firstkey

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -76,4 +76,4 @@ As above.
 
 ### genwallet.py
 
-Non-interactively generate a wallet, giving only wallet name and password. Returns wallet seed as `recovery_seed:`. Useful for automating JoinMarket deployments.
+Non-interactively generate a wallet, giving only wallet name and passphrase. Returns wallet seed as `recovery_seed:`. Useful for automating JoinMarket deployments.

--- a/scripts/genwallet.py
+++ b/scripts/genwallet.py
@@ -10,16 +10,16 @@ log = get_log()
 
 def main():
     parser = OptionParser(
-    usage='usage: %prog [options] wallet_file_name password',
-    description='Create a wallet with the given wallet name and password.')
+    usage='usage: %prog [options] wallet_file_name passphrase',
+    description='Create a wallet with the given wallet name and passphrase.')
     add_base_options(parser)
     (options, args) = parser.parse_args()
     if options.wallet_password_stdin:
         stdin = sys.stdin.read()
-        password = stdin.encode("utf-8")
+        passphrase = stdin.encode("utf-8")
     else:
-        assert len(args) > 1, "must provide password via stdin (see --help), or as second argument."
-        password = args[1].encode("utf-8")
+        assert len(args) > 1, "must provide passphrase via stdin (see --help), or as second argument."
+        passphrase = args[1].encode("utf-8")
     load_program_config(config_path=options.datadir)
     wallet_root_path = os.path.join(jm_single().datadir, "wallets")
     wallet_name = os.path.join(wallet_root_path, args[0])
@@ -27,7 +27,7 @@ def main():
         walletclass = SegwitWallet
     else:
         walletclass = SegwitLegacyWallet
-    wallet = create_wallet(wallet_name, password, 4, walletclass)
+    wallet = create_wallet(wallet_name, passphrase, 4, walletclass)
     jmprint("recovery_seed:{}"
          .format(wallet.get_mnemonic_words()[0]), "important")
     wallet.close()

--- a/scripts/joinmarket-qt.py
+++ b/scripts/joinmarket-qt.py
@@ -76,7 +76,7 @@ from jmclient import load_program_config, get_network, update_persist_config,\
 
 from qtsupport import ScheduleWizard, TumbleRestartWizard, config_tips,\
     config_types, QtHandler, XStream, Buttons, OkButton, CancelButton,\
-    PasswordDialog, MyTreeWidget, JMQtMessageBox, BLUE_FG,\
+    PassphraseDialog, MyTreeWidget, JMQtMessageBox, BLUE_FG,\
     donation_more_message, BitcoinAmountEdit, JMIntValidator,\
     ReceiveBIP78Dialog, QRCodePopup
 
@@ -1880,7 +1880,7 @@ class JMMainWindow(QMainWindow):
                 "wallet.jmdat",
                 display_seed_callback=None,
                 enter_seed_callback=self.seedEntry,
-                enter_wallet_password_callback=self.getPassword,
+                enter_wallet_passphrase_callback=self.getPassphrase,
                 enter_wallet_file_name_callback=self.getWalletFileName,
                 enter_if_use_seed_extension=None,
                 enter_seed_extension_callback=None,
@@ -1915,7 +1915,7 @@ class JMMainWindow(QMainWindow):
             while not decrypted:
                 text, ok = QInputDialog.getText(self,
                                                 'Decrypt wallet',
-                                                'Enter your password:',
+                                                'Enter your passphrase:',
                                                 echo=QLineEdit.Password)
                 if not ok:
                     return
@@ -1950,7 +1950,7 @@ class JMMainWindow(QMainWindow):
             wallet_path = get_wallet_path(str(firstarg), None)
             try:
                 wallet = open_test_wallet_maybe(wallet_path, str(firstarg),
-                        None, ask_for_password=False, password=pwd.encode('utf-8') if pwd else None,
+                        None, ask_for_passphrase=False, passphrase=pwd.encode('utf-8') if pwd else None,
                         gap_limit=jm_single().config.getint("GUI", "gaplimit"))
             except RetryableStorageError as e:
                 JMQtMessageBox(self,
@@ -2054,7 +2054,7 @@ class JMMainWindow(QMainWindow):
                            mbtype="crit", title="Error")
             return
         if not (self.checkPassphrase()
-                and wallet_change_passphrase(self.wallet_service, self.getPassword)):
+                and wallet_change_passphrase(self.wallet_service, self.getPassphrase)):
             JMQtMessageBox(self, "Failed to change passphrase.",
                            title="Error", mbtype="warn")
             return
@@ -2087,8 +2087,8 @@ class JMMainWindow(QMainWindow):
                            mbtype='info',
                            title="Error")
 
-    def getPassword(self):
-        pd = PasswordDialog()
+    def getPassphrase(self):
+        pd = PassphraseDialog()
         while True:
             for child in pd.findChildren(QLineEdit):
                 child.clear()
@@ -2109,8 +2109,8 @@ class JMMainWindow(QMainWindow):
                                title="Error")
                 continue
             break
-        self.textpassword = str(pd.new_pw.text())
-        return self.textpassword.encode('utf-8')
+        self.textpassphrase = str(pd.new_pw.text())
+        return self.textpassphrase.encode('utf-8')
 
     def getWalletFileName(self):
         walletname, ok = QInputDialog.getText(self, 'Choose wallet name',
@@ -2166,7 +2166,7 @@ class JMMainWindow(QMainWindow):
                     "generate", wallets_path, "wallet.jmdat",
                     display_seed_callback=self.displayWords,
                     enter_seed_callback=None,
-                    enter_wallet_password_callback=self.getPassword,
+                    enter_wallet_passphrase_callback=self.getPassphrase,
                     enter_wallet_file_name_callback=self.getWalletFileName,
                     enter_if_use_seed_extension=self.promptUseMnemonicExtension,
                     enter_seed_extension_callback=self.promptInputMnemonicExtension,
@@ -2182,7 +2182,7 @@ class JMMainWindow(QMainWindow):
 
             JMQtMessageBox(self, 'Wallet saved to ' + self.walletname,
                            title="Wallet created")
-        self.loadWalletFromBlockchain(self.walletname, pwd=self.textpassword)
+        self.loadWalletFromBlockchain(self.walletname, pwd=self.textpassphrase)
 
 def get_wallet_printout(wallet_service):
     """Given a WalletService object, retrieve the list of

--- a/scripts/qtsupport.py
+++ b/scripts/qtsupport.py
@@ -281,44 +281,44 @@ class CancelButton(QPushButton):
         self.clicked.connect(dialog.reject)
 
 
-def check_password_strength(password):
+def check_passphrase_strength(passphrase):
     '''
-    Check the strength of the password entered by the user and return back the same
-    :param password: password entered by user in New Password
-    :return: password strength Weak or Medium or Strong
+    Check the strength of the passphrase entered by the user and return back the same
+    :param passphrase: passphrase entered by user in New Passphrase
+    :return: passphrase strength Weak or Medium or Strong
     '''
-    n = math.log(len(set(password)))
-    num = re.search("[0-9]", password) is not None and re.match(
-        "^[0-9]*$", password) is None
-    caps = password != password.upper() and password != password.lower()
-    extra = re.match("^[a-zA-Z0-9]*$", password) is None
-    score = len(password) * (n + caps + num + extra) / 20
-    password_strength = {0: "Weak", 1: "Medium", 2: "Strong", 3: "Very Strong"}
-    return password_strength[min(3, int(score))]
+    n = math.log(len(set(passphrase)))
+    num = re.search("[0-9]", passphrase) is not None and re.match(
+        "^[0-9]*$", passphrase) is None
+    caps = passphrase != passphrase.upper() and passphrase != passphrase.lower()
+    extra = re.match("^[a-zA-Z0-9]*$", passphrase) is None
+    score = len(passphrase) * (n + caps + num + extra) / 20
+    passphrase_strength = {0: "Weak", 1: "Medium", 2: "Strong", 3: "Very Strong"}
+    return passphrase_strength[min(3, int(score))]
 
 
-def update_password_strength(pw_strength_label, password):
+def update_passphrase_strength(pw_strength_label, passphrase):
     '''
-    call the function check_password_strength and update the label pw_strength 
-    interactively as the user is typing the password
+    call the function check_passphrase_strength and update the label pw_strength 
+    interactively as the user is typing the passphrase
     :param pw_strength_label: the label pw_strength
-    :param password: password entered in New Password text box
+    :param passphrase: passphrase entered in New Passphrase text box
     :return: None
     '''
-    if password:
+    if passphrase:
         colors = {"Weak": "Red",
                   "Medium": "Blue",
                   "Strong": "Green",
                   "Very Strong": "Green"}
-        strength = check_password_strength(password)
-        label = "Password Strength"+ ": "+"<font color=" + \
+        strength = check_passphrase_strength(passphrase)
+        label = "Passphrase Strength"+ ": "+"<font color=" + \
         colors[strength] + ">" + strength + "</font>"
     else:
         label = ""
     pw_strength_label.setText(label)
 
 
-def make_password_dialog(self, msg):
+def make_passphrase_dialog(self, msg):
 
     self.new_pw = QLineEdit()
     self.new_pw.setEchoMode(QLineEdit.EchoMode(2))
@@ -355,18 +355,18 @@ def make_password_dialog(self, msg):
     grid.addWidget(self.conf_pw, 2, 1)
     vbox.addLayout(grid)
 
-    #Password Strength Label
+    #Passphrase Strength Label
     self.pw_strength = QLabel()
     grid.addWidget(self.pw_strength, 3, 0, 1, 2)
     self.new_pw.textChanged.connect(
-        lambda: update_password_strength(self.pw_strength, self.new_pw.text()))
+        lambda: update_passphrase_strength(self.pw_strength, self.new_pw.text()))
 
     vbox.addStretch(1)
     vbox.addLayout(Buttons(CancelButton(self), OkButton(self)))
     return vbox
 
 
-class PasswordDialog(QDialog):
+class PassphraseDialog(QDialog):
 
     def __init__(self):
         super().__init__()
@@ -375,7 +375,7 @@ class PasswordDialog(QDialog):
     def initUI(self):
         self.setWindowTitle('Create a new passphrase')
         msg = "Enter a new passphrase"
-        self.setLayout(make_password_dialog(self, msg))
+        self.setLayout(make_passphrase_dialog(self, msg))
         self.show()
 
 

--- a/test/common.py
+++ b/test/common.py
@@ -63,7 +63,6 @@ def make_wallets(n,
                  start_index=0,
                  fixed_seeds=None,
                  test_wallet=False,
-                 passwords=None,
                  walletclass=SegwitWallet,
                  mixdepths=5):
     '''n: number of wallets to be created
@@ -74,7 +73,6 @@ def make_wallets(n,
        sdev_amt: if randomness in amouts is desired, specify here.
        Returns: a dict of dicts of form {0:{'seed':seed,'wallet':Wallet object},1:..,}
        Default Wallet constructor is joinmarket.Wallet, else use TestWallet,
-       which takes a password parameter as in the list passwords.
        '''
     # FIXME: this is basically the same code as jmclient/test/commontest.py
     if len(wallet_structures) != n:
@@ -87,12 +85,6 @@ def make_wallets(n,
     wallets = {}
     for i in range(n):
         assert len(seeds[i]) == BIP32Wallet.ENTROPY_BYTES * 2
-
-        # FIXME: pwd is ignored (but do we really need this anyway?)
-        if test_wallet and passwords and i < len(passwords):
-            pwd = passwords[i]
-        else:
-            pwd = None
 
         w = open_test_wallet_maybe(seeds[i], seeds[i], mixdepths - 1,
                                    test_wallet_cls=walletclass)


### PR DESCRIPTION
Exception is `wallet_password_stdin`, renaming which would break compatibility for other tools calling JM scripts. Also removed unused password code for test suite wallet creation, don't see point in encrypting temporary test wallets.