### PR TITLE
secp256k1 version bump

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -252,8 +252,8 @@ libsecp256k1_build()
 
 libsecp256k1_install()
 {
-    secp256k1_lib_tar='0d9540b13ffcd7cd44cc361b8744b93d88aa76ba'
-    secp256k1_lib_sha="0803d2dddbf6dd702c379118f066f638bcef6b07eea959f12d31ad2f4721fbe1"
+    secp256k1_lib_tar='f2d9aeae6d5a7c7fbbba8bbb38b1849b784beef7'
+    secp256k1_lib_sha="bdcb0373cc830271733841cf507ad2bb95d61be558f5334c8ad304d127ee4da9"
     secp256k1_lib_url='https://github.com/bitcoin-core/secp256k1/archive'
     if ! dep_get "${secp256k1_lib_tar}.tar.gz" "${secp256k1_lib_sha}" "${secp256k1_lib_url}"; then
         return 1


### PR DESCRIPTION
Argument why use specific commit of secp256k1 was to have the same version as coincurve uses (https://github.com/JoinMarket-Org/joinmarket-clientserver/pull/536/files#r418937166). [Since January coincurve uses](https://github.com/ofek/coincurve/commit/871fbbdf82190b0dfcc5d21259ad4c104f5348a1) `f2d9aeae6d5a7c7fbbba8bbb38b1849b784beef7`.

Related - https://github.com/fort-nix/nix-bitcoin/pull/371.