### PR TITLE
Refactor: use term "passphrase" instead of "password" for JM wallets everywhere, for consistency

### DIFF
--- a/jmbase/jmbase/__init__.py
+++ b/jmbase/jmbase/__init__.py
@@ -1,6 +1,6 @@
 
 from .support import (get_log, chunks, debug_silence, jmprint,
-                      joinmarket_alert, core_alert, get_password,
+                      joinmarket_alert, core_alert, get_passphrase,
                       set_logging_level, set_logging_color,
                       lookup_appdata_folder, bintohex, bintolehex,
                       hextobin, lehextobin, utxostr_to_utxo,

--- a/jmbase/jmbase/support.py
+++ b/jmbase/jmbase/support.py
@@ -203,11 +203,11 @@ def set_logging_color(colored=False):
 def chunks(d, n):
     return [d[x:x + n] for x in range(0, len(d), n)]
 
-def get_password(msg): #pragma: no cover
-    password = getpass(msg)
-    if not isinstance(password, bytes):
-        password = password.encode('utf-8')
-    return password
+def get_passphrase(msg): #pragma: no cover
+    passphrase = getpass(msg)
+    if not isinstance(passphrase, bytes):
+        passphrase = passphrase.encode('utf-8')
+    return passphrase
 
 def lookup_appdata_folder(appname):
     """ Given an appname as a string,

--- a/jmclient/jmclient/__init__.py
+++ b/jmclient/jmclient/__init__.py
@@ -19,7 +19,7 @@ from .wallet import (Mnemonic, estimate_tx_fee, WalletError, BaseWallet, ImportW
                      UTXOManager, WALLET_IMPLEMENTATIONS, compute_tx_locktime,
                      UnknownAddressForLabel)
 from .storage import (Argon2Hash, Storage, StorageError, RetryableStorageError,
-                      StoragePasswordError, VolatileStorage)
+                      StoragePassphraseError, VolatileStorage)
 from .cryptoengine import (BTCEngine, BTC_P2PKH, BTC_P2SH_P2WPKH, BTC_P2WPKH, EngineError,
                            TYPE_P2PKH, TYPE_P2SH_P2WPKH, TYPE_P2WPKH, detect_script_type)
 from .configure import (load_test_config, process_shutdown,

--- a/jmclient/jmclient/cli_options.py
+++ b/jmclient/jmclient/cli_options.py
@@ -43,11 +43,12 @@ def add_base_options(parser):
                       default=False,
                       help=('choose to do detailed wallet sync, '
                             'used for recovering on new Core instance.'))
+    # keep "wallet-password-stdin" (not passphrase) to not break compatibility
     parser.add_option('--wallet-password-stdin',
                       action='store_true',
                       default=False,
                       dest='wallet_password_stdin',
-                      help='Read wallet password from stdin')
+                      help='Read wallet passphrase (password) from stdin')
     parser.add_option('--version',
                       action='callback',
                       callback=print_jm_version,

--- a/jmclient/jmclient/storage.py
+++ b/jmclient/jmclient/storage.py
@@ -9,12 +9,12 @@ from .support import get_random_bytes
 
 
 class Argon2Hash(object):
-    def __init__(self, password, salt=None, hash_len=32, salt_len=16,
+    def __init__(self, passphrase, salt=None, hash_len=32, salt_len=16,
                  time_cost=500, memory_cost=1000, parallelism=4,
                  argon2_type=low_level.Type.I, version=19):
         """
         args:
-          password: password as bytes
+          passphrase: passphrase as bytes
           salt: salt in bytes or None to create random one, must have length >= 8
           hash_len: generated hash length in bytes
           salt_len: salt length in bytes, ignored if salt is not None, must be >= 8
@@ -33,7 +33,7 @@ class Argon2Hash(object):
             'version': version
         }
         self.salt = salt if salt is not None else get_random_bytes(salt_len)
