### PR TITLE
Add a menu action to force wallet refresh

### DIFF
--- a/scripts/joinmarket-qt.py
+++ b/scripts/joinmarket-qt.py
@@ -1459,9 +1459,12 @@ class JMWalletTab(QWidget):
             menu.addAction("Copy extended public key to clipboard",
                            lambda: app.clipboard().setText(xpub),
                            shortcut=QKeySequence(QKeySequence.Copy))
+        menu.addAction("Refresh wallet",
+                       lambda: mainWindow.updateWalletInfo(None, "all"),
+                       shortcut=QKeySequence(QKeySequence.Refresh))
+
         #TODO add more items to context menu
-        if address_valid or xpub_exists:
-            menu.exec_(self.walletTree.viewport().mapToGlobal(position))
+        menu.exec_(self.walletTree.viewport().mapToGlobal(position))
 
     def openQRCodePopup(self, address):
         bip21_uri = btc.encode_bip21_uri(address, {})


### PR DESCRIPTION
After https://github.com/JoinMarket-Org/joinmarket-clientserver/pull/942, the Qt wallet view is only updated when the callback is triggered.

If, for some reason, the callback wasn't triggered properly, a user would have to close and re-open the Qt wallet to refresh the wallet.

This PR adds a new menu action, "Refresh Wallet", so that in this rare case, a user can use this menu action to force a wallet refresh.