### PR TITLE
Center the joinmarket-qt window and make the default size larger.

### DIFF
--- a/scripts/joinmarket-qt.py
+++ b/scripts/joinmarket-qt.py
@@ -1593,9 +1593,25 @@ class JMMainWindow(QMainWindow):
         else:
             event.ignore()
 
+    def resizeAndCenter(self):
+        # Resize the window base on the desktop size
+        default_width = 1000
+        default_height = 800
+
+        desktop_rect = QDesktopWidget().availableGeometry()
+        self.resize(
+            default_width if default_width < desktop_rect.width() - 100 else desktop_rect.width() - 100,
+            default_height if default_height < desktop_rect.height() - 100 else desktop_rect.height() - 100
+        )
+
+        # Center the window
+        window_rect = self.frameGeometry()
+        window_rect.moveCenter(desktop_rect.center())
+        self.move(window_rect.topLeft())
+
     def initUI(self):
         self.statusBar().showMessage("Ready")
-        self.setGeometry(300, 300, 250, 150)
+        self.resizeAndCenter()
         loadAction = QAction('&Load...', self)
         loadAction.setStatusTip('Load wallet from file')
         loadAction.triggered.connect(self.selectWallet)
@@ -2330,7 +2346,6 @@ tabWidget.addTab(SpendTab(), "Coinjoins")
 tabWidget.addTab(TxHistoryTab(), "Tx History")
 tabWidget.addTab(CoinsTab(), "Coins")
 
-mainWindow.resize(600, 500)
 if get_network() == 'testnet':
     suffix = ' - Testnet'
 elif get_network() == 'signet':


### PR DESCRIPTION
1. Increase the default size of QT window from 600x500 to 1000x800, but no larger than (desktop_width - 100) x (desktop_height - 100).
2. Move the QT window to the center of the desktop upon launch.

With both this PR and #932, the app looks like this upon launching:

![image](https://user-images.githubusercontent.com/87334822/126248338-0522b717-28a8-4bbb-96a3-39298d9e934b.png)
