### PR TITLE
Show an Open Wallet dialog upon launching the app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,4 +32,4 @@ scripts/jm-tx-history.txt
 scripts/snicker/joinmarket.cfg
 scripts/snicker/snicker-proposals.txt
 scripts/snicker/candidates.txt
-
+.qt_for_python/

--- a/jmbase/setup.py
+++ b/jmbase/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 setup(name='joinmarketbase',
       version='0.9.2dev',
       description='Joinmarket client library for Bitcoin coinjoins',
-      url='http://github.com/Joinmarket-Org/joinmarket-clientserver/jmbase',
+      url='https://github.com/JoinMarket-Org/joinmarket-clientserver/tree/master/jmbase',
       author='',
       author_email='',
       license='GPL',

--- a/jmbitcoin/setup.py
+++ b/jmbitcoin/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 setup(name='joinmarketbitcoin',
       version='0.9.2dev',
       description='Joinmarket client library for Bitcoin coinjoins',
-      url='http://github.com/Joinmarket-Org/joinmarket-clientserver/jmbitcoin',
+      url='https://github.com/JoinMarket-Org/joinmarket-clientserver/tree/master/jmbitcoin',
       author='',
       author_email='',
       license='GPL',

--- a/jmclient/setup.py
+++ b/jmclient/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 setup(name='joinmarketclient',
       version='0.9.2dev',
       description='Joinmarket client library for Bitcoin coinjoins',
-      url='http://github.com/Joinmarket-Org/joinmarket-clientserver/jmclient',
+      url='https://github.com/JoinMarket-Org/joinmarket-clientserver/tree/master/jmclient',
       author='',
       author_email='',
       license='GPL',

--- a/jmdaemon/setup.py
+++ b/jmdaemon/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 setup(name='joinmarketdaemon',
       version='0.9.2dev',
       description='Joinmarket client library for Bitcoin coinjoins',
-      url='http://github.com/Joinmarket-Org/joinmarket-clientserver/jmdaemon',
+      url='https://github.com/JoinMarket-Org/joinmarket-clientserver/tree/master/jmdaemon',
       author='',
       author_email='',
       license='GPL',

--- a/jmqtui/jmqtui/__init__.py
+++ b/jmqtui/jmqtui/__init__.py
@@ -1,0 +1,2 @@
+from .open_wallet_dialog import (
+    Ui_OpenWalletDialog)

--- a/jmqtui/jmqtui/open_wallet_dialog.py
+++ b/jmqtui/jmqtui/open_wallet_dialog.py
@@ -1,0 +1,136 @@
+# -*- coding: utf-8 -*-
+
+################################################################################
+## Form generated from reading UI file 'open_wallet_dialog.ui'
+##
+## Created by: Qt User Interface Compiler version 5.14.2
+##
+## WARNING! All changes made in this file will be lost when recompiling UI file!
+################################################################################
+
+from PySide2.QtCore import (QCoreApplication, QDate, QDateTime, QMetaObject,
+    QObject, QPoint, QRect, QSize, QTime, QUrl, Qt)
+from PySide2.QtGui import (QBrush, QColor, QConicalGradient, QCursor, QFont,
+    QFontDatabase, QIcon, QKeySequence, QLinearGradient, QPalette, QPainter,
+    QPixmap, QRadialGradient)
+from PySide2.QtWidgets import *
+
+
+class Ui_OpenWalletDialog(object):
+    def setupUi(self, OpenWalletDialog):
+        if not OpenWalletDialog.objectName():
+            OpenWalletDialog.setObjectName(u"OpenWalletDialog")
+        OpenWalletDialog.resize(590, 301)
+        sizePolicy = QSizePolicy(QSizePolicy.Maximum, QSizePolicy.Maximum)
+        sizePolicy.setHorizontalStretch(0)
+        sizePolicy.setVerticalStretch(0)
+        sizePolicy.setHeightForWidth(OpenWalletDialog.sizePolicy().hasHeightForWidth())
+        OpenWalletDialog.setSizePolicy(sizePolicy)
+        OpenWalletDialog.setFocusPolicy(Qt.TabFocus)
+        OpenWalletDialog.setModal(True)
+        self.verticalLayout = QVBoxLayout(OpenWalletDialog)
+        self.verticalLayout.setSpacing(10)
+        self.verticalLayout.setObjectName(u"verticalLayout")
+        self.verticalLayout.setContentsMargins(20, 20, 20, 20)
+        self.horizontalLayout = QHBoxLayout()
+        self.horizontalLayout.setSpacing(10)
+        self.horizontalLayout.setObjectName(u"horizontalLayout")
+        self.label = QLabel(OpenWalletDialog)
+        self.label.setObjectName(u"label")
+        sizePolicy1 = QSizePolicy(QSizePolicy.Fixed, QSizePolicy.Fixed)
+        sizePolicy1.setHorizontalStretch(0)
+        sizePolicy1.setVerticalStretch(0)
+        sizePolicy1.setHeightForWidth(self.label.sizePolicy().hasHeightForWidth())
+        self.label.setSizePolicy(sizePolicy1)
+
+        self.horizontalLayout.addWidget(self.label)
+
+        self.walletFileEdit = QLineEdit(OpenWalletDialog)
+        self.walletFileEdit.setObjectName(u"walletFileEdit")
+        sizePolicy2 = QSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
+        sizePolicy2.setHorizontalStretch(0)
+        sizePolicy2.setVerticalStretch(0)
+        sizePolicy2.setHeightForWidth(self.walletFileEdit.sizePolicy().hasHeightForWidth())
+        self.walletFileEdit.setSizePolicy(sizePolicy2)
+        self.walletFileEdit.setMinimumSize(QSize(400, 0))
+
+        self.horizontalLayout.addWidget(self.walletFileEdit)
+
+        self.chooseWalletButton = QPushButton(OpenWalletDialog)
+        self.chooseWalletButton.setObjectName(u"chooseWalletButton")
+        sizePolicy1.setHeightForWidth(self.chooseWalletButton.sizePolicy().hasHeightForWidth())
+        self.chooseWalletButton.setSizePolicy(sizePolicy1)
+
+        self.horizontalLayout.addWidget(self.chooseWalletButton)
+
+        self.horizontalLayout.setStretch(1, 1)
+
+        self.verticalLayout.addLayout(self.horizontalLayout)
+
+        self.horizontalLayout_2 = QHBoxLayout()
+        self.horizontalLayout_2.setSpacing(10)
+        self.horizontalLayout_2.setObjectName(u"horizontalLayout_2")
+        self.label_2 = QLabel(OpenWalletDialog)
+        self.label_2.setObjectName(u"label_2")
+        sizePolicy1.setHeightForWidth(self.label_2.sizePolicy().hasHeightForWidth())
+        self.label_2.setSizePolicy(sizePolicy1)
+
+        self.horizontalLayout_2.addWidget(self.label_2)
+
+        self.passphraseEdit = QLineEdit(OpenWalletDialog)
+        self.passphraseEdit.setObjectName(u"passphraseEdit")
+        self.passphraseEdit.setMinimumSize(QSize(200, 0))
+        self.passphraseEdit.setEchoMode(QLineEdit.Password)
+
+        self.horizontalLayout_2.addWidget(self.passphraseEdit)
+
+        self.horizontalSpacer = QSpacerItem(90, 20, QSizePolicy.Fixed, QSizePolicy.Minimum)
+
+        self.horizontalLayout_2.addItem(self.horizontalSpacer)
+
+        self.horizontalLayout_2.setStretch(1, 1)
+
+        self.verticalLayout.addLayout(self.horizontalLayout_2)
+
+        self.verticalSpacer = QSpacerItem(20, 150, QSizePolicy.Minimum, QSizePolicy.Minimum)
+
+        self.verticalLayout.addItem(self.verticalSpacer)
+
+        self.horizontalLayout_3 = QHBoxLayout()
+        self.horizontalLayout_3.setSpacing(10)
+        self.horizontalLayout_3.setObjectName(u"horizontalLayout_3")
+        self.horizontalSpacer_2 = QSpacerItem(40, 20, QSizePolicy.Expanding, QSizePolicy.Minimum)
+
+        self.horizontalLayout_3.addItem(self.horizontalSpacer_2)
+
+        self.buttonBox = QDialogButtonBox(OpenWalletDialog)
+        self.buttonBox.setObjectName(u"buttonBox")
+        self.buttonBox.setOrientation(Qt.Horizontal)
+        self.buttonBox.setStandardButtons(QDialogButtonBox.Cancel|QDialogButtonBox.Ok)
+
+        self.horizontalLayout_3.addWidget(self.buttonBox)
+
+        self.horizontalLayout_3.setStretch(0, 1)
+
+        self.verticalLayout.addLayout(self.horizontalLayout_3)
+
+        self.verticalLayout.setStretch(2, 1)
+        QWidget.setTabOrder(self.passphraseEdit, self.chooseWalletButton)
+        QWidget.setTabOrder(self.chooseWalletButton, self.walletFileEdit)
+
+        self.retranslateUi(OpenWalletDialog)
+        self.buttonBox.accepted.connect(OpenWalletDialog.accept)
+        self.buttonBox.rejected.connect(OpenWalletDialog.reject)
+
+        QMetaObject.connectSlotsByName(OpenWalletDialog)
+    # setupUi
+
+    def retranslateUi(self, OpenWalletDialog):
+        OpenWalletDialog.setWindowTitle(QCoreApplication.translate("OpenWalletDialog", u"JoinMarket - Open Wallet", None))
+        self.label.setText(QCoreApplication.translate("OpenWalletDialog", u"Wallet:", None))
+        self.walletFileEdit.setText(QCoreApplication.translate("OpenWalletDialog", u"wallet.jmdat", None))
+        self.walletFileEdit.setPlaceholderText("")
+        self.chooseWalletButton.setText(QCoreApplication.translate("OpenWalletDialog", u"Choose...", None))
+        self.label_2.setText(QCoreApplication.translate("OpenWalletDialog", u"Passphrase:", None))
+    # retranslateUi
+

--- a/jmqtui/jmqtui/open_wallet_dialog.ui
+++ b/jmqtui/jmqtui/open_wallet_dialog.ui
@@ -1,0 +1,236 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>OpenWalletDialog</class>
+ <widget class="QDialog" name="OpenWalletDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>590</width>
+    <height>301</height>
+   </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Maximum" vsizetype="Maximum">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
+  <property name="focusPolicy">
+   <enum>Qt::TabFocus</enum>
+  </property>
+  <property name="windowTitle">
+   <string>JoinMarket - Open Wallet</string>
+  </property>
+  <property name="modal">
+   <bool>true</bool>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout" stretch="0,0,1,0">
+   <property name="spacing">
+    <number>10</number>
+   </property>
+   <property name="leftMargin">
+    <number>20</number>
+   </property>
+   <property name="topMargin">
+    <number>20</number>
+   </property>
+   <property name="rightMargin">
+    <number>20</number>
+   </property>
+   <property name="bottomMargin">
+    <number>20</number>
+   </property>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout" stretch="0,1,0">
+     <property name="spacing">
+      <number>10</number>
+     </property>
+     <item>
+      <widget class="QLabel" name="label">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string>Wallet:</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLineEdit" name="walletFileEdit">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>400</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="text">
+        <string>wallet.jmdat</string>
+       </property>
+       <property name="placeholderText">
+        <string/>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="chooseWalletButton">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string>Choose...</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_2" stretch="0,1,0">
+     <property name="spacing">
+      <number>10</number>
+     </property>
+     <item>
+      <widget class="QLabel" name="label_2">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string>Passphrase:</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLineEdit" name="passphraseEdit">
+       <property name="minimumSize">
+        <size>
+         <width>200</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="echoMode">
+        <enum>QLineEdit::Password</enum>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeType">
+        <enum>QSizePolicy::Fixed</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>90</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeType">
+      <enum>QSizePolicy::Minimum</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>150</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_3" stretch="1,0">
+     <property name="spacing">
+      <number>10</number>
+     </property>
+     <item>
+      <spacer name="horizontalSpacer_2">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QDialogButtonBox" name="buttonBox">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="standardButtons">
+        <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <tabstops>
+  <tabstop>passphraseEdit</tabstop>
+  <tabstop>chooseWalletButton</tabstop>
+  <tabstop>walletFileEdit</tabstop>
+ </tabstops>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>OpenWalletDialog</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>248</x>
+     <y>254</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>157</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>OpenWalletDialog</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>316</x>
+     <y>260</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>286</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/jmqtui/setup.py
+++ b/jmqtui/setup.py
@@ -1,0 +1,16 @@
+from setuptools import setup
+import os
+
+setup(name='joinmarketui',
+      version='0.9.2dev',
+      description='Joinmarket client library for Bitcoin coinjoins',
+      url='http://github.com/Joinmarket-Org/joinmarket-clientserver/jmfg',
+      author='',
+      author_email='',
+      license='GPL',
+      packages=['jmqtui'],
+      install_requires=['PyQt5!=5.15.0,!=5.15.1,!=5.15.2,!=6.0'],
+      python_requires='>=3.6',
+      zip_safe=False)
+
+os.system('pyside2-uic jmqtui/open_wallet_dialog.ui -o jmqtui/open_wallet_dialog.py')

--- a/jmqtui/setup.py
+++ b/jmqtui/setup.py
@@ -4,7 +4,7 @@ import os
 setup(name='joinmarketui',
       version='0.9.2dev',
       description='Joinmarket client library for Bitcoin coinjoins',
-      url='http://github.com/Joinmarket-Org/joinmarket-clientserver/jmfg',
+      url='https://github.com/JoinMarket-Org/joinmarket-clientserver/tree/master/jmqtui',
       author='',
       author_email='',
       license='GPL',

--- a/requirements/gui.txt
+++ b/requirements/gui.txt
@@ -5,3 +5,5 @@ PySide2!=5.15.0,!=5.15.1,!=5.15.2,!=6.0
 PyQt5!=5.15.0,!=5.15.1,!=5.15.2,!=6.0
 qrcode[pil]
 https://github.com/sunu/qt5reactor/archive/58410aaead2185e9917ae9cac9c50fe7b70e4a60.zip#egg=qt5reactor
+
+-e ./jmqtui

--- a/scripts/joinmarket-qt.py
+++ b/scripts/joinmarket-qt.py
@@ -108,6 +108,25 @@ handler = QtHandler()
 handler.setFormatter(logging.Formatter("%(levelname)s:%(message)s"))
 log.addHandler(handler)
 
+
+from jmqtui import Ui_OpenWalletDialog
+class JMOpenWalletDialog(QDialog, Ui_OpenWalletDialog):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.setupUi(self)
+
+        self.chooseWalletButton.clicked.connect(self.chooseWalletFile)
+
+    def chooseWalletFile(self):
+        wallets_path = os.path.join(jm_single().datadir, 'wallets')
+        (filename, _) = QFileDialog.getOpenFileName(self,
+                                                'Choose Wallet File',
+                                                wallets_path,
+                                                options=QFileDialog.DontUseNativeDialog)
+        if filename:
+            self.walletFileEdit.setText(filename)
+
+
 class HelpLabel(QLabel):
 
     def __init__(self, text, help_text, wtitle):
@@ -2354,6 +2373,25 @@ mainWindow.setWindowTitle(appWindowTitle + suffix)
 tabWidget.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
 mainWindow.setCentralWidget(tabWidget)
 tabWidget.currentChanged.connect(onTabChange)
+
 mainWindow.show()
 reactor.runReturn()
+
+# Upon launching the app, allow the user to choose a wallet to open
+openWalletDialog = JMOpenWalletDialog()
+openWalletDialog.show()
+
+if openWalletDialog.exec_() == QDialog.Accepted:
+    wallet_path = openWalletDialog.walletFileEdit.text()
+    if not os.path.isabs(wallet_path):
+        wallet_path = os.path.join(jm_single().datadir, 'wallets', wallet_path)
+    
+    try:
+        mainWindow.loadWalletFromBlockchain(wallet_path, openWalletDialog.passphraseEdit.text())
+    except Exception as e:
+        JMQtMessageBox(None,
+                    str(e),
+                    mbtype='warn',
+                    title="Error")
+
 sys.exit(app.exec_())

--- a/test/lint/lint-python.sh
+++ b/test/lint/lint-python.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 # Based on Bitcoin Core's test/lint/lint-python.sh
 
+# The python files in jmqtui/jmqtui are auto generated.
+EXCLUDE_PATTERNS="jmqtui/jmqtui/*.py"
+
 if ! command -v flake8 > /dev/null; then
     echo "Skipping Python linting since flake8 is not installed."
     exit 0
@@ -10,7 +13,7 @@ elif flake8 --version | grep -q "Python 2"; then
 fi
 
 if [[ $# == 0 ]]; then
-    flake8 $(git ls-files "*.py")
+    flake8 $(git ls-files "*.py") --extend-exclude "${EXCLUDE_PATTERNS}"
 else
     flake8 "$@"
 fi


### PR DESCRIPTION
Updated PR Description
---

### The Open Wallet dialog

1. Upon launching the app, an Open Wallet dialog is displayed, allowing the user to enter the passphrase directly and press `Enter` key or the "OK" button to open the default wallet.

![image](https://user-images.githubusercontent.com/87334822/126019254-2b96c1ce-08f9-4c56-af4d-63c9dd5549a3.png)

2. User can use the "Choose..." button to select a different wallet to open.
3. User can press `ESC` key or the "Cancel" button to dismiss the Dialog.
4. The OpenWallet dialog is a Modal dialog, user has to dismiss the dialog first before they can interact with the main window.

### Next step improvements

1. Show all the error messages, like "Wrong Password", "File not exist", "Invalid wallet file" etc., within the same dialog, and allow the user to make changes to their decisions in the same dialog when these errors occur.
1. Update the UX of menu action "Wallet -> Load" to also use this new Open Wallet dialog.
1. Add a "Create Wallet" button to the dialog so that user can choose to create a new wallet as well in the same dialog. However, before that, **we need a redesign of the existing UX about creating a new wallet first.** The current UX consists of a series of different popups, ideally, we would show all the steps in the same dialog so that user doesn't have to jump from popup to popup.
1. The OpenWallet dialog is pre-populated with `wallet.jmdat`. We should remember the last-opened wallet and show that instead.
1. Consider delay the showing of the main window until after the user has made a decision with the "Open Wallet Dialog"



Original Draft PR Description Below 
--- 

I'm trying to implement a "open/create wallet" dialog (#930) to improve the user experience. And I think it would be a good idea for us to utilize Qt Designer for the UI Design in general:

![image](https://user-images.githubusercontent.com/87334822/125917665-41ac61fb-0a6e-49c9-ba96-3c2ca07983c3.png)

The "open wallet dialog" looks like this when running:
![image](https://user-images.githubusercontent.com/87334822/125919491-12da9f6a-dcf0-4974-a6e6-4e11e5d8ccff.png)


I believe this will make future adjustments of the UI easier, and it gives us a nice separation between the program logic and the UI layout.

However, before moving forward, I'd like to make sure I'm on the right track and that we can agree on the utilization of Qt Designer. So please let me know if you have any concerns.

(The `open_wallet_dialog.py` is generated by `pyside2-uic` based on `open_wallet_dialog.ui`, and that `open_wallet_dialog.ui` can be opened directly in Qt Designer, which can be installed on all major desktop platforms: Windows/macOS/Linux)  

Thanks!