-        self.hash = low_level.hash_secret_raw(password, self.salt,
+        self.hash = low_level.hash_secret_raw(passphrase, self.salt,
                                               **self.settings)
 
 
@@ -45,7 +45,7 @@ class RetryableStorageError(StorageError):
     pass
 
 
-class StoragePasswordError(RetryableStorageError):
+class StoragePassphraseError(RetryableStorageError):
     pass
 
 
@@ -69,11 +69,11 @@ class Storage(object):
     ENC_KEY_BYTES = 32  # AES-256
     SALT_LENGTH = 16
 
-    def __init__(self, path, password=None, create=False, read_only=False):
+    def __init__(self, path, passphrase=None, create=False, read_only=False):
         """
         args:
           path: file path to storage
-          password: bytes or None for unencrypted file
+          passphrase: bytes or None for unencrypted file
           create: create file if it does not exist
           read_only: do not change anything on the file system
         """
@@ -88,7 +88,7 @@ class Storage(object):
 
         if not os.path.isfile(path):
             if create and not read_only:
-                self._create_new(password)
+                self._create_new(passphrase)
                 self._save_file()
                 self.newly_created = True
             else:
@@ -96,7 +96,7 @@ class Storage(object):
         elif create:
             raise StorageError("File already exists.")
         else:
-            self._load_file(password)
+            self._load_file(passphrase)
 
         assert self.data is not None
         assert self._data_checksum is not None
@@ -115,13 +115,13 @@ class Storage(object):
         """
         return self._data_checksum != self._get_data_checksum()
 
-    def check_password(self, password):
-        return self._hash.hash == self._hash_password(password, self._hash.salt).hash
+    def check_passphrase(self, passphrase):
+        return self._hash.hash == self._hash_passphrase(passphrase, self._hash.salt).hash
 
-    def change_password(self, password):
+    def change_passphrase(self, passphrase):
         if self.read_only:
-            raise StorageError("Cannot change password of read-only file.")
-        self._set_hash(password)
+            raise StorageError("Cannot change passphrase of read-only file.")
+        self._set_hash(passphrase)
         self._save_file()
 
     def save(self):
@@ -156,15 +156,15 @@ class Storage(object):
     def _update_data_hash(self):
         self._data_checksum = self._get_data_checksum()
 
-    def _create_new(self, password):
+    def _create_new(self, passphrase):
         self.data = {}
-        self._set_hash(password)
+        self._set_hash(passphrase)
 
-    def _set_hash(self, password):
-        if password is None:
+    def _set_hash(self, passphrase):
+        if passphrase is None:
             self._hash = None
         else:
-            self._hash = self._hash_password(password)
+            self._hash = self._hash_passphrase(passphrase)
 
     def _save_file(self):
         assert self.read_only == False
@@ -175,7 +175,7 @@ class Storage(object):
         self._write_file(magic + enc_data)
         self._update_data_hash()
 
-    def _load_file(self, password):
+    def _load_file(self, passphrase):
         data = self._read_file()
         assert len(self.MAGIC_ENC) == len(self.MAGIC_UNENC) == 8
         magic = data[:8]
@@ -186,9 +186,9 @@ class Storage(object):
         data = data[8:]
 
         if magic == self.MAGIC_ENC:
-            if password is None:
-                raise RetryableStorageError("Password required to open wallet.")
-            data = self._decrypt_file(password, data)
+            if passphrase is None:
+                raise RetryableStorageError("Passphrase required to open wallet.")
+            data = self._decrypt_file(passphrase, data)
         else:
             assert magic == self.MAGIC_UNENC
 
@@ -241,14 +241,14 @@ class Storage(object):
         }
         return self._serialize(container)
 
-    def _decrypt_file(self, password, data):
-        assert password is not None
+    def _decrypt_file(self, passphrase, data):
+        assert passphrase is not None
 
         container = self._deserialize(data)
         assert b'enc' in container
         assert b'data' in container
 
-        self._hash = self._hash_password(password, container[b'enc'][b'salt'])
+        self._hash = self._hash_passphrase(passphrase, container[b'enc'][b'salt'])
 
         return self._decrypt(container[b'data'], container[b'enc'][b'iv'])
 
@@ -267,16 +267,16 @@ class Storage(object):
             dec_data = decrypter.feed(data)
             dec_data += decrypter.feed()
         except ValueError:
-            # in most "wrong password" cases the pkcs7 padding will be wrong
-            raise StoragePasswordError("Wrong password.")
+            # in most "wrong passphrase" cases the pkcs7 padding will be wrong
+            raise StoragePassphraseError("Wrong passphrase.")
 
         if not dec_data.startswith(self.MAGIC_DETECT_ENC):
-            raise StoragePasswordError("Wrong password.")
+            raise StoragePassphraseError("Wrong passphrase.")
         return dec_data[len(self.MAGIC_DETECT_ENC):]
 
     @classmethod
-    def _hash_password(cls, password, salt=None):
-        return Argon2Hash(password, salt,
+    def _hash_passphrase(cls, passphrase, salt=None):
+        return Argon2Hash(passphrase, salt,
                           hash_len=cls.ENC_KEY_BYTES, salt_len=cls.SALT_LENGTH)
 
     def _create_lock(self):
@@ -325,12 +325,12 @@ class VolatileStorage(Storage):
     This exists for easier testing.
     """
 
-    def __init__(self, password=None, data=None):
+    def __init__(self, passphrase=None, data=None):
         self.file_data = None
-        super().__init__('VOLATILE', password, create=True)
+        super().__init__('VOLATILE', passphrase, create=True)
         if data:
             self.file_data = data
-            self._load_file(password)
+            self._load_file(passphrase)
 
     def _create_lock(self):
         pass

--- a/jmclient/jmclient/wallet.py
+++ b/jmclient/jmclient/wallet.py
@@ -971,10 +971,10 @@ class BaseWallet(object):
         raise NotImplementedError()
 
     def check_wallet_passphrase(self, passphrase):
-        return self._storage.check_password(passphrase)
+        return self._storage.check_passphrase(passphrase)
 
     def change_wallet_passphrase(self, passphrase):
-        self._storage.change_password(passphrase)
+        self._storage.change_passphrase(passphrase)
 
     def yield_imported_paths(self, mixdepth):
         """

--- a/jmclient/test/test_storage.py
+++ b/jmclient/test/test_storage.py
@@ -25,7 +25,7 @@ class MockStorage(storage.Storage):
 
 
 def test_storage():
-    s = MockStorage(None, 'nonexistant', b'password', create=True)
+    s = MockStorage(None, 'nonexistant', b'passphrase', create=True)
     assert s.file_data.startswith(s.MAGIC_ENC)
     assert s.locked
     assert s.is_encrypted()
@@ -40,19 +40,19 @@ def test_storage():
     enc_data = s.file_data
 
     old_data = s.file_data
-    s.change_password(b'newpass')
+    s.change_passphrase(b'newpass')
     assert s.is_encrypted()
     assert not s.was_changed()
     assert s.file_data != old_data
 
     old_data = s.file_data
-    s.change_password(None)
+    s.change_passphrase(None)
     assert not s.is_encrypted()
     assert not s.was_changed()
     assert s.file_data != old_data
     assert s.file_data.startswith(s.MAGIC_UNENC)
 
-    s2 = MockStorage(enc_data, __file__, b'password')
+    s2 = MockStorage(enc_data, __file__, b'passphrase')
     assert s2.locked
     assert s2.is_encrypted()
     assert not s2.was_changed()
@@ -61,29 +61,29 @@ def test_storage():
 
 def test_storage_invalid():
     with pytest.raises(storage.StorageError):
-        MockStorage(None, 'nonexistant', b'password')
+        MockStorage(None, 'nonexistant', b'passphrase')
         pytest.fail("File does not exist")
 
-    s = MockStorage(None, 'nonexistant', b'password', create=True)
+    s = MockStorage(None, 'nonexistant', b'passphrase', create=True)
     with pytest.raises(storage.StorageError):
         MockStorage(s.file_data, __file__, b'wrongpass')
-        pytest.fail("Wrong password")
+        pytest.fail("Wrong passphrase")
 
     with pytest.raises(storage.StorageError):
         MockStorage(s.file_data, __file__)
-        pytest.fail("No password")
+        pytest.fail("No passphrase")
 
     with pytest.raises(storage.StorageError):
         MockStorage(b'garbagefile', __file__)
         pytest.fail("Non-wallet file, unencrypted")
 
     with pytest.raises(storage.StorageError):
-        MockStorage(b'garbagefile', __file__, b'password')
+        MockStorage(b'garbagefile', __file__, b'passphrase')
         pytest.fail("Non-wallet file, encrypted")
 
 def test_storage_readonly():
-    s = MockStorage(None, 'nonexistant', b'password', create=True)
-    s = MockStorage(s.file_data, __file__, b'password', read_only=True)
+    s = MockStorage(None, 'nonexistant', b'passphrase', create=True)
+    s = MockStorage(s.file_data, __file__, b'passphrase', read_only=True)
     s.data[b'mydata'] = b'test'
 
     assert not s.locked
@@ -93,7 +93,7 @@ def test_storage_readonly():
         s.save()
 
     with pytest.raises(storage.StorageError):
-        s.change_password(b'newpass')
+        s.change_passphrase(b'newpass')
 
 
 def test_storage_lock(tmpdir):

--- a/jmclient/test/test_wallet.py
+++ b/jmclient/test/test_wallet.py
@@ -954,24 +954,24 @@ def test_calculate_timelocked_fidelity_bond_value(setup_wallet):
     for vd in value_diff:
         assert abs(vd) < EPSILON
 
-@pytest.mark.parametrize('password, wallet_cls', [
+@pytest.mark.parametrize('passphrase, wallet_cls', [
     ["hunter2", SegwitLegacyWallet],
     ["hunter2", SegwitWallet],
 ])
-def test_create_wallet(setup_wallet, password, wallet_cls):
+def test_create_wallet(setup_wallet, passphrase, wallet_cls):
     wallet_name = test_create_wallet_filename
-    password = password.encode("utf-8")
+    passphrase = passphrase.encode("utf-8")
     # test mainnet (we are not transacting)
     btc.select_chain_params("bitcoin")
-    wallet = create_wallet(wallet_name, password, 4, wallet_cls)
+    wallet = create_wallet(wallet_name, passphrase, 4, wallet_cls)
     mnemonic = wallet.get_mnemonic_words()[0]
     firstkey = wallet.get_key_from_addr(wallet.get_addr(0,0,0))
     print("Created mnemonic, firstkey: ", mnemonic, firstkey)
     wallet.close()
-    # ensure that the wallet file created is openable with the password,
+    # ensure that the wallet file created is openable with the passphrase,
     # and has the parameters that were claimed on creation:
     new_wallet = open_test_wallet_maybe(wallet_name, "", 4,
-                        password=password, ask_for_password=False)
+                        passphrase=passphrase, ask_for_passphrase=False)
     assert new_wallet.get_mnemonic_words()[0] == mnemonic
     assert new_wallet.get_key_from_addr(
         new_wallet.get_addr(0,0,0)) == firstkey

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -76,4 +76,4 @@ As above.
 
 ### genwallet.py
 
-Non-interactively generate a wallet, giving only wallet name and password. Returns wallet seed as `recovery_seed:`. Useful for automating JoinMarket deployments.
+Non-interactively generate a wallet, giving only wallet name and passphrase. Returns wallet seed as `recovery_seed:`. Useful for automating JoinMarket deployments.

--- a/scripts/genwallet.py
+++ b/scripts/genwallet.py
@@ -16,8 +16,8 @@ log = get_log()
 
 def main():
     parser = OptionParser(
-        usage='usage: %prog [options] wallet_file_name [password]',
-        description='Create a wallet with the given wallet name and password.'
+        usage='usage: %prog [options] wallet_file_name [passphrase]',
+        description='Create a wallet with the given wallet name and passphrase.'
     )
     add_base_options(parser)
     parser.add_option(
@@ -30,9 +30,9 @@ def main():
     (options, args) = parser.parse_args()
     wallet_name = args[0]
     if options.wallet_password_stdin:
-        password = wallet_utils.read_password_stdin()
+        passphrase = wallet_utils.read_passphrase_stdin()
     else:
-        assert len(args) > 1, "must provide password via stdin (see --help), or as second argument."
+        assert len(args) > 1, "must provide passphrase via stdin (see --help), or as second argument."
         password = args[1].encode("utf-8")
     seed = options.seed_file and Path(options.seed_file).read_text().rstrip()
 
@@ -45,7 +45,7 @@ def main():
         # Fidelity Bonds are not available for segwit legacy wallets
         walletclass = SegwitLegacyWallet
     entropy = seed and SegwitLegacyWallet.entropy_from_mnemonic(seed)
-    wallet = create_wallet(wallet_path, password, wallet_utils.DEFAULT_MIXDEPTH, walletclass, entropy=entropy)
+    wallet = create_wallet(wallet_path, passphrase, wallet_utils.DEFAULT_MIXDEPTH, walletclass, entropy=entropy)
     jmprint("recovery_seed:{}"
          .format(wallet.get_mnemonic_words()[0]), "important")
     wallet.close()

--- a/scripts/joinmarket-qt.py
+++ b/scripts/joinmarket-qt.py
@@ -78,7 +78,7 @@ from jmclient.wallet import BaseWallet
 
 from qtsupport import ScheduleWizard, TumbleRestartWizard, config_tips,\
     config_types, QtHandler, XStream, Buttons, OkButton, CancelButton,\
-    PasswordDialog, MyTreeWidget, JMQtMessageBox, BLUE_FG,\
+    PassphraseDialog, MyTreeWidget, JMQtMessageBox, BLUE_FG,\
     donation_more_message, BitcoinAmountEdit, JMIntValidator,\
     ReceiveBIP78Dialog, QRCodePopup
 
@@ -1955,7 +1955,7 @@ class JMMainWindow(QMainWindow):
                 "wallet.jmdat",
                 display_seed_callback=None,
                 enter_seed_callback=self.seedEntry,
-                enter_wallet_password_callback=self.getPassword,
+                enter_wallet_passphrase_callback=self.getPassphrase,
                 enter_wallet_file_name_callback=self.getWalletFileName,
                 enter_if_use_seed_extension=None,
                 enter_seed_extension_callback=None,
@@ -2012,7 +2012,7 @@ class JMMainWindow(QMainWindow):
             while not decrypted:
                 text, ok = QInputDialog.getText(self,
                                                 'Decrypt wallet',
-                                                'Enter your password:',
+                                                'Enter your passphrase:',
                                                 echo=QLineEdit.Password)
                 if not ok:
                     return
@@ -2047,7 +2047,7 @@ class JMMainWindow(QMainWindow):
             wallet_path = get_wallet_path(str(firstarg), None)
             try:
                 wallet = open_test_wallet_maybe(wallet_path, str(firstarg),
-                        None, ask_for_password=False, password=pwd.encode('utf-8') if pwd else None,
+                        None, ask_for_passphrase=False, passphrase=pwd.encode('utf-8') if pwd else None,
                         gap_limit=jm_single().config.getint("GUI", "gaplimit"))
             except RetryableStorageError as e:
                 if rethrow:
@@ -2168,7 +2168,7 @@ class JMMainWindow(QMainWindow):
                            mbtype="crit", title="Error")
             return
         if not (self.checkPassphrase()
-                and wallet_change_passphrase(self.wallet_service, self.getPassword)):
+                and wallet_change_passphrase(self.wallet_service, self.getPassphrase)):
             JMQtMessageBox(self, "Failed to change passphrase.",
                            title="Error", mbtype="warn")
             return
@@ -2201,8 +2201,8 @@ class JMMainWindow(QMainWindow):
                            mbtype='info',
                            title="Error")
 
-    def getPassword(self):
-        pd = PasswordDialog()
+    def getPassphrase(self):
+        pd = PassphraseDialog()
         while True:
             for child in pd.findChildren(QLineEdit):
                 child.clear()
@@ -2223,8 +2223,8 @@ class JMMainWindow(QMainWindow):
                                title="Error")
                 continue
             break
-        self.textpassword = str(pd.new_pw.text())
-        return self.textpassword.encode('utf-8')
+        self.textpassphrase = str(pd.new_pw.text())
+        return self.textpassphrase.encode('utf-8')
 
     def getWalletFileName(self):
         walletname, ok = QInputDialog.getText(self, 'Choose wallet name',
@@ -2280,7 +2280,7 @@ class JMMainWindow(QMainWindow):
                     "generate", wallets_path, "wallet.jmdat",
                     display_seed_callback=self.displayWords,
                     enter_seed_callback=None,
-                    enter_wallet_password_callback=self.getPassword,
+                    enter_wallet_passphrase_callback=self.getPassphrase,
                     enter_wallet_file_name_callback=self.getWalletFileName,
                     enter_if_use_seed_extension=self.promptUseMnemonicExtension,
                     enter_seed_extension_callback=self.promptInputMnemonicExtension,
@@ -2296,7 +2296,7 @@ class JMMainWindow(QMainWindow):
 
             JMQtMessageBox(self, 'Wallet saved to ' + self.walletname,
                            title="Wallet created")
-        self.loadWalletFromBlockchain(self.walletname, pwd=self.textpassword)
+        self.loadWalletFromBlockchain(self.walletname, pwd=self.textpassphrase)
 
 def get_wallet_printout(wallet_service):
     """Given a WalletService object, retrieve the list of

--- a/scripts/qtsupport.py
+++ b/scripts/qtsupport.py
@@ -281,44 +281,44 @@ class CancelButton(QPushButton):
         self.clicked.connect(dialog.reject)
 
 
-def check_password_strength(password):
+def check_passphrase_strength(passphrase):
     '''
-    Check the strength of the password entered by the user and return back the same
-    :param password: password entered by user in New Password
-    :return: password strength Weak or Medium or Strong
+    Check the strength of the passphrase entered by the user and return back the same
+    :param passphrase: passphrase entered by user in New Passphrase
+    :return: passphrase strength Weak or Medium or Strong
     '''
-    n = math.log(len(set(password)))
-    num = re.search("[0-9]", password) is not None and re.match(
-        "^[0-9]*$", password) is None
-    caps = password != password.upper() and password != password.lower()
-    extra = re.match("^[a-zA-Z0-9]*$", password) is None
-    score = len(password) * (n + caps + num + extra) / 20
-    password_strength = {0: "Weak", 1: "Medium", 2: "Strong", 3: "Very Strong"}
-    return password_strength[min(3, int(score))]
+    n = math.log(len(set(passphrase)))
+    num = re.search("[0-9]", passphrase) is not None and re.match(
+        "^[0-9]*$", passphrase) is None
+    caps = passphrase != passphrase.upper() and passphrase != passphrase.lower()
+    extra = re.match("^[a-zA-Z0-9]*$", passphrase) is None
+    score = len(passphrase) * (n + caps + num + extra) / 20
+    passphrase_strength = {0: "Weak", 1: "Medium", 2: "Strong", 3: "Very Strong"}
+    return passphrase_strength[min(3, int(score))]
 
 
-def update_password_strength(pw_strength_label, password):
+def update_passphrase_strength(pw_strength_label, passphrase):
     '''
-    call the function check_password_strength and update the label pw_strength 
-    interactively as the user is typing the password
+    call the function check_passphrase_strength and update the label pw_strength 
+    interactively as the user is typing the passphrase
     :param pw_strength_label: the label pw_strength
-    :param password: password entered in New Password text box
+    :param passphrase: passphrase entered in New Passphrase text box
     :return: None
     '''
-    if password:
+    if passphrase:
         colors = {"Weak": "Red",
                   "Medium": "Blue",
                   "Strong": "Green",
                   "Very Strong": "Green"}
-        strength = check_password_strength(password)
-        label = "Password Strength"+ ": "+"<font color=" + \
+        strength = check_passphrase_strength(passphrase)
+        label = "Passphrase Strength"+ ": "+"<font color=" + \
         colors[strength] + ">" + strength + "</font>"
     else:
         label = ""
     pw_strength_label.setText(label)
 
 
-def make_password_dialog(self, msg):
+def make_passphrase_dialog(self, msg):
 
     self.new_pw = QLineEdit()
     self.new_pw.setEchoMode(QLineEdit.EchoMode(2))
@@ -355,18 +355,18 @@ def make_password_dialog(self, msg):
     grid.addWidget(self.conf_pw, 2, 1)
     vbox.addLayout(grid)
 
-    #Password Strength Label
+    #Passphrase Strength Label
     self.pw_strength = QLabel()
     grid.addWidget(self.pw_strength, 3, 0, 1, 2)
     self.new_pw.textChanged.connect(
-        lambda: update_password_strength(self.pw_strength, self.new_pw.text()))
+        lambda: update_passphrase_strength(self.pw_strength, self.new_pw.text()))
 
     vbox.addStretch(1)
     vbox.addLayout(Buttons(CancelButton(self), OkButton(self)))
     return vbox
 
 
