### PR TITLE
Message channel over c-lightning

### DIFF
--- a/docs/lightning-message-channels.md
+++ b/docs/lightning-message-channels.md
@@ -4,7 +4,11 @@
 
 1. [Purpose](#purpose)
 
-2. [Installing; checking your config and Tor setup](#config)
+2. [Installing c-lightning bundled, or using your pre-existing c-lightning.](#install)
+
+   i. [Choice B: bundled](#choiceb)
+
+   ii. [Choice A: non-bundled](#choicea)
 
 3. [Configure for signet](#signet)
 
@@ -21,15 +25,31 @@ The discussion of "more decentralized than just using IRC servers", for Joinmark
 Why Lightning and not just Tor? We gain a few things:
 
 * We can make connections between messaging and payments, or between actual coinjoins and Lightning payments. Neither of these probably works in the *simplest* way imaginable, but with a little sophistication this could be *tremendously* powerful (an obvious example: directory nodes could charge for their service on a per-message basis, not using Lightning payments inside the message flow, which is too slow, but based on Chaumian token issuance against earlier Lightning payments).
-* By using a plugin to a c-lightning node, we leverage the high quality, high performance of their C code to do a lot of heavy lifting. Passing messages over hops, using onion routing, is intrinsic to what their codebase has to provide (including, over Tor), so if we use the `sendonionmessage` between our nodes, we make use of that benefit.
+* By using a plugin to a c-lightning node, we leverage the high quality, high performance of their C code to do a lot of heavy lifting. Passing messages over hops, using onion routing, is intrinsic to what their codebase has to provide (including, over Tor), so if in future we use the `sendonionmessage` between our nodes, we make use of that benefit. For now we use the `sendcustommsg` feature which allows individual maker/taker bots to communicate directly, improving both the scalability and privacy of the coinjoin negotiations (though this is done opportunistically - falling back to E2E encrypted communications via the directory server, where the direct communication isn't possible).
 * There is an overlap in concept between *coinjoins* and *dual funding* in Lightning, since technically the latter *is* a class of the former. A natural question arises, hopefully one that can be answered over time: can we integrate Joinmarket style coinjoins into the dual funding process, or perhaps also single funding (some of this interacts with taproot, of course, so it's not a simple matter). Also related is recent work by @niftynei on "liquidity advertising", see e.g. [here](https://medium.com/blockstream/setting-up-liquidity-ads-in-c-lightning-54e4c59c091d).
 
 (c-lightning's [plugin architecture](https://lightning.readthedocs.io/PLUGINS.html) is a big part of what makes this relatively easy to implement; it means we have a very loose coupling via a simple plugin that forwards messages and notifications from the c-lightning node to joinmarket's jmdaemon, which is able to use it as "just another way of passing messages", basically).
 
 
-<a name="config" />
+<a name="install" />
 
-## Installing; checking your config and Tor setup.
+## Installing c-lightning bundled, or using your pre-existing c-lightning.
+
+If you are an existing user of Joinmarket, your choice here is:
+
+A. Use a c-lightning separately installed (which could be in use for payments, already, i.e. an active Lightning node), or:
+
+B. to let Joinmarket compile, build and install a "bundled" instance of c-lightning, inside Joinmarket itself (which will therefore be a pure networking/messaging component, not doing any payments, at least for now).
+
+Choice A is probably more flexible and "cleaner", over the long term, assuming you actually use Lightning for anything, or will do in future.
+
+Choice B is easier and requires less setup.
+
+<a name="choiceb" />
+
+### Choice B: bundled
+
+(B is first because it's easier!).
 
 If you are running this for the first time you need to go through a full install of Joinmarket using:
 
@@ -37,36 +57,86 @@ If you are running this for the first time you need to go through a full install
 a@b:/path/to/joinmarket-clientserver$ ./install.sh --with-ln-messaging
 ```
 
-and then follow the installation process as normal, including the final activation of the virtualenv. The `with-ln-messaging` flag will *compile* and install an instance of [c-lightning](https://github.com/ElementsProject/lightning) (the reason it must be compiled is that we use a currently experimental feature (onion messaging) not enabled in the release).
+and then follow the installation process as normal; note that it warns you that the c-lightning bundling isn't necessary, but go ahead and accept, because that's your choice here. As usual with this install process, don't forget the final step of activating the virtualenv. To be absolutely clear: the `with-ln-messaging` flag will *compile* and install an instance of [c-lightning](https://github.com/ElementsProject/lightning), locally (see below for where).
 
 Before starting up a coinjoin bot, examine the new config section which can be created by running `python wallet-tool.py somewallet.jmdat` as usual with your current `joinmarket.cfg` backed up to a different file name. You should see this new section:
 
 ```
 [MESSAGING:lightning1]
 type = ln-onion
+# Setting this .. <snipped comments>
+clightning-location = bundled
+# or (check your user has access rights):
+# clightning-location = /home/username/.lightning/bitcoin/lightning-rpc
 # This is a comma separated list (comma can be omitted if only one item).
 # Each item has format pubkey@host:port ; all are required. Host can be
 # a *.onion address (tor v3 only).
-directory-nodes = 0344bc51c0b0cf58ebfee222bdd8ff4855ac3becd7a9c8bff8ff08100771179047@mvm5ffyipzf4tis2g753w7q25evcqmvj6qnnwgr3dkpyukomykzvwuad.onion:9736
+directory-nodes = 033e65b76c4a3c0b907fddbc57822dbff1cf7ce48d341b8cfaf11bd324ea2d433d@45ojrjlrl2wh6yrnihlb2kl6    k752sonptt2rpuv4shbob7ubxkdcmdqd.onion:9736
 passthrough-port = 49101
 lightning-port = 9735
 ```
 
-The section name "lightning1" is not important, as this MESSAGING section is identified by its type `ln-onion`; there should be only one such (see below on directory-nodes - that's how we configure redundancy here, if desired). Apart from setting the directory nodes, there is usually no need to change the port settings, unless you are testing and want multiple bots running simultaneously; then, just make sure that `passthrough-port` values do not conflict.
+Notice that the `clightning-location = bundled` line is active (not commented out).
 
-### Tor setup.
+The section name "lightning1" is not important, as this MESSAGING section is identified by its type `ln-onion`; there should be **only one such** (see below on directory-nodes - that's how we configure redundancy here, if desired). Apart from setting the directory nodes, there is usually no need to change the port settings, unless you are testing and want multiple bots running simultaneously; then, just make sure that `passthrough-port` values do not conflict.
+
+#### Tor setup.
 
 Read through the introductory section on setting up c-lightning for Tor hidden/onion services [here](https://lightning.readthedocs.io/TOR.html#quick-start-on-linux); from the start of that subsection to the paragraph "If the above prints nothing and returns, then C-Lightning “should” work with your Tor." These steps will serve to ensure that your Tor is configured to allow c-lightning to use it. The rest of that document is not needed as it's handled by Joinmarket automatically.
 
-### OK, c-lightning is setup automatically; that's great, but where?
+#### OK, c-lightning is setup automatically, when 'bundled'; that's great, but where?
 
 First, the compiled binaries are in `joinmarket-clientserver/jmvenv/{bin,libexec}`. Second, the `lightning-dir` is set to `<jmdatadir>/lightning`, so that you will find it by default in `~/.joinmarket/lightning/config`. Given this consideration you might, in certain use cases, prefer to use a manually set separate joinmarket datadir, e.g. `python yg-privacyenhanced.py --datadir=/some/custom/location mywallet.jmdat`; remember this changes the location of all Joinmarket data too, including `joinmarket.cfg` and `wallets/`.
+
+<a name="choicea" />
+
+### Choice A: non-bundled
+
+This section won't explain how to [install c-lightning](https://github.com/ElementsProject/lightning). The current supported version is 0.10.2. Earlier versions may work but are not tested. Please use their existing excellent [documentation](https://github.com/ElementsProject/lightning/blob/master/doc/INSTALL.md) on how to install it, if necessary, before continuing.
+
+#### Config specific for Joinmarket.
+
+Lightning's own config by default is in `~/.lightning/config`. If you haven't already set one, do so now and here is an example that works fine for Joinmarket, on signet:
+
+```
+bitcoin-rpcconnect=127.0.0.1
+bitcoin-rpcport=38332
+bitcoin-rpcuser=bitcoinrpc
+bitcoin-rpcpassword=123456abcdef
+signet
+proxy=127.0.0.1:9050
+bind-addr=127.0.0.1:9736
+addr=statictor:127.0.0.1:9051/torport=9736
+always-use-proxy=true
+```
+
+The first part is orthogonal to JM, since you always need to configure your Bitcoin Core RPC to run anyway. The last 4 lines are how to set up the config to serve via an onion service on Tor, with default Tor control port, and in this case, specifying your Lightning-serving port as `9736`.
+
+In Joinmarket's config file, though, you must specify:
+
+```
+clightning-location = /home/username/.lightning/bitcoin/lightning-rpc
+```
+
+instead of the default value `bundled`; this tells Joinmarket how it can connect to Lightning's socket rpc file. Here `bitcoin` would be replaced with `signet` if you wanted to match the above example.
+
+You must also make sure the ports match: the `lightning-port` field in the `joinmarket.cfg` must correspond to your own c-lightning node, and the `passthrough-port` must be set as per the below subsection:
+
+#### Running lightningd with the jmcl.py plugin
+
+You must start or restart c-lightning with the following command line arguments (or dynamically load; see the [docs](https://lightning.readthedocs.io/PLUGINS.html#)):
+
+```
+lightningd --plugin=/path/to/joinmarket-clientserver/jmdaemon/jmdaemon/jmcl.py --jmport=49100
+```
+
+Other arguments are not specified here; either not needed because in the `config` file, or they are specific to your use case. Most important: the value specified here as `jmport` is exactly the port specified in `joinmarket.cfg` as `passthrough-port`. That's what allows c-lightning to talk to our Joinmarket messaging daemon.
 
 <a name="signet" />
 
 ## Configure for signet.
 
-There is no separate/special configuration for signet other than the configuration that is already needed for running Joinmarket against a signet backend (so e.g. RPC port of 38332). The correct configuration will automatically be ported into your embedded c-lightning instance.
+There is no separate/special configuration for signet other than the configuration that is already needed for running Joinmarket against a signet backend (so e.g. RPC port of 38332). The correct configuration will automatically be ported into your embedded c-lightning instance. If you want to help with testing, please setup either regtest or signet.
 
 <a name="directory" />
 
@@ -74,7 +144,7 @@ There is no separate/special configuration for signet other than the configurati
 
 ### As a non-directory nodes
 
-Enter the directory nodes you want to use in `joinmarket.cfg` as per above, comma separated. They must always be pubkey@host:port, whether onion or not. Or just keep the defaults you are given. The default currently as of Oct 2021 is a signet serving directory node.
+Enter the directory nodes you want to use in `joinmarket.cfg` as per above, comma separated. They must always be pubkey@host:port, whether onion or not. Or just keep the defaults you are given. The default currently as of Oct 2021 is a signet serving directory node (see above default config).
 
 ### As a directory node.
 

--- a/docs/lightning-message-channels.md
+++ b/docs/lightning-message-channels.md
@@ -1,0 +1,81 @@
+# HOW TO SETUP LIGHTNING MESSAGE CHANNELS IN JOINMARKET
+
+### Contents
+
+1. [Purpose](#purpose)
+
+2. [Installing; checking your config and Tor setup](#config)
+
+3. [Configure for signet](#signet)
+
+4. [Directory nodes](#directory)
+
+<a name="purpose" />
+
+## Purpose
+
+You can skip this whole section if you just want to install the software and run it.
+
+The discussion of "more decentralized than just using IRC servers", for Joinmarket, has been ongoing for years and in particular the most recent extended discussion is to be found in [this issue thread](https://github.com/JoinMarket-Org/joinmarket-clientserver/issues/415).
+
+Why Lightning and not just Tor? We gain a few things:
+
+* We can make connections between messaging and payments, or between actual coinjoins and Lightning payments. Neither of these probably works in the *simplest* way imaginable, but with a little sophistication this could be *tremendously* powerful (an obvious example: directory nodes could charge for their service on a per-message basis, not using Lightning payments inside the message flow, which is too slow, but based on Chaumian token issuance against earlier Lightning payments).
+* By using a plugin to a c-lightning node, we leverage the high quality, high performance of their C code to do a lot of heavy lifting. Passing messages over hops, using onion routing, is intrinsic to what their codebase has to provide (including, over Tor), so if we use the `sendonionmessage` between our nodes, we make use of that benefit.
+* There is an overlap in concept between *coinjoins* and *dual funding* in Lightning, since technically the latter *is* a class of the former. A natural question arises, hopefully one that can be answered over time: can we integrate Joinmarket style coinjoins into the dual funding process, or perhaps also single funding (some of this interacts with taproot, of course, so it's not a simple matter). Also related is recent work by @niftynei on "liquidity advertising", see e.g. [here](https://medium.com/blockstream/setting-up-liquidity-ads-in-c-lightning-54e4c59c091d).
+
+(c-lightning's [plugin architecture](https://lightning.readthedocs.io/PLUGINS.html) is a big part of what makes this relatively easy to implement; it means we have a very loose coupling via a simple plugin that forwards messages and notifications from the c-lightning node to joinmarket's jmdaemon, which is able to use it as "just another way of passing messages", basically).
+
+
+<a name="config" />
+
+## Installing; checking your config and Tor setup.
+
+If you are running this for the first time you need to go through a full install of Joinmarket using:
+
+```
+a@b:/path/to/joinmarket-clientserver$ ./install.sh --with-ln-messaging
+```
+
+and then follow the installation process as normal, including the final activation of the virtualenv. The `with-ln-messaging` flag will *compile* and install an instance of [c-lightning](https://github.com/ElementsProject/lightning) (the reason it must be compiled is that we use a currently experimental feature (onion messaging) not enabled in the release).
+
+Before starting up a coinjoin bot, examine the new config section which can be created by running `python wallet-tool.py somewallet.jmdat` as usual with your current `joinmarket.cfg` backed up to a different file name. You should see this new section:
+
+```
+[MESSAGING:lightning1]
+type = ln-onion
+# This is a comma separated list (comma can be omitted if only one item).
+# Each item has format pubkey@host:port ; all are required. Host can be
+# a *.onion address (tor v3 only).
+directory-nodes = 0344bc51c0b0cf58ebfee222bdd8ff4855ac3becd7a9c8bff8ff08100771179047@mvm5ffyipzf4tis2g753w7q25evcqmvj6qnnwgr3dkpyukomykzvwuad.onion:9736
+passthrough-port = 49101
+lightning-port = 9735
+```
+
+The section name "lightning1" is not important, as this MESSAGING section is identified by its type `ln-onion`; there should be only one such (see below on directory-nodes - that's how we configure redundancy here, if desired). Apart from setting the directory nodes, there is usually no need to change the port settings, unless you are testing and want multiple bots running simultaneously; then, just make sure that `passthrough-port` values do not conflict.
+
+### Tor setup.
+
+Read through the introductory section on setting up c-lightning for Tor hidden/onion services [here](https://lightning.readthedocs.io/TOR.html#quick-start-on-linux); from the start of that subsection to the paragraph "If the above prints nothing and returns, then C-Lightning “should” work with your Tor." These steps will serve to ensure that your Tor is configured to allow c-lightning to use it. The rest of that document is not needed as it's handled by Joinmarket automatically.
+
+### OK, c-lightning is setup automatically; that's great, but where?
+
+First, the compiled binaries are in `joinmarket-clientserver/jmvenv/{bin,libexec}`. Second, the `lightning-dir` is set to `<jmdatadir>/lightning`, so that you will find it by default in `~/.joinmarket/lightning/config`. Given this consideration you might, in certain use cases, prefer to use a manually set separate joinmarket datadir, e.g. `python yg-privacyenhanced.py --datadir=/some/custom/location mywallet.jmdat`; remember this changes the location of all Joinmarket data too, including `joinmarket.cfg` and `wallets/`.
+
+<a name="signet" />
+
+## Configure for signet.
+
+There is no separate/special configuration for signet other than the configuration that is already needed for running Joinmarket against a signet backend (so e.g. RPC port of 38332). The correct configuration will automatically be ported into your embedded c-lightning instance.
+
+<a name="directory" />
+
+## Directory nodes
+
+### As a non-directory nodes
+
+Enter the directory nodes you want to use in `joinmarket.cfg` as per above, comma separated. They must always be pubkey@host:port, whether onion or not. Or just keep the defaults you are given. The default currently as of Oct 2021 is a signet serving directory node.
+
+### As a directory node.
+
+This requires a long running bot, best on some VPS or other reliable setup. There is one change required: in `jmclient.configure.start_ln`, where the `lnconfiglines` are written, change from `autotor` to `statictor` (you can keep the entire rest of the configuration the same. This means that every time you restart you will use the same `.onion` address, which is of course necessary here. Further, make this `.onion` (in the correct pubkey@host:port format) be the only entry in `directory-nodes` in your Joinmarket.cfg. When you start up you will see a message `this is the genesis node` which will confirm to you that you are running as a directory. (Note, this will change to be more flexible shortly, probably with a specific config flag).

--- a/docs/lightning-message-channels.md
+++ b/docs/lightning-message-channels.md
@@ -158,7 +158,11 @@ A note: in this early stage, the usage of Lightning is only really network-layer
 
 There is one change required: in `jmclient.configure.start_ln`, where the `lnconfiglines` are written, change from `autotor` to `statictor` (you can keep the entire rest of the configuration the same. This means that every time you restart you will use the same `.onion` address, which is of course necessary here. Further, make this `.onion` (in the correct pubkey@host:port format) be the only entry in `directory-nodes` in your Joinmarket.cfg. When you start up you will see a message `this is the genesis node` which will confirm to you that you are running as a directory. (Note, this will change to be more flexible shortly, probably with a specific config flag).
 
-#### Bundled or not?
+##### Question: How to configure the `directory-nodes` list in our `joinmarket.cfg` for this directory node bot?
+
+Answer: **you must only enter your own node in this list!** (otherwise you may find your bot infinitely rebroadcasting messages).
+
+#### Question: Bundled or not?
 
 (See above in this document for what 'bundled' means here and how to configure). Answer: It should work both ways.
 

--- a/install.sh
+++ b/install.sh
@@ -320,7 +320,7 @@ libsecp256k1_install()
 
 clightning_build ()
 {
-    ./configure \
+    PG_CONFIG="" ./configure \
         --enable-developer \
         --enable-experimental-features \
         --prefix="${jm_root}"

--- a/install.sh
+++ b/install.sh
@@ -479,6 +479,19 @@ Options:
             with_qt='1'
         fi
     fi
+    if [[ ${with_ln_messaging} ]]; then
+        read -p "
+        INFO: Installing c-lightning is not needed
+        if you already have your own c-lightning node,
+        accessible over RPC. Are you sure you want to
+        build and install a bundled copy of c-lightning
+        in Joinmarket? [y|n]: "
+        if [[ ${REPLY} =~ y|Y ]]; then
+            with_ln_messaging='1'
+        else
+            with_ln_messaging='0'
+        fi
+    fi
 }
 
 os_is_deb ()

--- a/install.sh
+++ b/install.sh
@@ -183,6 +183,7 @@ venv_setup ()
     pip install --upgrade setuptools
     pip install mako
     pip install mrkd
+    pip install mistune==0.8.4
     deactivate
 }
 

--- a/jmbase/setup.py
+++ b/jmbase/setup.py
@@ -10,6 +10,6 @@ setup(name='joinmarketbase',
       license='GPL',
       packages=['jmbase'],
       install_requires=['twisted==21.7.0', 'service-identity',
-                        'chromalog==1.0.5', 'pyln-client'],
+                        'chromalog==1.0.5', 'pyln-client==0.10.2post0'],
       python_requires='>=3.6',
       zip_safe=False)

--- a/jmbase/setup.py
+++ b/jmbase/setup.py
@@ -10,6 +10,6 @@ setup(name='joinmarketbase',
       license='GPL',
       packages=['jmbase'],
       install_requires=['twisted==21.7.0', 'service-identity',
-                        'chromalog==1.0.5'],
+                        'chromalog==1.0.5', 'pyln-client'],
       python_requires='>=3.6',
       zip_safe=False)

--- a/jmclient/jmclient/__init__.py
+++ b/jmclient/jmclient/__init__.py
@@ -24,7 +24,7 @@ from .cryptoengine import (BTCEngine, BTC_P2PKH, BTC_P2SH_P2WPKH, BTC_P2WPKH, En
                            TYPE_P2PKH, TYPE_P2SH_P2WPKH, TYPE_P2WPKH, detect_script_type)
 from .configure import (load_test_config, process_shutdown,
     load_program_config, jm_single, get_network, update_persist_config,
-    validate_address, is_burn_destination, get_irc_mchannels,
+    validate_address, is_burn_destination, get_mchannels,
     get_blockchain_interface_instance, set_config, is_segwit_mode,
     is_native_segwit_mode, JMPluginService, get_interest_rate, get_bondless_makers_allowance)
 from .blockchaininterface import (BlockchainInterface,

--- a/jmclient/jmclient/client_protocol.py
+++ b/jmclient/jmclient/client_protocol.py
@@ -15,7 +15,7 @@ import os
 import sys
 from jmbase import (get_log, EXIT_FAILURE, hextobin, bintohex,
                     utxo_to_utxostr, bdict_sdict_convert)
-from jmclient import (jm_single, get_irc_mchannels,
+from jmclient import (jm_single, get_mchannels,
                       RegtestBitcoinCoreInterface,
                       SNICKERReceiver, process_shutdown)
 import jmbitcoin as btc
@@ -434,7 +434,7 @@ class JMMakerClientProtocol(JMClientProtocol):
                                                    "blockchain_source")
         #needed only for channel naming convention
         network = jm_single().config.get("BLOCKCHAIN", "network")
-        irc_configs = get_irc_mchannels()
+        irc_configs = get_mchannels()
         #only here because Init message uses this field; not used by makers TODO
         minmakers = jm_single().config.getint("POLICY", "minimum_makers")
         maker_timeout_sec = jm_single().maker_timeout_sec
@@ -600,7 +600,7 @@ class JMTakerClientProtocol(JMClientProtocol):
                                                    "blockchain_source")
         #needed only for channel naming convention
         network = jm_single().config.get("BLOCKCHAIN", "network")
-        irc_configs = get_irc_mchannels()
+        irc_configs = get_mchannels()
         minmakers = jm_single().config.getint("POLICY", "minimum_makers")
         maker_timeout_sec = jm_single().maker_timeout_sec
 

--- a/jmclient/jmclient/client_protocol.py
+++ b/jmclient/jmclient/client_protocol.py
@@ -434,7 +434,7 @@ class JMMakerClientProtocol(JMClientProtocol):
                                                    "blockchain_source")
         #needed only for channel naming convention
         network = jm_single().config.get("BLOCKCHAIN", "network")
-        irc_configs = get_mchannels()
+        irc_configs = self.factory.get_mchannels()
         #only here because Init message uses this field; not used by makers TODO
         minmakers = jm_single().config.getint("POLICY", "minimum_makers")
         maker_timeout_sec = jm_single().maker_timeout_sec
@@ -600,7 +600,7 @@ class JMTakerClientProtocol(JMClientProtocol):
                                                    "blockchain_source")
         #needed only for channel naming convention
         network = jm_single().config.get("BLOCKCHAIN", "network")
-        irc_configs = get_mchannels()
+        irc_configs = self.factory.get_mchannels()
         minmakers = jm_single().config.getint("POLICY", "minimum_makers")
         maker_timeout_sec = jm_single().maker_timeout_sec
 
@@ -792,6 +792,14 @@ class JMClientProtocolFactory(protocol.ClientFactory):
 
     def buildProtocol(self, addr):
         return self.protocol(self, self.client)
+
+    def get_mchannels(self):
+        """ A transparent wrapper that allows override,
+        so that a script can return a customised set of
+        message channel configs; currently used for testing
+        multiple bots on regtest.
+        """
+        return get_mchannels()
 
 def start_reactor(host, port, factory=None, snickerfactory=None,
                   bip78=False, jm_coinjoin=True, ish=True,

--- a/jmclient/jmclient/configure.py
+++ b/jmclient/jmclient/configure.py
@@ -153,13 +153,28 @@ socks5 = false
 # be only ONE such message channel configured (note the directory servers
 # can be multiple, below):
 type = ln-onion
+
+# Setting this to any value apart from the default, 'bundled':
+# This indicates to Joinmarket that the c-lightning executable is
+# already running on your machine and we instead use the contents
+# of this variable as the location of the RPC socket file for lightning.
+# By default it is found in ~/.lightning/[network]/lightning-rpc,
+# where [network] is one of bitcoin, signet, testnet, regtest.
+# Be sure to read the documentation at docs/lightning-message-channels.md
+# to find out how to run the Joinmarket plugin jmcl.py inside your c-lightning instance,
+# and configure the correct "TCP passthrough port" for it (see `passthrough-port` below).
+clightning-location = bundled
+# or (check your user has access rights):
+# clightning-location = /home/username/.lightning/bitcoin/lightning-rpc
+
 # This is a comma separated list (comma can be omitted if only one item).
 # Each item has format pubkey@host:port ; all are required. Host can be
 # a *.onion address (tor v3 only).
 directory-nodes = 0344bc51c0b0cf58ebfee222bdd8ff4855ac3becd7a9c8bff8ff08100771179047@mvm5ffyipzf4tis2g753w7q25evcqmvj6qnnwgr3dkpyukomykzvwuad.onion:9736
-# port via which we receive data from the c-lightning plugin:
+# The port via which we receive data from the c-lightning plugin; if not bundled,
+# make sure it matches what you set in the jmcl.py plugin:
 passthrough-port = 49100
-# this is the port serving lightning on your onion service:
+# this is the port serving lightning on your onion service, bundled or otherwise:
 lightning-port = 9735
 
 ## SERVER 4/4) ILITA IRC (Tor - disabled by default)
@@ -483,7 +498,8 @@ def get_mchannels():
               ("socks5", str), ("socks5_host", str), ("socks5_port", str)]
     lightning_fields = [("type", str), ("directory-nodes", str),
                         ("passthrough-port", int), ("lightning-rpc", str),
-                        ("lightning-hostname", str), ("lightning-port", int)]
+                        ("lightning-hostname", str), ("lightning-port", int),
+                        ("clightning-location", str)]
 
     configs = []
     for section in sections:
@@ -717,19 +733,34 @@ def load_program_config(config_path="", bs=None, plugin_services=[],
             if not os.path.exists(plogsdir):
                 os.makedirs(plogsdir)
             p.set_log_dir(plogsdir)
-    # if a ln-onion message channel was configured, we start the
-    # packaged/customised lightning daemon with the required ports
-    # in the background at the startup of each script.
+    # Check if a ln-onion message channel was configured:
     chans = get_mchannels()
     lnchans = [x for x in chans if "type" in x and x["type"] == "ln-onion"]
+    # only 1; multiple directories will be in the config:
     assert len(lnchans) < 2
     if lnchans and ln_backend_needed:
-        jm_ln_dir = os.path.join(global_singleton.datadir, "lightning")
-        if not os.path.exists(jm_ln_dir):
-            os.makedirs(jm_ln_dir)
-        start_ln(lnchans[0], jm_ln_dir)
+        lnchanconfig = lnchans[0]
+        if lnchanconfig["clightning-location"] == "bundled":
+            # The creation of a datadir and the startup of the daemon
+            # are considered not-needed if you are not running the bundled
+            # copy of c-lightning; you should have read the docs and set it up
+            # yourself otherwise (see the config comments).
+            jm_ln_dir = os.path.join(global_singleton.datadir, "lightning")
+            if not os.path.exists(jm_ln_dir):
+                os.makedirs(jm_ln_dir)
+            start_ln(lnchanconfig, jm_ln_dir)
+        else:
+            # we still need to set the location of the RPC to instantiate
+            # our LightningRpc object:
+            global_singleton.config.set(lnchanconfig["section-name"],
+                    "lightning-rpc", lnchanconfig["clightning-location"])
 
 def start_ln(chaninfo, jm_ln_dir):
+    """ If a LN message channel is configured with the
+    # "bundled" setting, we start the packaged/customised
+    # lightning daemon with the required ports
+    # in the background at the startup of each script.
+    """
     # First, we dynamically update this LN message chan
     # config section to include the location on which its
     # RPC socket will exist:
@@ -749,11 +780,13 @@ def start_ln(chaninfo, jm_ln_dir):
     floc = os.path.dirname(os.path.abspath(__file__))
     jmcl_loc = os.path.join(floc, "..", "..", "jmdaemon", "jmdaemon", "jmcl.py")
     command = [os.path.join(lightningd_loc, "lightningd"), "--plugin="+jmcl_loc,
-               "--jmport="+passthrough_port, "--lightning-dir=" + jm_ln_dir,
-               "--experimental-onion-messages"]
+               "--jmport="+passthrough_port, "--lightning-dir=" + jm_ln_dir]
     # testing needs static values:
     if brpc_net == "regtest":
-        fixed_key_str = "1212121212121212121212121212121212121212121212121212121212121211"
+        # just to save an extra var in tests, use the last digit of the
+        # passthrough port:
+        last_digit = str(chaninfo["passthrough-port"] % 10)
+        fixed_key_str = "121212121212121212121212121212121212121212121212121212121212121" + last_digit
         command.append("--dev-force-privkey="+fixed_key_str)
     # we need to create c-lightning's own config file, in lightningdir/config.
     # This requires the bitcoin rpc config also:
@@ -766,9 +799,13 @@ def start_ln(chaninfo, jm_ln_dir):
                      "bitcoin-rpcport=" + brpc_port,
                      "bitcoin-rpcuser=" + brpc_user,
                      "bitcoin-rpcpassword=" + brpc_password,
-                     brpc_net,
-                     "experimental-onion-messages",
-                     "proxy=127.0.0.1:9050",
+                     "network=" + brpc_net]
+    if brpc_net == "regtest":
+        lnconfiglines += ["addr=127.0.0.1:" + str(ln_serving_port),
+                          "log-level=debug",
+                          "log-file=" + jm_ln_dir + "/log"]
+    else:
+        lnconfiglines += ["proxy=127.0.0.1:9050",
                      "bind-addr=127.0.0.1:" + str(ln_serving_port),
                      "addr=autotor:127.0.0.1:9051/torport=" + str(ln_serving_port),
                      "always-use-proxy=true"]

--- a/jmclient/jmclient/configure.py
+++ b/jmclient/jmclient/configure.py
@@ -780,6 +780,9 @@ def load_program_config(config_path="", bs=None, plugin_services=[],
     lnchans = [x for x in chans if "type" in x and x["type"] == "ln-onion"]
     # only 1; multiple directories will be in this config section:
     assert len(lnchans) < 2
+    # The additional flag 'ln_backend_needed' exists to address
+    # the case of a user with Lightning configured, but doing a non-interactive
+    # operation; in this case, starting the Lightning backend is pointless.
     if lnchans and ln_backend_needed:
         lnchanconfig = lnchans[0]
         if lnchanconfig["clightning-location"] == "bundled":

--- a/jmclient/jmclient/configure.py
+++ b/jmclient/jmclient/configure.py
@@ -172,7 +172,7 @@ clightning-location = bundled
 # This is a comma separated list (comma can be omitted if only one item).
 # Each item has format pubkey@host:port ; all are required. Host can be
 # a *.onion address (tor v3 only).
-directory-nodes = 033e65b76c4a3c0b907fddbc57822dbff1cf7ce48d341b8cfaf11bd324ea2d433d@45ojrjlrl2wh6yrnihlb2kl6k752sonptt2rpuv4shbob7u    bxkdcmdqd.onion:9736
+directory-nodes = 033e65b76c4a3c0b907fddbc57822dbff1cf7ce48d341b8cfaf11bd324ea2d433d@45ojrjlrl2wh6yrnihlb2kl6k752sonptt2rpuv4shbob7ubxkdcmdqd.onion:9736
 # The port via which we receive data from the c-lightning plugin; if not bundled,
 # make sure it matches what you set in the jmcl.py plugin:
 passthrough-port = 49100

--- a/jmclient/jmclient/wallet_rpc.py
+++ b/jmclient/jmclient/wallet_rpc.py
@@ -159,6 +159,9 @@ class JMWalletDaemon(Service):
         # ensure shut down does not leave dangling services:
         atexit.register(self.stopService)
 
+    def get_client_factory(self):
+        return JMClientProtocolFactory(self.taker)
+
     def activate_coinjoin_state(self, state):
         """ To be set when a maker or taker
         operation is initialized; they cannot
@@ -393,7 +396,8 @@ class JMWalletDaemon(Service):
                         walletname=self.wallet_name,
                         token=encoded_token)
 
-    def taker_finished(self, res, fromtx=False, waittime=0.0, txdetails=None):
+    def taker_finished(self, res, fromtx=False,
+                               waittime=0.0, txdetails=None):
         # This is a slimmed down version compared with what is seen in
         # the CLI code, since that code encompasses schedules with multiple
         # entries; for now, the RPC only supports single joins.
@@ -868,13 +872,13 @@ class JMWalletDaemon(Service):
             self.taker = Taker(self.wallet_service, schedule,
                                max_cj_fee = max_cj_fee,
                                callbacks=(self.filter_orders_callback,
-                                          None,  self.taker_finished))
+                                None, self.taker_finished))
             # TODO ; this makes use of a pre-existing hack to allow
             # selectively disabling the stallMonitor function that checks
             # if transactions went through or not; here we want to cleanly
             # destroy the Taker after an attempt is made, successful or not.
             self.taker.testflag = True
-            self.clientfactory = JMClientProtocolFactory(self.taker)
+            self.clientfactory = self.get_client_factory()
 
             dhost, dport = self.check_daemon_ready()
 

--- a/jmclient/jmclient/yieldgenerator.py
+++ b/jmclient/jmclient/yieldgenerator.py
@@ -399,7 +399,7 @@ def ygmain(ygclass, nickserv_password='', gaplimit=6):
         parser.error('Needs a wallet')
         sys.exit(EXIT_ARGERROR)
 
-    load_program_config(config_path=options["datadir"])
+    load_program_config(config_path=options["datadir"], ln_backend_needed=True)
 
     # As per previous note, override non-default command line settings:
     for x in ["ordertype", "txfee_contribution", "txfee_contribution_factor",

--- a/jmdaemon/jmdaemon/__init__.py
+++ b/jmdaemon/jmdaemon/__init__.py
@@ -4,6 +4,7 @@ from .protocol import *
 from .enc_wrapper import as_init_encryption, decode_decrypt, \
     encrypt_encode, init_keypair, init_pubkey, get_pubkey, NaclError
 from .irc import IRCMessageChannel
+from .lnonion import LNOnionMessageChannel
 from jmbase.support import get_log
 from .message_channel import MessageChannel, MessageChannelCollection
 from .orderbookwatch import OrderbookWatch

--- a/jmdaemon/jmdaemon/jmcl.py
+++ b/jmdaemon/jmdaemon/jmcl.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+from pyln.client import Plugin
+import json
+import os
+from twisted.internet import reactor
+from twisted.internet.protocol import ReconnectingClientFactory
+from twisted.protocols.basic import LineReceiver
+
+""" jmcl - joinmarket over clightning.
+    This is deliberately a very "dumb" plugin.
+    It does almost nothing other than try to
+    forward messages, received as onionmessages,
+    from other nodes.
+    Messages are forwarded over a plain TCP socket
+    on localhost, using LineReceiver as the app-layer
+    way to distinguish individual messages.
+    In addition to forwarding messages, there are defined
+    a few "control messages", which relate to connected/
+    disconnected status of peers.
+"""
+
+class TCPPassthroughClientProtocol(LineReceiver):
+    def connectionMade(self):
+        plugin.log("Connection to joinmarketd backend established OK.")
+        plugin.is_connected_to_backend = True
+        self.send_message(self.starting_msg)
+
+    def dataReceived(self, data):
+        """ We're not currently receiving data from the backend.
+        """
+        self.transport.loseConnection()
+
+    def send_message(self, message: bytes) -> None:
+        self.sendLine(message)
+
+    def connectionLost(self, reason):
+        pass
+
+tcppp = TCPPassthroughClientProtocol()
+
+class TCPPassthroughClientFactory(ReconnectingClientFactory):
+    def buildProtocol(self, addr):
+        return tcppp
+    def clientConnectionLost(self, connector, reason):
+        if reactor.running:
+            ReconnectingClientFactory.clientConnectionLost(
+                self, connector, reason)
+    def clientConnectionFailed(self, connector, reason):
+        if reactor.running:
+            ReconnectingClientFactory.clientConnectionFailed(
+                self, connector, reason)
+
+def send_tcp_message(msg: bytes) -> None:
+    if plugin.is_connected_to_backend:
+        tcppp.send_message(msg)
+    else:
+        reactor.connectTCP("localhost", plugin.jmport,
+                           TCPPassthroughClientFactory())
+        tcppp.starting_msg = msg
+    
+def send_local_control_message(msgtype: int, text: str) -> None:
+    # Notice that this does *not* have the same format as those
+    # that come from the onionmessage calls:
+    msg = {"unknown_fields": [{"number": msgtype, "value": text}]}
+    send_tcp_message(json.dumps(msg).encode("utf-8"))
+
+plugin = Plugin(autopatch=False)
+plugin.is_connected_to_backend = False
+
+plugin.add_option("jmport",
+                  "49100",
+                  "TCP port for communication with joinmarketd",
+                  "int")
+
+@plugin.init()
+def init(options, configuration, plugin):
+    plugin.log("Plugin JMCL.py initialized")
+    plugin.jmport = options["jmport"]
+
+@plugin.subscribe("connect")
+def on_connect(plugin, id, address, **kwargs):
+    plugin.log("Received connect event for peer {}".format(id))
+    plugin.log("With address: {}".format(address))
+    send_local_control_message(785, id + "@" + address[
+        "address"] + ":" + str(address["port"]))
+
+@plugin.subscribe("disconnect")
+def on_disconnect(plugin, id, **kwargs):
+    plugin.log("Received disconnect event for peer {}".format(id))
+    send_local_control_message(787, id)
+
+@plugin.hook("onion_message")
+def on_onion_message(plugin, onion_message, **kwargs):
+    send_tcp_message(json.dumps(onion_message).encode("utf-8"))
+    return {"result": "continue"}
+
+def run():
+    # If we are not running inside lightningd we'll print usage
+    # and some information about the plugin.
+    if os.environ.get('LIGHTNINGD_PLUGIN', None) != '1':
+        return plugin.print_usage()
+    inner_run()
+
+def inner_run():
+    # iterate manually to shut down gracefully at the end:
+    try:
+        l = next(plugin.stdin.buffer)
+    except StopIteration:
+        reactor.stop()
+        return
+
+    plugin.buffer += l
+    msgs = plugin.buffer.split(b'\n\n')
+    if len(msgs) < 2:
+        reactor.callLater(0.0, inner_run)
+        return
+    plugin.buffer = plugin._multi_dispatch(msgs)
+    reactor.callLater(0.0, inner_run)
+
+plugin.buffer = b""
+reactor.callWhenRunning(run)
+reactor.run()
+

--- a/jmdaemon/jmdaemon/jmcl.py
+++ b/jmdaemon/jmdaemon/jmcl.py
@@ -1,10 +1,13 @@
 #!/usr/bin/env python3
 from pyln.client import Plugin
+from collections import namedtuple
+from urllib.parse import urlparse, parse_qs
+import socket
+import logging
 import json
 import os
-from twisted.internet import reactor
-from twisted.internet.protocol import ReconnectingClientFactory
-from twisted.protocols.basic import LineReceiver
+import re
+from binascii import hexlify
 
 """ jmcl - joinmarket over clightning.
     This is deliberately a very "dumb" plugin.
@@ -19,49 +22,148 @@ from twisted.protocols.basic import LineReceiver
     disconnected status of peers.
 """
 
-class TCPPassthroughClientProtocol(LineReceiver):
-    def connectionMade(self):
-        plugin.log("Connection to joinmarketd backend established OK.")
+# The following socket code is liberally copied from:
+# https://github.com/lightningd/plugins/blob/43fc3c6d34430bd46a332ff588df0feb66c4bc26/backup/socketbackend.py;
+# it extracts only the minimal required to:
+# (a) connect to a remote port
+# (b) send data *lines* to it (format allows us the receiver/server
+# to use `twisted.protocols.basic.LineReceiver`).
+
+# Total number of reconnection tries
+RECONNECT_TRIES=5
+
+# Delay in seconds between reconnections (initial)
+RECONNECT_DELAY=5
+
+# Scale delay factor after each failure
+RECONNECT_DELAY_BACKOFF=1.5
+
+HostPortInfo = namedtuple('HostPortInfo', ['host', 'port', 'addrtype'])
+SocketURLInfo = namedtuple('SocketURLInfo', ['target', 'proxytype', 'proxytarget'])
+
+# Network address type.
+class AddrType:
+    IPv4 = 0
+    IPv6 = 1
+    NAME = 2
+
+# Proxy type. Only SOCKS5 supported at the moment as this is sufficient for Tor.
+class ProxyType:
+    DIRECT = 0
+    SOCKS5 = 1
+
+def parse_host_port(path: str) -> HostPortInfo:
+    '''Parse a host:port pair.'''
+    if path.startswith('['): # bracketed IPv6 address
+        eidx = path.find(']')
+        if eidx == -1:
+            raise ValueError('Unterminated bracketed host address.')
+        host = path[1:eidx]
+        addrtype = AddrType.IPv6
+        eidx += 1
+        if eidx >= len(path) or path[eidx] != ':':
+            raise ValueError('Port number missing.')
+        eidx += 1
+    else:
+        eidx = path.find(':')
+        if eidx == -1:
+            raise ValueError('Port number missing.')
+        host = path[0:eidx]
+        if re.match('\d+\.\d+\.\d+\.\d+$', host): # matches IPv4 address format
+            addrtype = AddrType.IPv4
+        else:
+            addrtype = AddrType.NAME
+        eidx += 1
+
+    try:
+        port = int(path[eidx:])
+    except ValueError:
+        raise ValueError('Invalid port number')
+
+    return HostPortInfo(host=host, port=port, addrtype=addrtype)
+
+def parse_socket_url(destination: str) -> SocketURLInfo:
+    '''Parse a socket: URL to extract the information contained in it.'''
+    url = urlparse(destination)
+    if url.scheme != 'socket':
+        raise ValueError('Scheme for socket backend must be socket:...')
+
+    target = parse_host_port(url.path)
+
+    proxytype = ProxyType.DIRECT
+    proxytarget = None
+    # parse query parameters
+    # reject unknown parameters (currently all of them)
+    qs = parse_qs(url.query)
+    for (key, values) in qs.items():
+        if key == 'proxy': # proxy=socks5:127.0.0.1:9050
+            if len(values) != 1:
+                raise ValueError('Proxy can only have one value')
+
+            (ptype, ptarget) = values[0].split(':', 1)
+            if ptype != 'socks5':
+                raise ValueError('Unknown proxy type ' + ptype)
+
+            proxytype = ProxyType.SOCKS5
+            proxytarget = parse_host_port(ptarget)
+        else:
+            raise ValueError('Unknown query string parameter ' + key)
+
+    return SocketURLInfo(target=target, proxytype=proxytype, proxytarget=proxytarget)
+
+# This is still part of the "copied" code, but heavily
+# simplified/modified as no receiving is necessary, nor any
+# protocol other than lines:
+class SocketToBackend(object):
+    delimiter = b"\r\n"
+
+    def initialize(self, destination: str):
+        self.destination = destination
+        self.url = parse_socket_url(destination)
+
+    def connect(self):
+        if self.url.proxytype == ProxyType.DIRECT:
+            if self.url.target.addrtype == AddrType.IPv6:
+                self.sock = socket.socket(socket.AF_INET6, socket.SOCK_STREAM)
+            else: # TODO NAME is assumed to be IPv4 for now
+                self.sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        else:
+            assert False, "Not currently supporting SOCKS5"
+            #assert(self.url.proxytype == ProxyType.SOCKS5)
+            #import socks
+            #self.sock = socks.socksocket()
+            #self.sock.set_proxy(socks.SOCKS5, self.url.proxytarget.host, self.url.proxytarget.port)
+
+        logging.info('Connecting to {}:{} (addrtype {}, proxytype {}, proxytarget {})...'.format(
+            self.url.target.host, self.url.target.port, self.url.target.addrtype,
+                self.url.proxytype, self.url.proxytarget))
+        self.sock.connect((self.url.target.host, self.url.target.port))
+        plugin.log('Connected to JM backend at: {}'.format(self.destination))
         plugin.is_connected_to_backend = True
-        self.send_message(self.starting_msg)
 
-    def dataReceived(self, data):
-        """ We're not currently receiving data from the backend.
-        """
-        self.transport.loseConnection()
+    def sendLine(self, msg: bytes) -> None:
+        # TODO no length check here; should be accepted
+        # by backend if len(msg) < basic.LineReceiver.MAX_LENGTH
+        self.sock.sendall(msg + self.delimiter)
 
-    def send_message(self, message: bytes) -> None:
-        self.sendLine(message)
-
-    def connectionLost(self, reason):
-        pass
-
-tcppp = TCPPassthroughClientProtocol()
-
-class TCPPassthroughClientFactory(ReconnectingClientFactory):
-    def buildProtocol(self, addr):
-        return tcppp
-    def clientConnectionLost(self, connector, reason):
-        if reactor.running:
-            ReconnectingClientFactory.clientConnectionLost(
-                self, connector, reason)
-    def clientConnectionFailed(self, connector, reason):
-        if reactor.running:
-            ReconnectingClientFactory.clientConnectionFailed(
-                self, connector, reason)
+backend_line_sender = SocketToBackend()
 
 def send_tcp_message(msg: bytes) -> None:
-    if plugin.is_connected_to_backend:
-        tcppp.send_message(msg)
-    else:
-        reactor.connectTCP("localhost", plugin.jmport,
-                           TCPPassthroughClientFactory())
-        tcppp.starting_msg = msg
+    if not plugin.is_connected_to_backend:
+        # The 'lazy wait to connect' logic used here
+        # accounts for the fact that we don't expect the
+        # backend server to be up until we're ready to send
+        # messages:
+        plugin.log("Attempting connection to backend on port: {}".format(plugin.jmport))
+        backend_line_sender.initialize("socket:127.0.0.1:" + str(plugin.jmport))
+        backend_line_sender.connect()
+    backend_line_sender.sendLine(msg)
     
 def send_local_control_message(msgtype: int, text: str) -> None:
-    # Notice that this does *not* have the same format as those
-    # that come from the onionmessage calls:
-    msg = {"unknown_fields": [{"number": msgtype, "value": text}]}
+    # We use the same msgtype/msg format as custommsg for now:
+    hextype = "%0.4x" % msgtype
+    hextext = hexlify(text.encode("utf-8")).decode("utf-8")
+    msg = {"peer_id": "00", "payload": hextype + hextext}
     send_tcp_message(json.dumps(msg).encode("utf-8"))
 
 plugin = Plugin(autopatch=False)
@@ -78,46 +180,25 @@ def init(options, configuration, plugin):
     plugin.jmport = options["jmport"]
 
 @plugin.subscribe("connect")
-def on_connect(plugin, id, address, **kwargs):
-    plugin.log("Received connect event for peer {}".format(id))
-    plugin.log("With address: {}".format(address))
-    send_local_control_message(785, id + "@" + address[
+def on_connect(plugin, id, direction, address, **kwargs):
+    if direction == "out":
+        msgtype = 785
+    else:
+        msgtype = 797
+    send_local_control_message(msgtype, id + "@" + address[
         "address"] + ":" + str(address["port"]))
 
 @plugin.subscribe("disconnect")
 def on_disconnect(plugin, id, **kwargs):
-    plugin.log("Received disconnect event for peer {}".format(id))
     send_local_control_message(787, id)
 
-@plugin.hook("onion_message")
-def on_onion_message(plugin, onion_message, **kwargs):
-    send_tcp_message(json.dumps(onion_message).encode("utf-8"))
+@plugin.hook("custommsg")
+def on_custommsg(peer_id, payload, plugin, **kwargs):
+    send_tcp_message(json.dumps({"peer_id": peer_id,
+                                 "payload": payload}).encode("utf-8"))
     return {"result": "continue"}
 
-def run():
-    # If we are not running inside lightningd we'll print usage
-    # and some information about the plugin.
-    if os.environ.get('LIGHTNINGD_PLUGIN', None) != '1':
-        return plugin.print_usage()
-    inner_run()
-
-def inner_run():
-    # iterate manually to shut down gracefully at the end:
-    try:
-        l = next(plugin.stdin.buffer)
-    except StopIteration:
-        reactor.stop()
-        return
-
-    plugin.buffer += l
-    msgs = plugin.buffer.split(b'\n\n')
-    if len(msgs) < 2:
-        reactor.callLater(0.0, inner_run)
-        return
-    plugin.buffer = plugin._multi_dispatch(msgs)
-    reactor.callLater(0.0, inner_run)
-
-plugin.buffer = b""
-reactor.callWhenRunning(run)
-reactor.run()
-
+if os.environ.get('LIGHTNINGD_PLUGIN', None) != '1':
+    plugin.print_usage()
+else:
+    plugin.run()

--- a/jmdaemon/jmdaemon/lnonion.py
+++ b/jmdaemon/jmdaemon/lnonion.py
@@ -10,6 +10,12 @@ from twisted.internet.protocol import ServerFactory
 from twisted.protocols.basic import LineReceiver
 log = get_log()
 
+"""
+Messaging protocol (which wraps the underlying Joinmarket
+messaging protocol) used here is documented in:
+Joinmarket-Docs/lightning-messaging.md
+"""
+
 LOCAL_CONTROL_MESSAGE_TYPES = {"connect": 785, "disconnect": 787, "connect-in": 797}
 CONTROL_MESSAGE_TYPES = {"peerlist": 789, "getpeerlist": 791,
                          "handshake": 793, "dn-handshake": 795}
@@ -35,193 +41,14 @@ server_handshake_json = {"app-name": JM_APP_NAME,
   "proto-ver-max": JM_VERSION,
   "features": {},
   "accepted": False,
-  "nick": ""
+  "nick": "",
+  "motd": "Default MOTD, replace with information for the directory."
  }
 
 # states that keep track of relationship to a peer
 PEER_STATUS_UNCONNECTED, PEER_STATUS_CONNECTED, PEER_STATUS_HANDSHAKED, \
     PEER_STATUS_DISCONNECTED = range(4)
 
-"""
-### MESSAGE FORMAT USED on the LN-ONION CHANNELS
-
-( || means concatenation for strings, here)
-
-Messages conveyed between directly connected nodes with `sendcustommsg`
-have the format described here:
-
-https://lightning.readthedocs.io/PLUGINS.html#custommsg
-
-Note in particular, that `type` is a two byte hex-encoded string
-that prepends the actual message (also hex-encoded), without any intervening
-length field. This `type` is the integer specified in this file as *_MESSAGE_TYPES.
-
-Note also that the type *must* be odd for custom messages (the "it's OK to be odd" principle).
-
-In text, the messages we send via this mechanism are of this format:
-
-from-nick || COMMAND_PREFIX || to-nick || COMMAND_PREFIX || cmd || " " || innermessage
-
-(COMMAND_PREFIX defined in this package's protocol.py)
-
-Here `innermessage` may be a list of messages (e.g. the multiple offer case) separated by COMMAND PREFIX.
-
-Note that this syntax will still be as was described here:
-
-https://github.com/JoinMarket-Org/JoinMarket-Docs/blob/master/Joinmarket-messaging-protocol.md#joinmarket-messaging-protocol
-
-Note also that there is no chunking requirement applied here, based on the assumption that we have a sufficient 1300 byte limit.
-That'll probably be changed later.
-
-### CONTROL MESSAGES
-
-#### HANDSHAKE CONTROL MESSAGES
-
-The message `handshake` is sent by any peer/node not configured to act as
-directory node, to any other node it connects to, as the first message.
-The message `dn-handshake` is sent by any peer/node which is configured to
-act as a directory node, to any other node, as a response to the initial
-`handshake` message.
-(Notice that this configuration implies that directory nodes do not currently
-talk to each other).
-
-The syntax of `handshake` is:
-json serialized:
-  {"app-name": "joinmarket",
-   "directory": false,
-   "location-string": "hex-key@host:port",
-   "proto-ver": 5,
-   "features": {},
-   "nick": "J5***"
-  }
-Note that `proto-ver` is the version specified as `JM_VERSION` in jmdaemon.protocol.
-(It has not changed for many years, it only specifies the syntax of the messages).
-The `features` field is currently empty.
-
-The syntax of `dn-handshake` is:
-json serialized:
- {"app-name": "joinmarket",
-  "directory": true,
-  "proto-ver-min": 5,
-  "proto-ver-max": 5,
-  "features": {}
-  "accepted": true,
-  "nick": "J5**"
- }
-
- Non-directory nodes should send `handshake` to directory nodes,
- and directory nodes should return the `dn-handshake` method with `true`
- for accepted, if and only if:
- * the protocol version is in the accepted range
- * the `directory` field of the peer is false
- * the `app-name` is joinmarket
- * the set of features requested is both recognized and accepted (currently: none)
- * the nick used by this entity/bot across all message channels, used for cross-channel message spoofing protection
-
-Notice that more than one nick is NOT allowed per LN node; this is deferred to
-future updates.
-
- In case those conditions are met, return `"accepted": true`, else return
- `"accepted": false` and immediately disconnect the new peer.
- (in this rejection case, the remaining fields of the `dn-handshake` message do
- not matter, but can be kept as before for convenience).
-
-In case of a direct connection between peers (neither are directory nodes),
-the party which connects then sends the first `handshake` message, and the
-connected-to party responds with their own `handshake`.
-
-In this case, the connection should be accepted and maintained by the receiver
-if and only if:
-* the protocol version is identical
-* the `directory` field of the peer is false
-* the `app-name` is joinmarket
-* the set of features is both recognized and accepted (currently: none)
-
-otherwise the peer should be immediately disconnected.
-
-ALL OTHER MESSAGES (control or otherwise, as detailed below), cannot be sent/
-will be ignored until the above two-way handshake is complete.
-
-#### OTHER CONTROL MESSAGES
-
-The syntax of `peerlist` is:
-
-nick || NICK_PEERLOCATOR_SEPARATOR || peer-location || "," ... (repeated)
-
-i.e. a serialized list of two-element tuples, each of which is a Joinmarket nick
-followed by a peer location.
-
-`peerlist` may be sent by directory nodes to non-directory nodes at any time,
-but currently it is sent according to a specific rule described below.
-
-#### LOCAL CONTROL MESSAGES
-
-There are two messages passed inside the plugin, to Joinmarketd, in response to events in lightningd,
-namely the `connect` and `disconnect` events triggered at the LN level. These are used to update
-the *state* of existing peers that we have recorded as connected at some point, to ourselves.
-
-The mechanisms here are loosely synchronizing a database of JM peers, with obviously the directory
-node(s) acting as the data provider. It's notable that there are no guarantees of accuracy or
-synchrony here.
-
-### PARSING OF RECEIVED JM_MESSAGES
-
-
-The text will be utf-encoded before being hexlified, and therefore the following actions are needed of the receiver:
-
-Extract the peerid of the sender, and the actual message, received as encoded json:
-
-* peerid: json.loads(msg.decode("utf-8"))["peer_id"]
-* message: json.loads(msg.decode("utf-8"))["payload"]
-(which is prepended by a two byte message_type; see below).
-
-##### peerid:
-
-This field comes in three potential forms (as hex):
-"00" : special null peerid indicating a local control message (see above).
-"hex-key": peerid without connection information, allowing us to record the existence of a peer,
-           but not to send messages to it directly (only via the directory node).
-"hex-key@host:port": peerid with connection information, allowing us to attempt to connect to it,
-           and send private messages to it directly.
-
-##### payload:
-
-This is parsed by:
-
-1. Take the first two hex-encoded bytes and convert to an integer: this is the
-                   message type. Take the remaining part of the hex string and unhexlify,
-                   converting to binary, then .decode("utf-8") again, converting to a string.
-                   This means encoding is sometimes very inefficient, if the underlying string actually
-                   contains hex or other encoding, but can't really be changed until the underlying
-                   Joinmarket messaging protocol is changed.
-
-2. Split the decoded string by COMMAND PREFIX and parse as `from nick, to nick, command, message(s)`
-           (see above for syntax).
-
-The resulting messages can be passed into Joinmarket's normal message channel processing, and should be
-identical to that coming from IRC.
-
-However, before doing so, we need to identify "public messages" versus private, which does not
-have as natural a meaning here as it does on IRC; we impose it by using a to-nick value of PUBLIC
-and by sending the message_type `687` to the Lightning RPC instead of the default
-message_type `685` for privmsgs to a single counterparty. This will instruct the directory node
-to send the message to every peer it knows about.
-
-### GETTING INFORMATION ABOUT PEERS FOR DIRECT CONNECTIONS
-
-To avoid passing huge lists of peers around, the directory node takes a "lazy" approach to
-sharing connection info between peers:
-
-When Peer J51 asks to privmsg J52 (which it discovered when receiving a privmsg from J52, usually
-here that would be in response to a `!orderbook` pubmsg by J51), the directory node does as instructed,
-but then sends also a `peerlist` message to J51, containing the full network location of J52.
-
-Given this new information, J51 opportunistically tries to connect to J52 directly and if the network
-connection succeeds, sends a handshake to J52. If J52 responds with acceptance, the direct messaging
-connection is established, and from then on, until J51 sees a disconnect event for that network peer,
-he will divert any `privmsg` to that party to use the direct connection instead of the directory node.
-
-"""
 
 """ this passthrough protocol allows
     the joinmarket daemon to receive messages
@@ -826,6 +653,8 @@ class LNOnionMessageChannel(MessageChannel):
         assert self.self_as_peer.directory
         peerid = self.get_peerid_by_nick(nick)
         if not peerid:
+            log.debug("We were asked to send a message from {} to {}, "
+                      "but {} is not connected.".format(from_nick, nick, nick))
             return
         # The `message` passed in has format COMMAND_PREFIX||command||" "||msg
         # we need to parse out cmd, message for sending.

--- a/jmdaemon/jmdaemon/lnonion.py
+++ b/jmdaemon/jmdaemon/lnonion.py
@@ -1,0 +1,853 @@
+from jmdaemon.message_channel import MessageChannel
+from jmdaemon.protocol import COMMAND_PREFIX
+from jmbase import get_log, bintohex, hextobin, stop_reactor
+from pyln.client import LightningRpc, RpcError
+from io import BytesIO
+import struct
+import json
+from twisted.internet import reactor, task
+from twisted.internet.protocol import ServerFactory
+from twisted.protocols.basic import LineReceiver
+log = get_log()
+
+LOCAL_CONTROL_MESSAGE_TYPES = {"connect": 785, "disconnect": 787}
+CONTROL_MESSAGE_TYPES = {"peerlist": 789, "getpeerlist": 791}
+JM_MESSAGE_TYPES = {"privmsg": 685, "pubmsg": 687}
+
+# Used for some control message construction, as detailed below.
+NICK_PEERLOCATOR_SEPARATOR = ";"
+
+"""
+### MESSAGE FORMAT USED on the LN-ONION CHANNELS
+
+( || means concatenation for strings, here)
+
+`rawtlv` as defined in https://lightning.readthedocs.io/lightning-sendonionmessage.7.html
+is hex-encoded and therefore is of form:
+
+hex-encoded-varint-message-type || hex-encoded-length-of-message || hex-encoded-message
+
+This encoding must happen here (though, as explained below, the receiving side is different).
+
+The rest of this description is how the third field, `message`, is created, and read:
+
+Since we cannot assume a 1:1 mapping of `nick` to lightning daemon (and therefore peerid),
+we prepend with both the Joinmarket nicks (this is slightly awkward but keeps compatibility
+with existing IRC message channels).
+
+In text, the message is therefore:
+
+from-nick || COMMAND_PREFIX || to-nick || COMMAND_PREFIX || cmd || " " || innermessage
+
+(COMMAND_PREFIX defined in this package's protocol.py)
+
+Here `innermessage` may be a list of messages (e.g. the multiple offer case) separated by COMMAND PREFIX.
+
+Note that this syntax will still be as was described here:
+
+https://github.com/JoinMarket-Org/JoinMarket-Docs/blob/master/Joinmarket-messaging-protocol.md#joinmarket-messaging-protocol
+
+Note also that there is no chunking requirement applied here, based on the assumption that we have a sufficient 1300 byte limit.
+That'll probably be changed later.
+
+### CONTROL MESSAGES
+
+The messages `getpeerlist` and `peerlist` are special messages sent to and
+from directory servers.
+
+The syntax of `getpeerlist` is:
+
+from-nick || NICK_PEERLOCATOR_SEPARATOR || peer-location
+
+`from_nick` must be a valid Joinmarket nick belonging to the sending node.
+The `peer-location` field can either be a 66 character hex-encoded pubkey or a full peer location
+as `pubkey@host:port`.
+
+This message is crucial to the network function, since only from here does the directory node know
+the match between the nick (which is cryptographically signed in Joinmarket across channels) and the
+LN node pubkey. Notice that more than one nick is NOT allowed per LN node; this is deferred to
+future updates.
+
+The syntax of `peerlist` is:
+
+nick || NICK_PEERLOCATOR_SEPARATOR || peer-location || "," ... (repeated)
+
+i.e. a serialization of two-element tuples, each of which is a Joinmarket nick followed by a peer
+location, as for the `getpeerlist` message.
+
+#### LOCAL CONTROL MESSAGES
+
+There are two messages passed inside the plugin, to Joinmarketd, in response to events in lightningd,
+namely the `connect` and `disconnect` events triggered at the LN level. These are used to update
+the *state* of existing peers that we have recorded as connected at some point, to ourselves.
+
+The mechanisms here are loosely synchronizing a database of JM peers, with obviously the directory
+node(s) acting as a queryable resource. It's notable that there are no guarantees of accuracy or
+synchrony here.
+
+PARSING OF RECEIVED JM_MESSAGES
+===
+
+The text will be utf-encoded before being hexlified, and therefore the following actions are needed of the receiver:
+
+Extract rawtlv field which is received as encoded json:
+
+json.loads(msg.decode("utf-8"))["unknown_fields"][0]["value"]
+
+(the ["number"] key is used to check for control messages, see below for details).
+
+Then: unhexlify, converting to binary, then .decode("utf-8") again, converting to a string.
+
+Split the string by COMMAND PREFIX and parse as `from nick, to nick, command, message(s)`.
+
+These arguments can be passed into Joinmarket's normal message channel processing, and should be
+identical to that coming from IRC.
+
+However, before doing so, we need to identify "public messages" versus private, which does not
+have as natural a meaning here as it does on IRC; we impose it by using a to-nick value of PUBLIC
+and by sending the message type `687` to the lightning plugin `jmcl.py` instead of the default
+message type `685` for privmsgs to a single counterparty. This will instruct the directory server
+to send the message to every peer it knows about.
+"""
+
+""" this passthrough protocol allows
+    the joinmarket daemon to receive messages
+    from some outside process, instead of from
+    a client connection created in this process.
+    We use a LineReceiver as the app-layer distinguisher
+    of individual messages.
+"""
+class TCPPassThroughProtocol(LineReceiver):
+    def __init__(self, factory):
+        self.factory = factory
+
+    def connectionMade(self):
+        print("connection made in lnonion passthrough")
+
+    def connectionLost(self, reason):
+        print("connection lost in lnonion passthrough")
+
+    def lineReceived(self, line):
+        """ Data passed over this TCP socket
+        is assumed to be JSON encoded, only.
+        """
+        try:
+            data = line.decode("utf-8")
+        except UnicodeDecodeError:
+            log.warn("Received invalid data over the wire, ignoring.")
+            return
+        if len(self.factory.listeners) == 0:
+            log.msg("WARNING! We received: {} but there "
+                    "were no listeners.".format(data))
+        for listener in self.factory.listeners:
+            try:
+                listener.receive_msg(json.loads(data))
+            except json.decoder.JSONDecodeError as e:
+                log.error("Error receiving data: {}, {}".format(data, repr(e)))
+
+
+class TCPPassThroughFactory(ServerFactory):
+    # the protocol created here is a singleton,
+    # global to the joinmarket(d) process;
+    # we interact with it from multiple Joinmarket
+    # protocol instantiations by adding listeners
+    # (because all it does is listen).
+    # Listeners are added to the factory, not the
+    # protocol instance as that won't exist until
+    # someone connects.
+    def __init__(self):
+        # listeners will all receive
+        # all messages; they must have
+        # a `receive_msg` method that
+        # process messages in JSON.
+        self.listeners = []
+
+    def buildProtocol(self, addr):
+        self.p = TCPPassThroughProtocol(self)
+        return self.p
+    def add_tcp_listener(self, listener):
+        self.listeners.append(listener)
+
+    def remove_tcp_listener(self, listener):
+        try:
+            self.listeners.remove(listener)
+        except ValueError:
+            pass
+
+""" Taken from @cdecker's https://github.com/lightningd/plugins/blob/master/noise/primitives.py
+    Of note: we could import this functionality from our backend (jmbitcoin <- python-bitcointx),
+    however jmdaemon must not rely on the jmbitcoin package.
+"""
+def varint_encode(i, w):
+    """Encode an integer `i` into the writer `w`
+    """
+    if i < 0xFD:
+        w.write(struct.pack("!B", i))
+    elif i <= 0xFFFF:
+        w.write(struct.pack("!BH", 0xFD, i))
+    elif i <= 0xFFFFFFFF:
+        w.write(struct.pack("!BL", 0xFE, i))
+    else:
+        w.write(struct.pack("!BQ", 0xFF, i))
+
+def int_to_var_bytes(i):
+    b = BytesIO()
+    varint_encode(i, b)
+    return b.getvalue()
+
+class LNOnionPeerError(Exception):
+    pass
+
+class LNOnionPeerIDError(LNOnionPeerError):
+    pass
+
+class LNOnionPeerDirectoryWithoutHostError(LNOnionPeerError):
+    pass
+
+class LNOnionPeerConnectionError(LNOnionPeerError):
+    pass
+
+class LNOnionPeer(object):
+
+    def __init__(self, peerid: str, hostname: str=None,
+                 port: int=-1, directory: bool=False,
+                 nick: str=""):
+        if not len(peerid) == 66:
+            # TODO: check valid pubkey without jmbitcoin?
+            raise LNOnionPeerIDError()
+        self.peerid = peerid
+        self.nick = nick
+        self.hostname = hostname
+        self.port = port
+        if directory and not (self.hostname):
+            raise LNOnionPeerDirectoryWithoutHostError()
+        self.directory = directory
+        self.is_connected = False
+
+    def set_nick(self, nick):
+        self.nick = nick
+
+    def get_nick_peerlocation_ser(self):
+        if not self.nick:
+            raise LNOnionPeerError("Cannot serialize "
+                "identifier string without nick.")
+        return self.nick + NICK_PEERLOCATOR_SEPARATOR + \
+               self.peer_location_or_id()
+
+    @classmethod
+    def from_location_string(cls, locstr: str,
+                directory: bool=False):
+        peerid, hostport = locstr.split("@")
+        host, port = hostport.split(":")
+        port = int(port)
+        return cls(peerid, host, port, directory)
+
+    def set_host_port(self, hostname: str, port: int) -> None:
+        """ If the connection info is discovered
+        after this peer was already added to our list,
+        we can set it with this method.
+        """
+        self.hostname = hostname
+        self.port = port
+
+    def peer_location_or_id(self):
+        try:
+            return self.peer_location()
+        except AssertionError:
+            return self.peerid
+
+    def peer_location(self):
+        assert (self.hostname and self.port > 0)
+        return self.peerid + "@" + self.hostname + ":" + str(self.port)
+
+    def connect(self, rpcclient: LightningRpc) -> None:
+        """ This method is called to fire the RPC `connect`
+        call to the LN peer associated with this instance.
+        """
+        if self.is_connected:
+            return
+        if not (self.hostname and self.port > 0):
+            raise LNOnionPeerConnectionError(
+                "Cannot connect without host, port info")
+        try:
+            rpcclient.call("connect", [self.peer_location()])
+        except RpcError as e:
+            raise LNOnionPeerConnectionError(
+                "Connection to: {}failed with error: {}".format(
+                    self.peer_location(), repr(e)))
+        self.is_connected = True
+
+    def try_to_connect(self, rpcclient: LightningRpc) -> None:
+        """ This method wraps LNOnionPeer.connect and accepts
+        any error if that fails.
+        """
+        try:
+            self.connect(rpcclient=rpcclient)
+        except LNOnionPeerConnectionError as e:
+            log.debug("Tried to connect but failed: {}".format(repr(e)))
+        except Exception as e:
+            log.warn("Got unexpected exception in connect attempt: {}".format(
+                repr(e)))
+
+    def disconnect(self, rpcclient: LightningRpc) -> None:
+        if not self.is_connected:
+            return
+        if not (self.hostname and self.port > 0):
+            raise LNOnionPeerConnectionError(
+                "Cannot disconnect without host, port info")
+        rpcclient.call("disconnect", [self.peer_location()])
+        self.is_connected = False
+
+class LNOnionMessage(object):
+    """ Encapsulates the messages passed over the wire
+    from c-lightning, allow conversion into the text
+    strings used in Joinmarket message channels.
+    """
+    def __init__(self, text: str, msgtype: int):
+        self.text = text
+        self.msgtype = msgtype
+
+    def encode(self) -> str:
+        bintext = self.text.encode("utf-8")
+        hextext = bintohex(bintext)
+        self.encoded = bintohex(int_to_var_bytes(
+            self.msgtype)) + bintohex(int_to_var_bytes(
+            len(bintext))) + hextext
+        return self.encoded
+
+    @classmethod
+    def from_sendonionmessage_decode(cls, msg:
+                    str, msgtype: int):
+        """ This is not the reverse operation to encode,
+        since we receive the messages as output of
+        c-lightning's `sendonionmessage`.
+        """
+        text = hextobin(msg).decode("utf-8")
+        return cls(text, msgtype)
+
+class LNOnionMessageChannel(MessageChannel):
+    """ Uses the plugin architecture to hook
+    the `sendonionmessage` feature of c-lightning
+    to receive messages over the LN onion network,
+    and the provided RPC client LightningRPC to send
+    messages.
+    See the file jmcl.py for the actual Lightning plugin,
+    which must be loaded in a running instance of c-lightning,
+    for this to work.
+    Uses one or more configured "directory nodes"
+    to access a list of current active nodes, and updates
+    dynamically from messages seen.
+    """
+    def __init__(self,
+                 configdata,
+                 daemon=None):
+        MessageChannel.__init__(self, daemon=daemon)
+        # configures access to c-lightning RPC over the unix socket.
+        self.clnrpc_socket_path = configdata["lightning-rpc"]
+        # hostid is a feature to avoid replay attacks across message channels;
+        # TODO investigate, but for now, treat LN as one "server".
+        self.hostid = "lightning-network"
+        # keep track of peers. the list will be instances
+        # of LNOnionPeer:
+        self.peers = set()
+        for dn in configdata["directory-nodes"].split(","):
+            # note we don't use a nick for directories:
+            self.peers.add(LNOnionPeer.from_location_string(dn,
+                                                directory=True))
+        # the protocol factory for receiving TCP message for us:
+        self.tcp_passthrough_factory = TCPPassThroughFactory()
+        port = configdata["passthrough-port"]
+        self.tcp_passthrough_listener = reactor.listenTCP(port,
+                                    self.tcp_passthrough_factory)
+        # will be needed to send messages:
+        self.rpc_client = None
+
+        # special "genesis" bootstrap case; there are no
+        # directories but us.
+        self.genesis_node = False
+
+        # monitoring loop for getting up to date peer lists:
+        self.peer_request_loop = None
+
+    def get_rpc_client(self, path):
+        return LightningRpc(path)
+
+# ABC implementation section
+    def run(self):
+        self.rpc_client = self.get_rpc_client(self.clnrpc_socket_path)
+        # now the RPC is up, let's find out our own details,
+        # so we can forward them to peers:
+        self.get_our_peer_info()
+        # Next, tell the server routing Lightning messages *to* us
+        # that we're ready to listen:
+        self.tcp_passthrough_factory.add_tcp_listener(self)
+        # at this point the only peers added are directory
+        # nodes from config, so we connect to all, and
+        # after connecting, we retrieve the peer lists available:
+        reactor.callLater(0.0, self.connect_to_directories)
+
+    def get_pubmsg(self, msg, source_nick=None):
+        """ Converts a message into the known format for
+        pubmsgs; if we are not sending this (because we
+        are a directory, forwarding it), `source_nick` must be set.
+        Note that pubmsg does NOT prefix the *message* with COMMAND_PREFIX.
+        """
+        nick = source_nick if source_nick else self.nick
+        return nick + COMMAND_PREFIX + "PUBLIC" + msg
+ 
+    def get_privmsg(self, nick, cmd, message, source_nick=None):
+        """ See `get_pubmsg` for comment on `source_nick`.
+        """
+        from_nick = source_nick if source_nick else self.nick
+        return from_nick + COMMAND_PREFIX + nick + COMMAND_PREFIX + \
+               cmd + " " + message
+
+    def _pubmsg(self, msg):
+        """ Best effort broadcast of message `msg`:
+        send the message to every known directory node,
+        with the PUBLIC message type and nick.
+        """
+        peerids = self.get_directory_peers()
+        for peerid in peerids:
+            self._send(peerid, LNOnionMessage(self.get_pubmsg(msg),
+                                JM_MESSAGE_TYPES["pubmsg"]).encode())
+
+    def _privmsg(self, nick, cmd, msg):
+        log.debug("Privmsging to: {}, {}, {}".format(nick, cmd, msg))
+        encoded_privmsg = LNOnionMessage(self.get_privmsg(nick, cmd, msg),
+                            JM_MESSAGE_TYPES["privmsg"]).encode()
+        peerid = self.get_peerid_by_nick(nick)
+        if peerid:
+            peer = self.get_peer_by_id(peerid)
+        # notice the order matters here!:
+        if not peerid or not peer or not peer.is_connected:
+            # If we are trying to message a peer via their nick, we
+            # may not yet have a connection; then we just
+            # forward via directory nodes.
+            log.debug("Privmsg peer: {} but don't have peerid; "
+                     "sending via directory.".format(nick))
+            try:
+                peerid = self.get_connected_directory_peers()[0].peerid
+            except Exception as e:
+                log.warn("Failed to send privmsg because no "
+                "directory peer is connected. Error: {}".format(repr(e)))
+                return
+        self._send(peerid, encoded_privmsg)
+
+    def _announce_orders(self, offerlist):
+        for offer in offerlist:
+            self._pubmsg(offer)
+
+# End ABC implementation section
+
+
+    def get_our_peer_info(self):
+        """ Create a special LNOnionPeer object,
+        outside of our peerlist, to refer to ourselves.
+        """
+        resp = self.rpc_client.call("getinfo")
+        print("Got response from getinfo: ", resp)
+        # See: https://lightning.readthedocs.io/lightning-getinfo.7.html
+        # for the syntax of the response.
+        #
+        # TODO handle an error response.
+        peerid = resp["id"]
+        dp = self.get_directory_peers()
+        self_dir = False
+        if [peerid] == dp:
+            print("this is the genesis node: ", peerid)
+            self.genesis_node = True
+            self_dir = True
+        elif peerid in dp:
+            # Here we are just one of many directory nodes,
+            # which should be fine, we should just be careful
+            # to not query ourselves.
+            self_dir = True
+
+        # TODO ; any obvious way to process multiple addresses,
+        # other than just take the first?
+        if len(resp["address"]) > 0:
+            a = resp["address"][0]
+        else:
+            # special case regtest: we just use local, no
+            # address, only binding:
+            a = resp["binding"][0]
+        addrtype = a["type"]
+        if addrtype not in ["ipv4", "ipv6", "torv3"]:
+            raise LNOnionPeerError("Unsupported internet address type: "
+                                   "{}".format(addrtype))
+        hostname = a["address"]
+        port = a["port"]
+        # TODO probably need to parse version, alias and network info
+        self.self_as_peer = LNOnionPeer(peerid, hostname, port,
+                                        self_dir, nick=self.nick)
+
+    def connect_to_directories(self):
+        """ First job of the bot is to get an
+        up to date peer list (assuming it is not the seeding
+        node).
+        """
+        if self.genesis_node:
+            self.on_welcome(self)
+            return
+        for p in self.peers:
+            log.info("Trying to connect to node: {}".format(p.peerid))
+            try:
+                p.connect(self.rpc_client)
+            except LNOnionPeerConnectionError:
+                pass
+        # after all the connections are in place, we can
+        # start our continuous request for peer updates:
+        self.peer_request_loop = task.LoopingCall(self.send_getpeers)
+        self.peer_request_loop.start(10.0)
+        # Signal that we're ready.
+        # (we needed to wait until we had a fresh peer list).
+        # This is what triggers the start of taker/maker workflows.
+        self.on_welcome(self)
+
+    def get_directory_peers(self):
+        return [ p.peerid for p in self.peers if p.directory is True]
+
+    def get_peerid_by_nick(self, nick):
+        for p in self.get_all_connected_peers():
+            if p.nick == nick:
+                return p.peerid
+        return None
+
+    def _send(self, peerid: str, message: bytes) -> bool:
+        """
+        This method is "raw" in that it only respects
+        c-lightning's sendonionmessage syntax; it does
+        not manage the syntax of the underlying Joinmarket
+        message in any way.
+        Sends a message to a peer on the message channel,
+        identified by `peerid`, in TLV hex format.
+        To encode the `message` field use `LNOnionMessage.encode`.
+        Arguments:
+        peerid: hex-encoded string.
+        message: raw bytes, encoded as per above.
+        Returns:
+        False if RpcError is raised by a failed RPC call,
+        or True otherwise.
+        """
+        payload={
+            "hops": [{"id": peerid,
+                      "rawtlv": message}]
+        }
+        # TODO handle return:
+        try:
+            # TODO: as of 0.10.2 this format is obsolete ("obs"),
+            # so we will need to change it soon:
+            self.rpc_client.call("sendobsonionmessage", payload)
+        except RpcError as e:
+            # This can happen when a peer disconnects, depending
+            # on the timing:
+            log.warn("Failed RPC call to: " + peerid + \
+                     ", error: " + repr(e))
+            return False
+        return True
+
+    def shutdown(self):
+        """ TODO
+        """
+
+    def receive_msg(self, data):
+        """ The entry point for all data coming over LN into our process.
+        This includes control messages from the plugin that inform
+        us about updates to peers. Notice that since the lightningd daemon
+        doesn't know about our message types, it just lumps them all into
+        "unknown_fields".
+        """
+        try:
+            msgtypeval = data["unknown_fields"][0]
+            msgtype = msgtypeval["number"]
+            msgval = msgtypeval["value"]
+        except Exception as e:
+            log.warn("Ill formed message received: {}, exception: {}".format(
+                data, e))
+            return
+        if msgtype in LOCAL_CONTROL_MESSAGE_TYPES.values():
+            self.process_control_message(msgtype, msgval)
+            # local control messages are processed first, as their "value"
+            # field is not in the onion-TLV format.
+            return
+        # this converts the hex-encoded message from c-lightning
+        # into JM's text string:
+        msgval = LNOnionMessage.from_sendonionmessage_decode(msgval,
+                                                    msgtype).text
+        if self.process_control_message(msgtype, msgval):
+            # will return True if it is, elsewise, a control message.
+            return
+
+        # ignore non-JM messages:
+        if not msgtype in JM_MESSAGE_TYPES.values():
+            log.debug("Invalid message type, ignoring: {}".format(msgtype))
+            return
+
+        # real JM message; should be: from_nick, to_nick, cmd, message
+        try:
+            nicks_msgs = msgval.split(COMMAND_PREFIX)
+            from_nick, to_nick = nicks_msgs[:2]
+            msg = COMMAND_PREFIX + COMMAND_PREFIX.join(nicks_msgs[2:])
+            if to_nick == "PUBLIC":
+                log.debug("A pubmsg is being processed by {} from {}; it "
+                    "is {}".format(self.self_as_peer.nick, from_nick, msg))
+                self.on_pubmsg(from_nick, msg)
+                if self.self_as_peer.directory:
+                    self.forward_pubmsg_to_peers(msg, from_nick)
+            elif to_nick != self.nick:
+                if not self.self_as_peer.directory:
+                    log.debug("Ignoring message, not for us: {}".format(msg))
+                else:
+                    self.forward_privmsg_to_peer(to_nick, msg, from_nick)
+            else:
+                self.on_privmsg(from_nick, msg)
+        except Exception as e:
+            log.debug("Invalid joinmarket message: {}, error was: {}".format(msgval, repr(e)))
+            return
+
+    def forward_pubmsg_to_peers(self, msg, from_nick):
+        """ Used by directory nodes currently. Takes a received
+        message that was PUBLIC and broadcasts it to the non-directory
+        peers.
+        """
+        assert self.self_as_peer.directory
+        pubmsg = self.get_pubmsg(msg, source_nick=from_nick)
+        msgtype = JM_MESSAGE_TYPES["pubmsg"]
+        # TODO: specifically with forwarding/broadcasting,
+        # we introduce the danger of infinite re-broadcast,
+        # if there is more than one party forwarding.
+        encoded_msg = LNOnionMessage(pubmsg, msgtype).encode()
+        for peer in self.get_connected_nondirectory_peers():
+            # don't loop back to the sender:
+            if peer.nick == from_nick:
+                continue
+            log.debug("Sending {}:{} to nondir peer {}".format(msgtype, pubmsg, peer.peerid))
+            self._send(peer.peerid, encoded_msg)
+
+    def forward_privmsg_to_peer(self, nick, message, from_nick):
+        assert self.self_as_peer.directory
+        peerid = self.get_peerid_by_nick(nick)
+        if not peerid:
+            return
+        # The `message` passed in has format COMMAND_PREFIX||command||" "||msg
+        # we need to parse out cmd, message for sending.
+        _, cmdmsg = message.split(COMMAND_PREFIX)
+        cmdmsglist = cmdmsg.split(" ")
+        cmd = cmdmsglist[0]
+        msg = " ".join(cmdmsglist[1:])
+        privmsg = self.get_privmsg(nick, cmd, msg, source_nick=from_nick)
+        log.debug("Sending out privmsg: {} to peer: {}".format(privmsg, peerid))
+        encoded_msg = LNOnionMessage(privmsg,
+                        JM_MESSAGE_TYPES["privmsg"]).encode()
+        self._send(peerid, encoded_msg)
+
+    def process_control_message(self, msgtype: int, msgval: str) -> bool:
+        """ Triggered by a directory node feeding us
+        peers, or by a connect/disconnect hook
+        in the c-lightning plugin; this is our housekeeping
+        to try to create, and keep track of, useful connections.
+        """
+        all_ctrl = list(LOCAL_CONTROL_MESSAGE_TYPES.values(
+            )) + list(CONTROL_MESSAGE_TYPES.values())
+        if msgtype not in all_ctrl:
+            return False
+        # this is too noisy, but TODO, investigate allowing
+        # some kind of control message monitoring e.g. default-off
+        # log-to-file (we don't currently have a 'TRACE' level debug).
+        #log.debug("received control message: {},{}".format(msgtype, msgval))
+        if msgtype == CONTROL_MESSAGE_TYPES["peerlist"]:
+            # This is the base method of seeding connections;
+            # a directory node can send this any time. We may well
+            # need to control this; for now it just gets processed,
+            # whereever it came from:
+            try:
+                peerlist = msgval.split(",")
+                for peer in peerlist:
+                    # defaults mean we just add the peer, not
+                    # add or alter its connection status:
+                    self.add_peer(peer, with_nick=True)
+            except Exception as e:
+                log.debug("Incorrectly formatted peer list: {}, "
+                      "ignoring, {}".format(msgval, e))
+                # returning True either way, because although it was an
+                # invalid message, it *was* a control message, and should
+                # not be processed as something else.
+            return True
+        elif msgtype == CONTROL_MESSAGE_TYPES["getpeerlist"]:
+            # getpeerlist must be accompanied by a full node
+            # locator, and nick;
+            # add that peer before returning our peer list.
+            p = self.add_peer(msgval, connection=True,
+                              overwrite_connection=True, with_nick=True)
+            try:
+                self.send_peers(p)
+            except LNOnionPeerConnectionError:
+                pass
+            # comment much as above; if we can't connect, it's none
+            # of our business.
+            return True
+        elif msgtype == LOCAL_CONTROL_MESSAGE_TYPES["connect"]:
+            self.add_peer(msgval, connection=True,
+                          overwrite_connection=True)
+        elif msgtype == LOCAL_CONTROL_MESSAGE_TYPES["disconnect"]:
+            self.add_peer(msgval, connection=False,
+                          overwrite_connection=True)
+        else:
+            assert False
+        # If we got here it is *not* a non-local control message;
+        # so we must process it as a Joinmarket message.
+        return False
+
+    def get_peer_by_id(self, p: str):
+        """ Returns the LNOnionPeer with peerid p,
+        if it is in self.peers, otherwise returns False.
+        """
+        for x in self.peers:
+            if x.peerid == p:
+                return x
+        return False
+
+    def add_peer(self, peerdata: str, connection: bool=False,
+                overwrite_connection: bool=False, with_nick=False) -> None:
+        """ add non-directory peer from (nick, peer) serialization `peerdata`,
+        where "peer" is peerid or full peerid@host:port;
+        return the created LNOnionPeer object. Or, with_nick=False means
+        that `peerdata` has only the peer location.
+        If the peer is already in our peerlist it can be updated in
+        one of these ways:
+        * the nick can be added
+        * it can be marked as 'connected' if it was previously unconnected,
+        with this conditional on whether the flag `overwrite_connection` is
+        set.
+        """
+        if with_nick:
+            try:
+                nick, peer = peerdata.split(NICK_PEERLOCATOR_SEPARATOR)
+            except Exception as e:
+                # TODO: as of now, this is not an error, but expected.
+                # Don't log? Do something else?
+                log.debug("Received invalid peer identifier string: {}, {}".format(
+                    peerdata, e))
+                return
+        else:
+            peer = peerdata
+        if len(peer) == 66:
+            p = self.get_peer_by_id(peer)
+            if not p:
+                # no address info here
+                p = LNOnionPeer(peer)
+                p.is_connected = connection
+                self.peers.add(p)
+            elif overwrite_connection:
+                p.is_connected = connection
+            if with_nick:
+                p.set_nick(nick)
+            return p
+        elif len(peer) > 66:
+            # assumed that it's passing a full string
+            # TODO need to think about logic of 'is_connected'
+            # state here.
+            try:
+                temp_p = LNOnionPeer.from_location_string(peer)
+            except Exception as e:
+                # There are currently a few ways the location
+                # parsing and Peer object construction can fail;
+                # TODO specify exception types.
+                log.warn("Failed to add peer: {}, exception: {}".format(peer, repr(e)))
+                return
+            if not self.get_peer_by_id(temp_p.peerid):
+                temp_p.is_connected = connection
+                if with_nick:
+                    temp_p.set_nick(nick)
+                self.peers.add(temp_p)
+                if not connection:
+                    # Here, we have a full location string,
+                    # and we are not currently connected. We
+                    # try to connect asynchronously. We don't pay attention
+                    # to any return; this is opportunistic, only, currently.
+                    reactor.callLater(0.0, temp_p.try_to_connect, self.rpc_client)
+                return temp_p
+            else:
+                p = self.get_peer_by_id(temp_p.peerid)
+                if overwrite_connection:
+                    p.is_connected = connection
+                if with_nick:
+                    p.set_nick(nick)
+                return p
+        else:
+            raise LNOnionPeerError(
+            "Invalid peer location string: {}".format(peer))
+
+    def get_all_connected_peers(self):
+        return self.get_connected_directory_peers() + \
+               self.get_connected_nondirectory_peers()
+
+    def get_connected_directory_peers(self):
+        return [p for p in self.peers if p.directory and p.is_connected]
+
+    def get_connected_nondirectory_peers(self):
+        return [p for p in self.peers if (not p.directory) and p.is_connected]
+
+    """ CONTROL MESSAGES SENT BY US
+    """
+    def send_getpeers(self):
+        """ This message is sent to all currently connected
+        directory nodes.
+        If it fails we must update our directory node list or quit.
+        """
+        for dp in self.get_connected_directory_peers():
+            # This message embeds the connection information
+            # for *ourselves* to add to peer lists of other
+            # nodes.
+            msg = self.self_as_peer.get_nick_peerlocation_ser()
+            success = self._send(dp.peerid, LNOnionMessage(msg,
+                    CONTROL_MESSAGE_TYPES["getpeerlist"]).encode())
+            if not success:
+                # a failure of the RPC call is interpreted as a failure
+                # to connect. We must drop this dn, with a warning,
+                # and we must shut down this loop and the whole program
+                # if we have no directory peers left.
+                log.warn("Losing connection to directory: " + dp.peerid)
+                dp.is_connected = False
+                if len(self.get_connected_directory_peers()) == 0:
+                    # we cannot continue if we have no existing directory
+                    # peers.
+                    self.peer_request_loop.stop()
+                    self.shutdown()
+                    stop_reactor()
+                    break
+
+    def send_peers(self, requesting_peer):
+        """ This message is sent by directory peers on request
+        by non-directory peers.
+        The peerlist message should have this format:
+        (1) entries comma separated
+        (2) each entry is serialized nick then the NICK_PEERLOCATOR_SEPARATOR
+            then *either* 66 char hex peerid, *or* peerid@host:port
+        (3) However since it's very likely that this message
+            is long enough to exceed a 1300 byte limit, we
+            must split it into multiple messages (TODO).
+        """
+        if not requesting_peer.is_connected:
+            raise LNOnionPeerConnectionError(
+                "Cannot send peer list to unconnected peer")
+        peerlist = set()
+        for p in self.get_connected_nondirectory_peers():
+            # don't send a peer to itself
+            if p.peerid == requesting_peer.peerid:
+                continue
+            if not p.is_connected:
+                # don't advertise what is not online (?)
+                continue
+            # peers that haven't sent their nick yet are not
+            # privmsg-reachable; don't send them
+            if p.nick == "":
+                continue
+            peerlist.add(p.get_nick_peerlocation_ser())
+        # For testing: dns won't usually participate:
+        peerlist.add(self.self_as_peer.get_nick_peerlocation_ser())
+        self._send(requesting_peer.peerid, LNOnionMessage(",".join(
+            peerlist), CONTROL_MESSAGE_TYPES["peerlist"]).encode())
+
+

--- a/jmdaemon/jmdaemon/message_channel.py
+++ b/jmdaemon/jmdaemon/message_channel.py
@@ -263,9 +263,9 @@ class MessageChannelCollection(object):
                     #is supposed to be sent. There used to be an exception raise.
                     #to prevent a crash (especially in makers), we just inform
                     #the user about it for now
-                    log.error("Tried to communicate on this IRC server but "
+                    log.error("Tried to communicate on this message channel but "
                               "failed: " + str(mc))
-                    log.error("You might have to comment out this IRC server "
+                    log.error("You might have to comment out this message channel"
                               "in joinmarket.cfg and restart.")
                     log.error("No action needed for makers / yield generators!")
                     # todo: add logic to continue on other available mc
@@ -444,7 +444,7 @@ class MessageChannelCollection(object):
                 if (not self.on_welcome_announce_id) and self.on_welcome:
                     self.on_welcome_announce_id = reactor.callLater(60, self.on_welcome_setup_finished,)
             else:
-                log.info("All IRC servers connected, starting execution.")
+                log.info("All message channels connected, starting execution.")
                 if self.on_welcome_announce_id:
                     self.on_welcome_announce_id.cancel()
                 self.on_welcome_setup_finished()

--- a/jmdaemon/test/ln_test_data.py
+++ b/jmdaemon/test/ln_test_data.py
@@ -1,5 +1,6 @@
-from jmbase import bintohex
-from jmdaemon.lnonion import NICK_PEERLOCATOR_SEPARATOR
+from jmbase import bintohex, JM_APP_NAME
+import json
+from jmdaemon import JM_VERSION
 
 nick1 = "ln_publisher"
 nick2 = "ln_receiver"
@@ -12,15 +13,29 @@ mock_getinfo_result = {'id': '03df15dbd9e20c811cc5f4155745e89540a0b83f33978317ce
                        'version': 'v0.9.1-13-gc8c2227', 'blockheight': 61988, 'network': 'regtest',
                        'msatoshi_fees_collected': 0, 'fees_collected_msat': "0msat", 'lightning-dir': '/not/real/path'}
 
-def get_mock_msg(num, msg, nick=None):
+mock_client_handshake_json = {"app-name": JM_APP_NAME,
+ "directory": False,
+ "location-string": "028984b787834f93dbac6b9902368cdc2da34c563cb5626a484109f35aac32e84e@dummyhost:9735",
+ "proto-ver": JM_VERSION,
+ "features": {},
+ "nick": nick2
+}
+
+def get_mock_msg(num, msg, peerid=None, nick=None):
     hextype = "%0.4x" % num
     msgval = b""
     if nick:
-        msgval = (nick + NICK_PEERLOCATOR_SEPARATOR).encode("utf-8")
+        msgval = nick.encode("utf-8")
     msgval += msg
     msgval = bintohex(msgval)
-    return {"peer_id": "fake_peerid", "payload": hextype + msgval}
+    if not peerid:
+        # this is the case for local control messages
+        peerid = "00"
+    return {"peer_id": peerid, "payload": hextype + msgval}
 
-mock_control_message1 = get_mock_msg(789, b";028984b787834f93dbac6b9902368cdc2da34c563cb5626a484109f35aac32e84e", nick2)
+mock_control_message1 = get_mock_msg(789, b";028984b787834f93dbac6b9902368cdc2da34c563cb5626a484109f35aac32e84e",
+                                     "028984b787834f93dbac6b9902368cdc2da34c563cb5626a484109f35aac32e84e", nick2)
 mock_control_connected_message = get_mock_msg(785, b"028984b787834f93dbac6b9902368cdc2da34c563cb5626a484109f35aac32e84e@dummyhost:9735")
-mock_receiver_pubmsg = get_mock_msg(687, b"!PUBLIC!orderbook", nick2)
+mock_receiver_pubmsg = get_mock_msg(687, b"!PUBLIC!orderbook", "028984b787834f93dbac6b9902368cdc2da34c563cb5626a484109f35aac32e84e", nick2)
+mock_client_handshake_message = get_mock_msg(793, json.dumps(mock_client_handshake_json).encode("utf-8"),
+                                             "028984b787834f93dbac6b9902368cdc2da34c563cb5626a484109f35aac32e84e")

--- a/jmdaemon/test/ln_test_data.py
+++ b/jmdaemon/test/ln_test_data.py
@@ -1,0 +1,24 @@
+from jmbase import bintohex
+
+nick1 = "ln_publisher"
+nick2 = "ln_receiver"
+nick3 = "ln_thirdparty"
+
+mock_getinfo_result = {'id': '03df15dbd9e20c811cc5f4155745e89540a0b83f33978317cebe9dfc46c5253c55',
+                       'alias': 'BIZARREYARD-v0.9.1-13-gc8c2227', 'color': '028984', 'num_peers': 0,
+                       'num_pending_channels': 0, 'num_active_channels': 0, 'num_inactive_channels': 0,
+                       'address': [], 'binding': [{'type': 'ipv4', 'address': '127.0.0.1', 'port': 9835}],
+                       'version': 'v0.9.1-13-gc8c2227', 'blockheight': 61988, 'network': 'regtest',
+                       'msatoshi_fees_collected': 0, 'fees_collected_msat': "0msat", 'lightning-dir': '/not/real/path'}
+
+def get_mock_msg(num, msg, nick=None, local=False):
+    if local:
+        msgval = msg.decode("utf-8")
+    else:
+        msgval = bintohex(nick.encode("utf-8") + msg)
+    return {"unknown_fields": [{"number": num, "value": msgval}]}
+
+mock_control_message1 = get_mock_msg(789, b";028984b787834f93dbac6b9902368cdc2da34c563cb5626a484109f35aac32e84e", nick2)
+mock_control_connected_message = get_mock_msg(785, b"028984b787834f93dbac6b9902368cdc2da34c563cb5626a484109f35aac32e84e@dummyhost:9735",
+                                              nick2, local=True)
+mock_receiver_pubmsg = get_mock_msg(687, b"!PUBLIC!orderbook", nick2)

--- a/jmdaemon/test/ln_test_data.py
+++ b/jmdaemon/test/ln_test_data.py
@@ -1,4 +1,5 @@
 from jmbase import bintohex
+from jmdaemon.lnonion import NICK_PEERLOCATOR_SEPARATOR
 
 nick1 = "ln_publisher"
 nick2 = "ln_receiver"
@@ -11,14 +12,15 @@ mock_getinfo_result = {'id': '03df15dbd9e20c811cc5f4155745e89540a0b83f33978317ce
                        'version': 'v0.9.1-13-gc8c2227', 'blockheight': 61988, 'network': 'regtest',
                        'msatoshi_fees_collected': 0, 'fees_collected_msat': "0msat", 'lightning-dir': '/not/real/path'}
 
-def get_mock_msg(num, msg, nick=None, local=False):
-    if local:
-        msgval = msg.decode("utf-8")
-    else:
-        msgval = bintohex(nick.encode("utf-8") + msg)
-    return {"unknown_fields": [{"number": num, "value": msgval}]}
+def get_mock_msg(num, msg, nick=None):
+    hextype = "%0.4x" % num
+    msgval = b""
+    if nick:
+        msgval = (nick + NICK_PEERLOCATOR_SEPARATOR).encode("utf-8")
+    msgval += msg
+    msgval = bintohex(msgval)
+    return {"peer_id": "fake_peerid", "payload": hextype + msgval}
 
 mock_control_message1 = get_mock_msg(789, b";028984b787834f93dbac6b9902368cdc2da34c563cb5626a484109f35aac32e84e", nick2)
-mock_control_connected_message = get_mock_msg(785, b"028984b787834f93dbac6b9902368cdc2da34c563cb5626a484109f35aac32e84e@dummyhost:9735",
-                                              nick2, local=True)
+mock_control_connected_message = get_mock_msg(785, b"028984b787834f93dbac6b9902368cdc2da34c563cb5626a484109f35aac32e84e@dummyhost:9735")
 mock_receiver_pubmsg = get_mock_msg(687, b"!PUBLIC!orderbook", nick2)

--- a/jmdaemon/test/test_daemon_protocol.py
+++ b/jmdaemon/test/test_daemon_protocol.py
@@ -59,7 +59,7 @@ class JMTestClientProtocol(JMBaseProtocol):
 
     def clientStart(self):
         self.sigs_received = 0
-        irc = get_mchannels()
+        irc = [get_mchannels()[0]]
         d = self.callRemote(JMInit,
                             bcsource="dummyblockchain",
                             network="dummynetwork",

--- a/jmdaemon/test/test_daemon_protocol.py
+++ b/jmdaemon/test/test_daemon_protocol.py
@@ -7,7 +7,7 @@ from jmdaemon.daemon_protocol import JMDaemonServerProtocol
 from jmdaemon.protocol import NICK_HASH_LENGTH, NICK_MAX_ENCODED, JM_VERSION,\
     JOINMARKET_NICK_HEADER
 from jmbase import get_log
-from jmclient import (load_test_config, jm_single, get_irc_mchannels)
+from jmclient import (load_test_config, jm_single, get_mchannels)
 from twisted.python.log import msg as tmsg
 from twisted.python.log import startLogging
 from twisted.internet import protocol, reactor, task
@@ -59,7 +59,7 @@ class JMTestClientProtocol(JMBaseProtocol):
 
     def clientStart(self):
         self.sigs_received = 0
-        irc = get_irc_mchannels()
+        irc = get_mchannels()
         d = self.callRemote(JMInit,
                             bcsource="dummyblockchain",
                             network="dummynetwork",

--- a/jmdaemon/test/test_irc_messaging.py
+++ b/jmdaemon/test/test_irc_messaging.py
@@ -6,7 +6,7 @@ from twisted.trial import unittest
 from twisted.internet import reactor, task
 from jmdaemon import IRCMessageChannel, MessageChannelCollection
 #needed for test framework
-from jmclient import (load_test_config, get_irc_mchannels, jm_single)
+from jmclient import (load_test_config, get_mchannels, jm_single)
 
 si = 1
 class DummyDaemon(object):
@@ -95,7 +95,7 @@ def junk_fill(mc):
 
 def getmc(nick):
     dm = DummyDaemon()
-    mc = DummyMC(get_irc_mchannels()[0], nick, dm)
+    mc = DummyMC(get_mchannels()[0], nick, dm)
     mc.register_orderbookwatch_callbacks(on_order_seen=on_order_seen)
     mc.register_taker_callbacks(on_pubkey=on_pubkey)
     mc.on_connect = on_connect
@@ -108,7 +108,7 @@ class TrialIRC(unittest.TestCase):
 
     def setUp(self):
         load_test_config()
-        print(get_irc_mchannels()[0])
+        print(get_mchannels()[0])
         jm_single().maker_timeout_sec = 1
         dm, mc, mcc = getmc("irc_publisher")
         dm2, mc2, mcc2 = getmc("irc_receiver")

--- a/jmdaemon/test/test_lnonion_message_channel.py
+++ b/jmdaemon/test/test_lnonion_message_channel.py
@@ -1,0 +1,185 @@
+#! /usr/bin/env python
+'''Tests of LNOnionMessageChannel function '''
+
+import copy
+from twisted.trial import unittest
+from twisted.internet import reactor, defer
+from jmdaemon import LNOnionMessageChannel, MessageChannelCollection, COMMAND_PREFIX
+from jmclient import (load_test_config, get_mchannels, jm_single)
+from jmbase import get_log
+from ln_test_data import *
+
+""" We need to spoof both incoming and outcoming.
+Incoming is from lightningd -> sendonionmessage trigger -> jmcl plugin -> tcp-passthrough
+Outgoing is from here to lightningd via LightningRpc.
+Creating a full test of the lightningd backend, which necessarily requires multiple nodes,
+is a large project, so here we are less ambitious. We make a pretend version of the
+LightningRpc client which stores the received messages, indexed by nick.
+Then that same object sends back the messages in tcp-passthrough messages.
+"""
+
+log = get_log()
+
+# The "daemon" here is specifically the daemon protocol in
+# jmdaemon; we just make sure that the usual nick signature
+# verification alawys passes:
+class DummyDaemon(object):
+    def request_signature_verify(self, a, b, c, d, e,
+            f, g, h):
+        return True
+
+# wrapper class allows us to set a nick
+# initially without jmclient interaction:
+class DummyMC(LNOnionMessageChannel):
+    def __init__(self, configdata, nick, daemon):
+        super().__init__(configdata, daemon=daemon)
+        self.daemon = daemon
+        self.set_nick(nick)
+
+    def get_rpc_client(self, path):
+        return DummyRpcClient(path)
+
+class DummyRpcClient(object):
+    def __init__(self, path):
+        self.path = path
+
+    def call(self, method, obj=None):
+        "Call of method {} with data {} occurred in DummyRpcClient".format(method, obj)
+        if method == "getinfo":
+            return mock_getinfo_result
+        else:
+            return {}
+
+def on_connect(x):
+    print('simulated on-connect')
+
+def on_welcome(mc):
+    print('simulated on-welcome')
+def on_disconnect(x):
+    print('simulated on-disconnect')
+
+def on_order_seen(dummy, counterparty, oid, ordertype, minsize,
+                                           maxsize, txfee, cjfee):
+    global yg_name
+    yg_name = counterparty
+
+def on_pubkey(pubkey):
+    print("received pubkey: " + pubkey)
+
+def junk_pubmsgs(mc):
+    mc.request_orderbook()
+    #now try directly
+    mc.pubmsg("!orderbook")
+    #should be ignored; can we check?
+    mc.pubmsg("!orderbook!orderbook")
+
+def junk_longmsgs(mc):
+    # TODO: not currently using real `sendonionmessage`,
+    # so testing a longer than expected message is pointless.
+    # in future mock or use the real lightning rpc call.
+    # Leaving here for now as it doesn't hurt.
+    mc.pubmsg("junk and crap"*40)
+
+def junk_announce(mc):
+    #try a long order announcement in public
+    #because we don't want to build a real orderbook,
+    #TODO: how to test that the sent format was correct?
+    mc._announce_orders(["!abc def gh 0001"]*30)
+
+def junk_fill(mc):
+    #send a fill with an invalid pubkey to the existing yg;
+    #this should trigger a NaclError but should NOT kill it.
+    mc._privmsg(nick2, "fill", "0 10000000 abcdef")
+    #Try with ob flag
+    mc._pubmsg("!reloffer stuff")
+    # TODO: What happens if we send messages larger than the onion
+    # packet size limit? As per above, need real LN parsing.
+    mc._privmsg(nick2, "tx", "aa"*5000)
+    mc.send_error(nick2, "fly you fools!")
+    return mc
+
+def getmc(nick):
+    dm = DummyDaemon()
+    mc = DummyMC(get_mchannels()[0], nick, dm)
+    mc.register_orderbookwatch_callbacks(on_order_seen=on_order_seen)
+    mc.register_taker_callbacks(on_pubkey=on_pubkey)
+    mc.on_connect = on_connect
+    mc.on_disconnect = on_disconnect
+    mc.on_welcome = on_welcome
+    mcc = MessageChannelCollection([mc])
+    mc.on_pubmsg_trigger = mcc.see_nick
+    return dm, mc, mcc
+
+class LNOnionTest(unittest.TestCase):
+
+    def setUp(self):
+        # add a config section dynamically, specifically
+        # for this purpose:
+        load_test_config()
+        self.old_config = copy.deepcopy(jm_single().config)
+        jm_single().config.remove_section("MESSAGING:server1")
+        jm_single().config.remove_section("MESSAGING:server2")
+        jm_single().config.add_section("MESSAGING:lightning1")
+        
+        jm_single().config.set("MESSAGING:lightning1", "type", "ln-onion")
+        jm_single().config.set("MESSAGING:lightning1", "directory-nodes",
+            "03df15dbd9e20c811cc5f4155745e89540a0b83f33978317cebe9dfc46c5253c55@127.0.0.1:9835")
+        jm_single().config.set("MESSAGING:lightning1", "passthrough-port", str(49100))
+        jm_single().config.set("MESSAGING:lightning1", "lightning-port", "9835")
+        jm_single().config.set("MESSAGING:lightning1", "lightning-rpc", "mock-rpc-socket-file")
+        print(get_mchannels()[0])
+        jm_single().maker_timeout_sec = 1
+        self.dm, self.mc, self.mcc = getmc("irc_publisher")
+        self.mcc.run()
+
+    def test_all(self):
+        # it's slightly simpler to test each functionality in series
+        # in one test function (so we can preserve order).
+        self.mc.on_welcome(self.mc)
+        tm = "testmessage"
+        assert self.mc.get_pubmsg(tm, source_nick=nick1) == \
+               nick1 + COMMAND_PREFIX + "PUBLIC" + tm
+        assert self.mc.get_privmsg(nick2, "ioauth", tm,
+                source_nick=nick1) == nick1 + COMMAND_PREFIX + \
+               nick2 + COMMAND_PREFIX + "ioauth " + tm
+        self.mcc.pubmsg(tm)
+        # in order for us to privmsg a counterparty we need to think
+        # it's visible *and* connected, because *we* are the only
+        # directory. To do that we mock a control message from the dn
+        # telling us that he's there:
+        self.mc.receive_msg(mock_control_message1)
+        self.mc.receive_msg(mock_control_connected_message)
+        # and then we mock him sending out a pubmsg; this is needed,
+        # because msgchans only register nicks 'active' on that mc via
+        # the on_pubmsg_trigger; otherwise they might be connected, but they
+        # are not 'active':
+        self.mc.receive_msg(mock_receiver_pubmsg)
+        # absence of 'peer not found' in response to this
+        # privmsg will mean the above worked:
+        self.mc._privmsg(nick2, "ioauth", tm)
+        # check our peerinfo is right:
+        sap = self.mc.self_as_peer       
+        assert sap.peerid == '03df15dbd9e20c811cc5f4155745e89540a0b83f33978317cebe9dfc46c5253c55'
+        assert sap.hostname == '127.0.0.1'
+        assert sap.port == 9835
+        # we have no directory or non-directory peers right now:
+        assert self.mc.get_connected_directory_peers() == []
+        assert len(self.mc.get_connected_nondirectory_peers()) == 1
+        junk_pubmsgs(self.mc)
+        junk_longmsgs(self.mc)
+        junk_announce(self.mc)
+        junk_fill(self.mc)
+
+
+    def tearDown(self):
+        jm_single().config = self.old_config
+        for dc in reactor.getDelayedCalls():
+            dc.cancel()
+        # only fire if everything is finished:
+        return defer.maybeDeferred(self.mc.tcp_passthrough_listener.stopListening)
+
+
+
+
+
+

--- a/jmdaemon/test/test_lnonion_message_channel.py
+++ b/jmdaemon/test/test_lnonion_message_channel.py
@@ -44,11 +44,17 @@ class DummyRpcClient(object):
         self.path = path
 
     def call(self, method, obj=None):
-        "Call of method {} with data {} occurred in DummyRpcClient".format(method, obj)
+        print("Call of method {} with data {} occurred in "
+              "DummyRpcClient".format(method, obj))
         if method == "getinfo":
             return mock_getinfo_result
         else:
             return {}
+
+    def sendcustommsg(self, peerid, msg):
+        print("simulating send of msg to peer: {}".format(
+            peerid))
+        return self.call("sendcustommsg", obj=msg)
 
 def on_connect(x):
     print('simulated on-connect')

--- a/jmdaemon/test/test_orderbookwatch.py
+++ b/jmdaemon/test/test_orderbookwatch.py
@@ -2,7 +2,7 @@ import pytest
 
 from jmdaemon.orderbookwatch import OrderbookWatch
 from jmdaemon import IRCMessageChannel, fidelity_bond_cmd_list
-from jmclient import get_irc_mchannels, load_test_config
+from jmclient import get_mchannels, load_test_config
 from jmdaemon.protocol import JM_VERSION, ORDER_KEYS
 from jmbase.support import hextobin
 from jmclient.fidelity_bond import FidelityBondProof
@@ -24,7 +24,7 @@ def on_welcome(x):
 def get_ob():
     load_test_config()
     dm = DummyDaemon()
-    mc = DummyMC(get_irc_mchannels()[0], "test", dm)
+    mc = DummyMC(get_mchannels()[0], "test", dm)
     ob = OrderbookWatch()
     ob.on_welcome = on_welcome
     ob.set_msgchan(mc)

--- a/scripts/joinmarket-qt.py
+++ b/scripts/joinmarket-qt.py
@@ -2343,7 +2343,7 @@ parser.remove_option("--wallet-password-stdin")
 
 config_load_error = False
 try:
-    load_program_config(config_path=options.datadir)
+    load_program_config(config_path=options.datadir, ln_backend_needed=True)
 except Exception as e:
     config_load_error = "Failed to setup joinmarket: "+repr(e)
     if "RPC" in repr(e):

--- a/scripts/obwatch/ob-watcher.py
+++ b/scripts/obwatch/ob-watcher.py
@@ -44,7 +44,7 @@ if 'matplotlib' in sys.modules:
     import matplotlib.pyplot as plt
 
 from jmclient import jm_single, load_program_config, calc_cj_fee, \
-     get_irc_mchannels, add_base_options
+     get_mchannels, add_base_options
 from jmdaemon import OrderbookWatch, MessageChannelCollection, IRCMessageChannel
 #TODO this is only for base58, find a solution for a client without jmbitcoin
 import jmbitcoin as btc
@@ -804,7 +804,7 @@ def main():
     (options, args) = parser.parse_args()
     load_program_config(config_path=options.datadir)
     hostport = (options.host, options.port)
-    mcs = [ObIRCMessageChannel(c) for c in get_irc_mchannels()]
+    mcs = [ObIRCMessageChannel(c) for c in get_mchannels()]
     mcc = MessageChannelCollection(mcs)
     mcc.set_nick(get_dummy_nick())
     taker = ObBasic(mcc, hostport)

--- a/scripts/sendpayment.py
+++ b/scripts/sendpayment.py
@@ -53,7 +53,9 @@ def pick_order(orders, n): #pragma: no cover
 def main():
     parser = get_sendpayment_parser()
     (options, args) = parser.parse_args()
-    load_program_config(config_path=options.datadir)
+    ln_backend_needed = True if options.makercount != 0 else False
+    load_program_config(config_path=options.datadir,
+                        ln_backend_needed=ln_backend_needed)
 
     if options.schedule == '':
         if ((len(args) < 2) or

--- a/scripts/tumbler.py
+++ b/scripts/tumbler.py
@@ -25,7 +25,7 @@ def main():
     if len(args) < 1:
         jmprint('Error: Needs a wallet file', "error")
         sys.exit(EXIT_ARGERROR)
-    load_program_config(config_path=options['datadir'])
+    load_program_config(config_path=options['datadir'], ln_backend_needed=True)
     logsdir = os.path.join(os.path.dirname(
         jm_single().config_location), "logs")
     tumble_log = get_tumble_log(logsdir)

--- a/test/e2e-coinjoin-test.py
+++ b/test/e2e-coinjoin-test.py
@@ -1,0 +1,394 @@
+#! /usr/bin/env python
+'''Creates wallets and yield generators in regtest,
+   then runs both them and a JMWalletDaemon instance
+   for the taker, injecting the newly created taker
+   wallet into it and running sendpayment once.
+   Number of ygs is configured in the joinmarket.cfg
+   with `regtest-count` in the `ln-onion` type MESSAGING
+   section.
+   See notes below for more detail on config.
+   Run it like:
+   pytest \
+   --btcroot=/path/to/bitcoin/bin/ \
+   --btcpwd=123456abcdef --btcconf=/blah/bitcoin.conf \
+   -s test/ln-ygrunner.py
+   '''
+import os
+from twisted.internet import task, reactor, defer
+from twisted.web.client import readBody, Headers
+from common import make_wallets
+import pytest
+import random
+import json
+from datetime import datetime
+from jmbase import get_nontor_agent, BytesProducer, jmprint, get_log, stop_reactor
+from jmclient import (YieldGeneratorBasic, load_test_config, jm_single,
+    JMClientProtocolFactory, start_reactor, SegwitWallet, get_mchannels,
+    SegwitLegacyWallet, SNICKERClientProtocolFactory, SNICKERReceiver,
+    JMWalletDaemon)
+from jmclient.wallet_utils import wallet_gettimelockaddress
+from jmclient.wallet_rpc import api_version_string
+
+log = get_log()
+
+# For quicker testing, restrict the range of timelock
+# addresses to avoid slow load of multiple bots.
+# Note: no need to revert this change as ygrunner runs
+# in isolation.
+from jmclient import FidelityBondMixin
+FidelityBondMixin.TIMELOCK_ERA_YEARS = 2
+FidelityBondMixin.TIMELOCK_EPOCH_YEAR = datetime.now().year
+FidelityBondMixin.TIMENUMBERS_PER_PUBKEY = 12
+
+wallet_name = "test-ln-yg-runner.jmdat"
+
+# Note for tests of Lightning message channels:
+# (this data is not really needed *here* as the bots
+# retrieve their keys on startup with RPC `getinfo`, but is here
+# for reference).
+#
+# These nodes are generated with private keys (using --dev-force-privkey):
+# (note of course that c-lightning must be built with --enable-developer)
+# 121212121212121212121212121212121212121212121212121212121212121$i
+# with $i 1..3
+#
+# the passthrough ports are 4910$i and they all run on localhost (this is default for regtest).
+# the lightning node ports are 9735+$i
+# l1-regtest:
+#  lightningd: Server started with public key 03df15dbd9e20c811cc5f4155745e89540a0b83f33978317cebe9dfc46c5253c55,
+#  alias HOPPINGSET(color #03df15)
+# l2-regtest:
+#  lightningd: Server started with public key 036360e856310ce5d294e8be33fc807077dc56ac80d95d9cd4ddbd21325eff73f7,
+#  alias GREENSPAWN(color #036360)
+# l3-regtest:
+# lightningd: Server started with public key 02edde301d65a673fc8a37e9c8d34878adfbc561f66afbcc37db9bc9fbf5088ef5,
+# alias HOPPINGSQUIRREL(color #02edde)
+# We will treat the first of these three, as the directory node for the tests
+#
+# Here is the config the tester should actually enter in joinmarket.cfg:
+# [MESSAGING:lightning1]
+# type = ln-onion
+# clightning-location = bundled
+# directory-nodes = 03df15dbd9e20c811cc5f4155745e89540a0b83f33978317cebe9dfc46c5253c55@localhost:9735
+# passthrough-port = 49101
+# lightning-port = 9736
+# regtest-count=i
+#
+# and replace 'i' for how many bots you want. The passthrough port and lightning-port will be ignored in
+# favour of the settings mentioned above.
+#
+# note: this will auto-fill the directory /lightning under JM's datadir/lnregtest-$i,
+# during setup in configure.py, for each $i, and start a separate lightning daemon for each;
+# his setup is triggered by the use of regtest.
+# Most importantly, the lightning-rpc location for sending RPC calls, and the receiving
+# tcp passthrough port for receiving messages from jmcl.py, are dynamically created at
+# this point and then passed into the LNOnionMessageChannel object init, which are the
+# only way in which the daemon processing is dependent on the config (the other elements
+# all occur during the aforementioned setup).
+#
+def get_ln_messaging_config_regtest(run_num: int):
+    """ Sets a ln messaging channel section for a regtest instance
+    indexed by `run_num`.
+    """
+    rpc_location = os.path.join(jm_single().datadir,
+                    "lightning-regtest"+str(run_num),
+                    "regtest", "lightning-rpc")
+    passthrough_port = 49100 + run_num
+    # This node corresponds to run_num=1:
+    dn_nodes_list = "03df15dbd9e20c811cc5f4155745e89540a0b83f33978317cebe9dfc46c5253c55@127.0.0.1:9736"
+    return {"type": "ln-onion",
+            "lightning-rpc": rpc_location,
+            "passthrough-port": passthrough_port,
+            "directory-nodes": dn_nodes_list}
+
+class RegtestJMClientProtocolFactory(JMClientProtocolFactory):
+    i = 1
+    def get_mchannels(self):
+        # swaps out any existing lightning configs
+        # in the config settings on startup, for one
+        # that's indexed to the regtest counter var:
+        default_chans = get_mchannels()
+        new_chans = []
+        ln_found = False
+        for c in default_chans:
+            if "type" in c and c["type"] == "ln-onion":
+                ln_found = True
+                continue
+            new_chans.append(c)
+        if ln_found:
+            new_chans.append(get_ln_messaging_config_regtest(self.i))
+        return new_chans
+
+class JMWalletDaemonT(JMWalletDaemon):
+    def check_cookie(self, request):
+        if self.auth_disabled:
+            return True
+        return super().check_cookie(request)
+
+class TWalletRPCManager(object):
+    """ Base class for set up of tests of the
+    Wallet RPC calls using the wallet_rpc.JMWalletDaemon service.
+    """
+    # the port for the jmwallet daemon
+    dport = 28183
+    # the port for the ws
+    wss_port = 28283
+    
+    def __init__(self):
+        # a client connnection object which is often but not always
+        # instantiated:
+        self.client_connector = None
+        self.daemon = JMWalletDaemonT(self.dport, self.wss_port, tls=False)
+        self.daemon.auth_disabled = True
+        # because we sync and start the wallet service manually here
+        # (and don't use wallet files yet), we won't have set a wallet name,
+        # so we set it here:
+        self.daemon.wallet_name = wallet_name
+
+    def start(self):
+        r, s = self.daemon.startService()
+        self.listener_rpc = r
+        self.listener_ws = s        
+
+    def get_route_root(self):
+        addr = "http://127.0.0.1:" + str(self.dport)
+        addr += api_version_string
+        return addr
+
+    def stop(self):
+        for dc in reactor.getDelayedCalls():
+            dc.cancel()        
+        d1 = defer.maybeDeferred(self.listener_ws.stopListening)
+        d2 = defer.maybeDeferred(self.listener_rpc.stopListening)
+        if self.client_connector:
+            self.client_connector.disconnect()
+        # only fire if everything is finished:
+        return defer.gatherResults([d1, d2])
+
+    @defer.inlineCallbacks
+    def do_request(self, agent, method, addr, body, handler, token=None):
+        if token:
+            headers = Headers({"Authorization": ["Bearer " + self.jwt_token]})
+        else:
+            headers = None
+        response = yield agent.request(method, addr, headers, bodyProducer=body)
+        yield self.response_handler(response, handler)
+
+    @defer.inlineCallbacks
+    def response_handler(self, response, handler):
+        body = yield readBody(response)
+        # these responses should always be 200 OK.
+        assert response.code == 200
+        # handlers check the body is as expected; no return.
+        yield handler(body)
+        return True
+
+@pytest.mark.parametrize(
+    "num_ygs, wallet_structures, fb_indices, mean_amt",
+    [
+        # 1sp 2yg, honest makers, one maker has FB:
+        (3, [[1, 3, 0, 0, 0]] * 4, [], 2),
+        # 1sp 3yg
+        #(3, [[1, 3, 0, 0, 0]] * 4, [], 2),
+        # 1 sp 9 ygs
+        #(9, [[1, 3, 0, 0, 0]] * 10, [], 2),
+    ])
+def test_start_ygs(setup_ln_ygrunner, num_ygs, wallet_structures, fb_indices,
+                   mean_amt):
+    """Set up some wallets, for the ygs and 1 sp.
+    Then start the ygs in background and publish
+    the seed of the sp wallet for easy import into -qt
+    """
+    if jm_single().config.get("POLICY", "native") == "true":
+        walletclass = SegwitWallet
+    else:
+        # TODO add Legacy
+        walletclass = SegwitLegacyWallet
+
+    wallet_services = make_wallets(num_ygs + 1,
+                           wallet_structures=wallet_structures,
+                           mean_amt=mean_amt,
+                           walletclass=walletclass,
+                           fb_indices=fb_indices)
+    #the sendpayment bot uses the last wallet in the list
+    wallet_service = wallet_services[num_ygs]['wallet']
+    jmprint("\n\nTaker wallet seed : " + wallet_services[num_ygs]['seed'])
+    # for manual audit if necessary, show the maker's wallet seeds
+    # also (note this audit should be automated in future, see
+    # test_full_coinjoin.py in this directory)
+    jmprint("\n\nMaker wallet seeds: ")
+    for i in range(num_ygs):
+        jmprint("Maker seed: " + wallet_services[i]['seed'])
+    jmprint("\n")
+    wallet_service.sync_wallet(fast=True)
+    ygclass = YieldGeneratorBasic
+
+    # As per previous note, override non-default command line settings:
+    options = {}
+    for x in ["ordertype", "txfee_contribution", "txfee_contribution_factor",
+              "cjfee_a", "cjfee_r", "cjfee_factor", "minsize", "size_factor"]:
+        options[x] = jm_single().config.get("YIELDGENERATOR", x)
+    ordertype = options["ordertype"]
+    txfee_contribution = int(options["txfee_contribution"])
+    txfee_contribution_factor = float(options["txfee_contribution_factor"])
+    cjfee_factor = float(options["cjfee_factor"])
+    size_factor = float(options["size_factor"])
+    if ordertype == 'reloffer':
+        cjfee_r = options["cjfee_r"]
+        # minimum size is such that you always net profit at least 20%
+        #of the miner fee
+        minsize = max(int(1.2 * txfee_contribution / float(cjfee_r)),
+            int(options["minsize"]))
+        cjfee_a = None
+    elif ordertype == 'absoffer':
+        cjfee_a = int(options["cjfee_a"])
+        minsize = int(options["minsize"])
+        cjfee_r = None
+    else:
+        assert False, "incorrect offertype config for yieldgenerator."
+
+    txtype = wallet_service.get_txtype()
+    if txtype == "p2wpkh":
+        prefix = "sw0"
+    elif txtype == "p2sh-p2wpkh":
+        prefix = "sw"
+    elif txtype == "p2pkh":
+        prefix = ""
+    else:
+        assert False, "Unsupported wallet type for yieldgenerator: " + txtype
+
+    ordertype = prefix + ordertype
+
+    for i in range(num_ygs):
+        cfg = [txfee_contribution, cjfee_a, cjfee_r, ordertype, minsize,
+               txfee_contribution_factor, cjfee_factor, size_factor]
+        wallet_service_yg = wallet_services[i]["wallet"]
+
+        wallet_service_yg.startService()
+
+        yg = ygclass(wallet_service_yg, cfg)
+        if i in fb_indices:
+            # create a timelocked address and fund it;
+            # must be done after sync, so deferred:
+            wallet_service_yg.timelock_funded = False
+            sync_wait_loop = task.LoopingCall(get_addr_and_fund, yg)
+            sync_wait_loop.start(1.0, now=False)
+        clientfactory = RegtestJMClientProtocolFactory(yg, proto_type="MAKER")
+        # This ensures that the right rpc/port config is passed into the daemon,
+        # for this specific bot:
+        clientfactory.i = i + 1
+        if jm_single().config.get("SNICKER", "enabled") == "true":
+            snicker_r = SNICKERReceiver(wallet_service_yg)
+            servers = jm_single().config.get("SNICKER", "servers").split(",")
+            snicker_factory = SNICKERClientProtocolFactory(snicker_r, servers)
+        else:
+            snicker_factory = None
+        nodaemon = jm_single().config.getint("DAEMON", "no_daemon")
+        daemon = True if nodaemon == 1 else False
+        #rs = True if i == num_ygs - 1 else False
+        start_reactor(jm_single().config.get("DAEMON", "daemon_host"),
+                      jm_single().config.getint("DAEMON", "daemon_port"),
+                      clientfactory, snickerfactory=snicker_factory,
+                      daemon=daemon, rs=False)
+    reactor.callLater(1.0, start_test_taker, wallet_services[num_ygs]['wallet'], 4)
+    reactor.run()
+
+@defer.inlineCallbacks
+def start_test_taker(wallet_service, i):
+    # this rpc manager has auth disabled,
+    # and the wallet_service is set manually,
+    # so no unlock etc.
+    mgr = TWalletRPCManager()
+    mgr.daemon.wallet_service = wallet_service
+    # because we are manually setting the wallet_service
+    # of the JMWalletDaemon instance, we do not follow the
+    # usual flow of `initialize_wallet_service`, we do not set
+    # the auth token or start the websocket; so we must manually
+    # sync the wallet, including bypassing any restart callback:
+    def dummy_restart_callback(msg):
+        log.warn("Ignoring rescan request from backend wallet service: " + msg)
+    mgr.daemon.wallet_service.add_restart_callback(dummy_restart_callback)
+    mgr.daemon.wallet_name = wallet_name
+    while not mgr.daemon.wallet_service.synced:
+        mgr.daemon.wallet_service.sync_wallet(fast=True)
+    mgr.daemon.wallet_service.startService()
+    def get_client_factory():
+        clientfactory = RegtestJMClientProtocolFactory(mgr.daemon.taker,
+                                                       proto_type="TAKER")
+        clientfactory.i = i
+        return clientfactory
+
+    mgr.daemon.get_client_factory = get_client_factory
+    # before preparing the RPC call to the wallet daemon,
+    # we decide a coinjoin destination and amount. Choosing
+    # a destination in the wallet is a bit easier because
+    # we can query the mixdepth balance at the end.
+    coinjoin_destination = mgr.daemon.wallet_service.get_internal_addr(4)
+    cj_amount = 22000000
+    # once the taker is finished we sanity check before
+    # shutting down:
+    def dummy_taker_finished(res, fromtx=False,
+                               waittime=0.0, txdetails=None):
+        jmprint("Taker is finished")
+        # check that the funds have arrived.
+        mbal = mgr.daemon.wallet_service.get_balance_by_mixdepth()[4]
+        assert mbal == cj_amount
+        jmprint("Funds: {} sats successfully arrived into mixdepth 4.".format(cj_amount))
+        stop_reactor()
+    mgr.daemon.taker_finished = dummy_taker_finished
+    mgr.start()
+    agent = get_nontor_agent()
+    addr = mgr.get_route_root()
+    addr += "/wallet/"
+    addr += mgr.daemon.wallet_name
+    addr += "/taker/coinjoin"
+    addr = addr.encode()
+    body = BytesProducer(json.dumps({"mixdepth": "1",
+        "amount_sats": cj_amount,
+        "counterparties": "2",
+        "destination": coinjoin_destination}).encode())
+    yield mgr.do_request(agent, b"POST", addr, body,
+                          process_coinjoin_response)
+
+def process_coinjoin_response(response):
+    json_body = json.loads(response.decode("utf-8"))
+    print("coinjoin response: {}".format(json_body))
+
+def get_addr_and_fund(yg):
+    """ This function allows us to create
+    and publish a fidelity bond for a particular
+    yield generator object after the wallet has reached
+    a synced state and is therefore ready to serve up
+    timelock addresses. We create the TL address, fund it,
+    refresh the wallet and then republish our offers, which
+    will also publish the new FB.
+    """
+    if not yg.wallet_service.synced:
+        return
+    if yg.wallet_service.timelock_funded:
+        return
+    addr = wallet_gettimelockaddress(yg.wallet_service.wallet, "2021-11")
+    print("Got timelockaddress: {}".format(addr))
+
+    # pay into it; amount is randomized for now.
+    # Note that grab_coins already mines 1 block.
+    fb_amt = random.randint(1, 5)
+    jm_single().bc_interface.grab_coins(addr, fb_amt)
+
+    # we no longer have to run this loop (TODO kill with nonlocal)
+    yg.wallet_service.timelock_funded = True
+
+    # force wallet to check for the new coins so the new
+    # yg offers will include them:
+    yg.wallet_service.transaction_monitor()
+
+    # publish a new offer:
+    yg.offerlist = yg.create_my_orders()
+    yg.fidelity_bond = yg.get_fidelity_bond_template()
+    jmprint('updated offerlist={}'.format(yg.offerlist))
+
+@pytest.fixture(scope="module")
+def setup_ln_ygrunner():
+    load_test_config(ln_backend_needed=True)
+    jm_single().bc_interface.tick_forward_chain_interval = 10
+    jm_single().bc_interface.simulate_blocks()

--- a/test/e2e-coinjoin-test.py
+++ b/test/e2e-coinjoin-test.py
@@ -295,7 +295,7 @@ def test_start_yg_and_taker_setup(setup_ln_ygrunner):
         start_reactor(jm_single().config.get("DAEMON", "daemon_host"),
                       jm_single().config.getint("DAEMON", "daemon_port"),
                       clientfactory, daemon=daemon, rs=False)
-    reactor.callLater(1.0, start_test_taker, wallet_services[end_bot_num - 1]['wallet'], 4)
+    reactor.callLater(1.0, start_test_taker, wallet_services[end_bot_num - 1]['wallet'], end_bot_num)
     reactor.run()
 
 @defer.inlineCallbacks

--- a/test/regtest_joinmarket.cfg
+++ b/test/regtest_joinmarket.cfg
@@ -46,11 +46,8 @@ clightning-location = bundled
 directory-nodes = 03df15dbd9e20c811cc5f4155745e89540a0b83f33978317cebe9dfc46c5253c55@localhost:9735
 passthrough-port = 49101
 lightning-port = 9736
-# means we use indices 1,2,3,4:
-regtest-count=1,4
-
-# Note: for now, lightning messaging section is created
-# on the fly for the ln-onion specific test.
+# means we use indices 1,2,3,4,5:
+regtest-count=1,5
 
 [TIMEOUT]
 maker_timeout_sec = 10

--- a/test/regtest_joinmarket.cfg
+++ b/test/regtest_joinmarket.cfg
@@ -16,6 +16,7 @@ network = testnet
 rpc_wallet_file = jm-test-wallet
 
 [MESSAGING:server1]
+type = irc
 host = localhost
 hostid = localhost1
 channel = joinmarket-pit
@@ -26,6 +27,7 @@ socks5_host = localhost
 socks5_port = 9150
 
 [MESSAGING:server2]
+type = irc
 host = localhost
 hostid = localhost2
 channel = joinmarket-pit
@@ -34,6 +36,9 @@ usessl = false
 socks5 = false
 socks5_host = localhost
 socks5_port = 9150
+
+# Note: for now, lightning messaging section is created
+# on the fly for the ln-onion specific test.
 
 [TIMEOUT]
 maker_timeout_sec = 15

--- a/test/regtest_joinmarket.cfg
+++ b/test/regtest_joinmarket.cfg
@@ -37,11 +37,26 @@ socks5 = false
 socks5_host = localhost
 socks5_port = 9150
 
+[MESSAGING:lightning1]
+type = ln-onion
+clightning-location = bundled
+# This is a comma separated list (comma can be omitted if only one item).
+# Each item has format pubkey@host:port ; all are required. Host can be
+# a *.onion address (tor v3 only).
+directory-nodes = 03df15dbd9e20c811cc5f4155745e89540a0b83f33978317cebe9dfc46c5253c55@localhost:9735
+passthrough-port = 49101
+lightning-port = 9736
+# means we use indices 1,2,3,4:
+regtest-count=1,4
+
 # Note: for now, lightning messaging section is created
 # on the fly for the ln-onion specific test.
 
 [TIMEOUT]
-maker_timeout_sec = 15
+maker_timeout_sec = 10
+
+[LOGGING]
+console_log_level = DEBUG
 
 [POLICY]
 # for dust sweeping, try merge_algorithm = gradual

--- a/test/ygrunner.py
+++ b/test/ygrunner.py
@@ -260,7 +260,7 @@ def get_addr_and_fund(yg):
 
 @pytest.fixture(scope="module")
 def setup_ygrunner():
-    load_test_config()
+    load_test_config(ln_backend_needed=True)
     jm_single().bc_interface.tick_forward_chain_interval = 10
     jm_single().bc_interface.simulate_blocks()
     # handles the custom regtest hrp for bech32

--- a/test/ygrunner.py
+++ b/test/ygrunner.py
@@ -96,7 +96,7 @@ class DeterministicMaliciousYieldGenerator(YieldGeneratorBasic):
     "num_ygs, wallet_structures, fb_indices, mean_amt, malicious, deterministic",
     [
         # 1sp 3yg, honest makers, one maker has FB:
-        (3, [[1, 3, 0, 0, 0]] * 4, [1, 2], 2, 0, False),
+        (3, [[1, 3, 0, 0, 0]] * 4, [], 2, 0, False),
         # 1sp 3yg, malicious makers reject on auth and on tx 30% of time
         #(3, [[1, 3, 0, 0, 0]] * 4, 2, 30, False),
         # 1 sp 9 ygs, deterministically malicious 50% of time
@@ -173,6 +173,27 @@ def test_start_ygs(setup_ygrunner, num_ygs, wallet_structures, fb_indices,
             ygclass = DeterministicMaliciousYieldGenerator
         else:
             ygclass = MaliciousYieldGenerator
+    # Note for tests of Lightning message channels:
+    # (this data is not really needed *here* as the bots
+    # retrieve their keys on startup with `getinfo`, but is here
+    # for reference).
+    #
+    # These nodes are generated with private keys (using --dev-force-privkey):
+    # (note of course that c-lightning must be built with --enable-developer)
+    # 121212121212121212121212121212121212121212121212121212121212121$i
+    # with $i 1..3
+    #
+    # l1-regtest:
+    #  lightningd: Server started with public key 03df15dbd9e20c811cc5f4155745e89540a0b83f33978317cebe9dfc46c5253c55,
+    #  alias HOPPINGSET-v0.10.1rc2-modded (color #03df15) and lightningd v0.10.1rc2-modded
+    # l2-regtest:
+    #  lightningd: Server started with public key 036360e856310ce5d294e8be33fc807077dc56ac80d95d9cd4ddbd21325eff73f7,
+    #  alias GREENSPAWN-v0.10.1rc2-modded (color #036360) and lightningd v0.10.1rc2-modded
+    # l3-regtest:
+    # lightningd: Server started with public key 02edde301d65a673fc8a37e9c8d34878adfbc561f66afbcc37db9bc9fbf5088ef5,
+    # alias HOPPINGSQUIRREL-0.10.1rc2-modded (color #02edde) and lightningd v0.10.1rc2-modded
+    # We will treat the first of these three, with port 7171 on localhost, as the directory node for the tests
+
     for i in range(num_ygs):
         cfg = [txfee_contribution, cjfee_a, cjfee_r, ordertype, minsize,
                txfee_contribution_factor, cjfee_factor, size_factor]


### PR DESCRIPTION
*I made several updates to this description on 29 Dec 2021 as it was substantially out of date.*

See commit message for a brief technical summary of implementation in code.

For an explanation of the reasoning for creating this, see the first section of https://github.com/JoinMarket-Org/joinmarket-clientserver/blob/3f8fa0ea8156eeabe40c2a62a3c3e38026dae31f/docs/lightning-message-channels.md.

Some extra points relevant to review and further progress:

* Transactions work. And on regtest/localhost they are a *lot* faster than using our existing IRC tests (miniircd), which is encouraging, if not hugely meaningful.
* No tests have yet been added (and indeed some existing tests are broken, though that is probably trivial).
* This should work correctly with a mixture of IRC+LN message channels.

Those are more trivial points, but the bigger ones:

* I don't want to go whole-hog to a mainnet ready implementation until others like @chris-belcher @undeath @kristapsk and others have had a chance to give their thoughts. In particular: does this kind of "meta-layer" of communication need some extra features? ~~My best guess is that for now we should embed a version number in all the LN-sent messages such that we can support an upgrade in future (i.e. new bots with a better system can happily talk to old bots on the old system .. this usually means version range).~~ done
* The most important thing that this *doesn't* do yet is: pass messages over hops. Although bots can always `!privmsg` directly to other bots, if they have a connection, ~~there is not currently implemented, even an attempt to connect to bots other than the directory nodes that we connect to at the start~~ - see later comments, we now switch to *direct* messaging once we learn of peers via `!fill` and `!offer` messages. ~~This means that it's more the old IRC model of "privmsgs are end to end encrypted" and not really decentralized further than the existing model; but that's just because I haven't tried to code that yet, not because it can't be done.~~ ~~In a similar vein, while the user can configure a list of directory nodes, the code currently only uses the first directory node in the list.~~ This second sentence is also now out of date, multiple directory nodes are supported.
* A more long term one but important will be: the directory node's DOS control measures. I envisage issuance of tokens against small Lightning payments, but you could conceivably use one of the two methods we've already used against Sybil/DOS: PoDLE or fidelity bonds. I like the Chaumian tokens against small LN payments personally, but that's a bunch of new stuff (idea: directory issues its own tokens, user pays a tiny fraction on a per message basis, see e.g. Wabisabi MACs, although that's just one example, maybe such denomination flexibility not needed here). Anything that prevents "million messages per second from one guy" could do as a starting point.


Points of discussion at the code/design level:

About the messaging, the most important thing to read is ~~the set of comments at the top of `jmdaemon/lnonion.py`~~ (this has been moved to a [PR](https://github.com/JoinMarket-Org/JoinMarket-Docs/pull/9) in Joinmarket-Docs) which explains how we translate from (Joinmarket text formatted messages) -> (a slightly extend string containing to/from information to be passed into Lightning) -> (the contents of the `sendcustommsg` message).

Design-wise, pretty much everything here is arguable. The main goal was to have a class which inherits from `jmdaemon.message_channel.MessageChannel` and implement it, as `irc.py` does, and that is achieved here. The slightly obscure differences between privmsg and pubmsg are not as easy to reason about as they might be, but, it's OK. The layers of encoding are kind of painful, but at least we maintain consistency.

The actual message parsing is "asymmetric" in a weird way: messages come *in* via the plugin, via this hook:

```python3
@plugin.hook("custommsg")
on_custommsg(peer_id, payload, plugin, **kwargs):
```

and they are then handed over to `jmdaemon` over TCP port (default 49100) to a `twisted.protocols.basic.LineReceiver`. The messages go *out*, however, by sending the RPC command `sendcustommsg` (same format, of course). See this method in `LNOnionMessageChannel`:

```python3
    def _send(self, peerid: str, message: bytes) -> None:
```

(Since it's only referenced in the doc, tagging here: #415 ).