### PR TITLE
Hide the donateLayout as it is currently disabled.

### DIFF
--- a/scripts/joinmarket-qt.py
+++ b/scripts/joinmarket-qt.py
@@ -536,8 +536,9 @@ class SpendTab(QWidget):
         innerTopLayout.setSpacing(4)
         self.single_join_tab.setLayout(innerTopLayout)
 
-        donateLayout = self.getDonateLayout()
-        innerTopLayout.addLayout(donateLayout, 0, 0, 1, 2)
+        #Temporarily disabled
+        # donateLayout = self.getDonateLayout()
+        # innerTopLayout.addLayout(donateLayout, 0, 0, 1, 2)
 
         recipientLabel = QLabel('Recipient address / URI')
         recipientLabel.setToolTip(


### PR DESCRIPTION
The current Coinjoins tab has a disabled donation checkbox:
![image](https://user-images.githubusercontent.com/87334822/132644961-225b303c-be4b-4642-ae9e-be618d6003b7.png)

When a user click the More button, it shows the following message:
![image](https://user-images.githubusercontent.com/87334822/132645137-de9a9a1c-bbf5-4937-9fe6-2c27e665ff31.png)

I think it's not a great idea to show the donation feature while it's disabled, so I propose in this PR, that we hide this section entirely until we re-enabled the donation feature.