-class PasswordDialog(QDialog):
+class PassphraseDialog(QDialog):
 
     def __init__(self):
         super().__init__()
@@ -375,7 +375,7 @@ class PasswordDialog(QDialog):
     def initUI(self):
         self.setWindowTitle('Create a new passphrase')
         msg = "Enter a new passphrase"
-        self.setLayout(make_password_dialog(self, msg))
+        self.setLayout(make_passphrase_dialog(self, msg))
         self.show()
 
 

--- a/test/common.py
+++ b/test/common.py
@@ -64,7 +64,6 @@ def make_wallets(n,
                  start_index=0,
                  fixed_seeds=None,
                  test_wallet=False,
-                 passwords=None,
                  walletclass=SegwitWallet,
                  mixdepths=5,
                  fb_indices=[]):
@@ -80,7 +79,6 @@ def make_wallets(n,
        if walletclass=SegwitWallet.
        Returns: a dict of dicts of form {0:{'seed':seed,'wallet':Wallet object},1:..,}
        Default Wallet constructor is joinmarket.Wallet, else use TestWallet,
-       which takes a password parameter as in the list passwords.
        '''
     # FIXME: this is basically the same code as jmclient/test/commontest.py
     if len(wallet_structures) != n:
@@ -94,11 +92,6 @@ def make_wallets(n,
     for i in range(n):
         assert len(seeds[i]) == BIP32Wallet.ENTROPY_BYTES * 2
 
-        # FIXME: pwd is ignored (but do we really need this anyway?)
-        if test_wallet and passwords and i < len(passwords):
-            pwd = passwords[i]
-        else:
-            pwd = None
         if i in fb_indices:
             assert walletclass == SegwitWallet, "Cannot use FB except for native segwit."
             wc = WALLET_IMPLEMENTATIONS[get_configured_wallet_type(True)]


### PR DESCRIPTION
Re-opened and rebased #916 (I accidentally deleted my JM forked repo, could not figure out how to rebase in that PR).