### PR TITLE
Better error message in case of invalid joinmarket.cfg format

### DIFF
--- a/jmclient/jmclient/configure.py
+++ b/jmclient/jmclient/configure.py
@@ -591,8 +591,14 @@ def load_program_config(config_path="", bs=None, plugin_services=[]):
         global_singleton.datadir, global_singleton.config_location)
 
     remove_unwanted_default_settings(global_singleton.config)
-    loadedFiles = global_singleton.config.read([global_singleton.config_location
-                                               ])
+    try:
+        loadedFiles = global_singleton.config.read(
+            [global_singleton.config_location])
+    except UnicodeDecodeError:
+        jmprint("Error loading `joinmarket.cfg`, invalid file format.",
+            "info")
+        sys.exit(EXIT_FAILURE)
+
     #Hack required for electrum; must be able to enforce a different
     #blockchain interface even in default/new load.
     if bs:


### PR DESCRIPTION
Better handle situations when there is random noise in `joinmarket.cfg`. Happened on my RPi test box with likely dying SD card or filesystem corruption.

Before:
```
User data location: /home/bitcoin/.joinmarket/
Traceback (most recent call last):
  File "./scripts/wallet-tool.py", line 6, in <module>
    jmprint(wallet_tool_main("wallets"), "success")
  File "/home/bitcoin/joinmarket/jmclient/jmclient/wallet_utils.py", line 1447, in wallet_tool_main
    load_program_config(config_path=options.datadir)
  File "/home/bitcoin/joinmarket/jmclient/jmclient/configure.py", line 594, in load_program_config
    loadedFiles = global_singleton.config.read([global_singleton.config_location
  File "/usr/lib/python3.8/configparser.py", line 697, in read
    self._read(fp, filename)
  File "/usr/lib/python3.8/configparser.py", line 1017, in _read
    for lineno, line in enumerate(fp, start=1):
  File "/usr/lib/python3.8/codecs.py", line 322, in decode
    (result, consumed) = self._buffer_decode(data, self.errors, final)
UnicodeDecodeError: 'utf-8' codec can't decode byte 0x97 in position 0: invalid start byte
```
After:
```
User data location: /home/bitcoin/.joinmarket/
Error loading `joinmarket.cfg`, invalid file format.
```
Could be tested by doing:
```
$ head -c 500 /dev/urandom > ~/.joinmarket/joinmarket.cfg
```