### PR TITLE
Update Agora Tor host to onion v3

### DIFF
--- a/jmclient/jmclient/configure.py
+++ b/jmclient/jmclient/configure.py
@@ -163,7 +163,7 @@ socks5_port = 9050
 #socks5_port = 9050
 #
 ##for tor
-##host = agora3cdw6kdty5y.onion
+##host = vxecvd6lc4giwtasjhgbrr3eop6pzq6i5rveracktioneunalgqlwfad.onion
 ##port = 6667
 ##usessl = false
 ##socks5 = true


### PR DESCRIPTION
Source - https://anarplex.net/agorairc/connect/

Probably also could be enabled by default again, haven't noticed any issues with it recently.