### PR TITLE
Qt: Uppercase simple bech32 BIP21 URI's for QR code encoding

### DIFF
--- a/scripts/joinmarket-qt.py
+++ b/scripts/joinmarket-qt.py
@@ -72,7 +72,8 @@ from jmclient import load_program_config, get_network, update_persist_config,\
     BTCEngine, FidelityBondMixin, wallet_change_passphrase, \
     parse_payjoin_setup, send_payjoin, JMBIP78ReceiverManager, \
     detect_script_type, general_custom_change_warning, \
-    nonwallet_custom_change_warning, sweep_custom_change_warning, EngineError
+    nonwallet_custom_change_warning, sweep_custom_change_warning, EngineError,\
+    TYPE_P2WPKH
 from jmclient.wallet import BaseWallet
 
 from qtsupport import ScheduleWizard, TumbleRestartWizard, config_tips,\
@@ -1461,7 +1462,17 @@ class JMWalletTab(QWidget):
             menu.exec_(self.walletTree.viewport().mapToGlobal(position))
 
     def openQRCodePopup(self, address):
-        popup = QRCodePopup(self, address, btc.encode_bip21_uri(address, {}))
+        bip21_uri = btc.encode_bip21_uri(address, {})
+        # From BIP173 (bech32) spec:
+        #   For presentation, lowercase is usually preferable, but inside
+        #   QR codes uppercase SHOULD be used, as those permit the use of
+        #   alphanumeric mode, which is 45% more compact than the normal
+        #   byte mode.
+        # So we keep case for QR popup title, but convert BIP21 URI to be
+        # encoded in QR code to uppercase, if possible.
+        if detect_script_type(mainWindow.wallet_service.addr_to_script(address)) == TYPE_P2WPKH:
+            bip21_uri = bip21_uri.upper()
+        popup = QRCodePopup(self, address, bip21_uri)
         popup.show()
 
     def updateWalletInfo(self, walletinfo=None):


### PR DESCRIPTION
From [BIP173](https://github.com/bitcoin/bips/blob/master/bip-0173.mediawiki):

> For presentation, lowercase is usually preferable, but inside QR codes uppercase SHOULD be used, as those permit the use of alphanumeric mode, which is 45% more compact than the normal byte mode.

This is possible only for simple address QR code popups in wallet view, but not for payjoins, as only schema part of [BIP21](https://github.com/bitcoin/bips/blob/master/bip-0021.mediawiki) is case-insenstive, parameters aren't.

> The scheme component ("bitcoin:") is case-insensitive, and implementations must accept any combination of uppercase and lowercase letters. The rest of the URI is case-sensitive, including the query parameter keys.