### PR TITLE
Remove unused imports in test/ygrunner.py

### DIFF
--- a/test/ygrunner.py
+++ b/test/ygrunner.py
@@ -11,14 +11,14 @@
    --btcpwd=123456abcdef --btcconf=/blah/bitcoin.conf \
    --nirc=2 -s test/ygrunner.py
    '''
-from twisted.internet import task, reactor
+from twisted.internet import task
 from common import make_wallets
 import pytest
 import random
 from datetime import datetime
 from jmbase import jmprint
 from jmclient import YieldGeneratorBasic, load_test_config, jm_single,\
-    JMClientProtocolFactory, start_reactor, SegwitWallet, WalletService,\
+    JMClientProtocolFactory, start_reactor, SegwitWallet,\
     SegwitLegacyWallet, cryptoengine, SNICKERClientProtocolFactory, SNICKERReceiver
 from jmclient.wallet_utils import wallet_gettimelockaddress
 


### PR DESCRIPTION
```
$ ./test/lint/lint-python.sh 
test/ygrunner.py:14:1: F401 'twisted.internet.reactor' imported but unused
test/ygrunner.py:20:1: F401 'jmclient.WalletService' imported but unused
2     F401 'twisted.internet.reactor' imported but unused
```

These were introduced with #872.