### PR TITLE
Qt: By default auto-expand mixdepth 0

### DIFF
--- a/scripts/joinmarket-qt.py
+++ b/scripts/joinmarket-qt.py
@@ -1511,8 +1511,9 @@ class JMWalletTab(QWidget):
             # if expansion states existed, reinstate them:
             if len(previous_expand_states) == max_mixdepth_count:
                 m_item.setExpanded(previous_expand_states[mixdepth][0])
-            # by default, if the balance of the mix depth is greater than 0, expand it
-            elif float(mdbalance) > 0:
+            # by default, if the mixdepth is 0 or balance of the mixdepth is
+            # greater than 0, expand it
+            elif mixdepth == 0 or float(mdbalance) > 0:
                 m_item.setExpanded(True)
 
             for forchange in [0, 1]:


### PR DESCRIPTION
Restore pre-#934 behaviour in this regard. See discussion in #937.