### PR TITLE
Show "available balance" along side total balance.

### DIFF
--- a/scripts/joinmarket-qt.py
+++ b/scripts/joinmarket-qt.py
@@ -1556,9 +1556,8 @@ class JMWalletTab(QWidget):
             # if expansion states existed, reinstate them:
             if len(previous_expand_states) == max_mixdepth_count:
                 m_item.setExpanded(previous_expand_states[mixdepth][0])
-            # by default, if the mixdepth is 0 or balance of the mixdepth is
-            # greater than 0, expand it
-            elif mixdepth == 0 or float(mdbalance) > 0:
+            # we expand at the mixdepth level by default
+            else:
                 m_item.setExpanded(True)
 
             for address_type in [


### PR DESCRIPTION
1. If an address has any disabled UTXO, display a `[FROZEN]` tag next to the address in wallet-display
2. If an address has any unconfirmed UTXO, display a `[PENDING]` tag next to the address in wallet-display
3. If the fund is **locked** in the fidelity bond, or is **frozen**, it is considered **"unavailable balance"** 
4. If the fund is **pending**, it is still considered **"available balance"** 
4. If there is any unavailable balance, show two numbers: the "available balance", and the "total balance"

Works in both the terminal and the QT client.