### PR TITLE
Improve the UX of Open Wallet dialog

### DIFF
--- a/jmqtui/jmqtui/open_wallet_dialog.py
+++ b/jmqtui/jmqtui/open_wallet_dialog.py
@@ -92,6 +92,30 @@ class Ui_OpenWalletDialog(object):
 
         self.verticalLayout.addLayout(self.horizontalLayout_2)
 
+        self.horizontalLayout_4 = QHBoxLayout()
+        self.horizontalLayout_4.setSpacing(10)
+        self.horizontalLayout_4.setObjectName(u"horizontalLayout_4")
+        self.errorMessageLabel = QLabel(OpenWalletDialog)
+        self.errorMessageLabel.setObjectName(u"errorMessageLabel")
+        palette = QPalette()
+        brush = QBrush(QColor(239, 41, 41, 255))
+        brush.setStyle(Qt.SolidPattern)
+        palette.setBrush(QPalette.Active, QPalette.WindowText, brush)
+        palette.setBrush(QPalette.Inactive, QPalette.WindowText, brush)
+        brush1 = QBrush(QColor(190, 190, 190, 255))
+        brush1.setStyle(Qt.SolidPattern)
+        palette.setBrush(QPalette.Disabled, QPalette.WindowText, brush1)
+        self.errorMessageLabel.setPalette(palette)
+        font = QFont()
+        font.setBold(True)
+        font.setWeight(75)
+        self.errorMessageLabel.setFont(font)
+
+        self.horizontalLayout_4.addWidget(self.errorMessageLabel)
+
+
+        self.verticalLayout.addLayout(self.horizontalLayout_4)
+
         self.verticalSpacer = QSpacerItem(20, 150, QSizePolicy.Minimum, QSizePolicy.Minimum)
 
         self.verticalLayout.addItem(self.verticalSpacer)
@@ -114,9 +138,9 @@ class Ui_OpenWalletDialog(object):
 
         self.verticalLayout.addLayout(self.horizontalLayout_3)
 
-        self.verticalLayout.setStretch(2, 1)
-        QWidget.setTabOrder(self.passphraseEdit, self.chooseWalletButton)
-        QWidget.setTabOrder(self.chooseWalletButton, self.walletFileEdit)
+        self.verticalLayout.setStretch(3, 1)
+        QWidget.setTabOrder(self.walletFileEdit, self.chooseWalletButton)
+        QWidget.setTabOrder(self.chooseWalletButton, self.passphraseEdit)
 
         self.retranslateUi(OpenWalletDialog)
         self.buttonBox.accepted.connect(OpenWalletDialog.accept)
@@ -132,5 +156,6 @@ class Ui_OpenWalletDialog(object):
         self.walletFileEdit.setPlaceholderText("")
         self.chooseWalletButton.setText(QCoreApplication.translate("OpenWalletDialog", u"Choose...", None))
         self.label_2.setText(QCoreApplication.translate("OpenWalletDialog", u"Passphrase:", None))
+        self.errorMessageLabel.setText("")
     # retranslateUi
 

--- a/jmqtui/jmqtui/open_wallet_dialog.ui
+++ b/jmqtui/jmqtui/open_wallet_dialog.ui
@@ -25,7 +25,7 @@
   <property name="modal">
    <bool>true</bool>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout" stretch="0,0,1,0">
+  <layout class="QVBoxLayout" name="verticalLayout" stretch="0,0,0,1,0">
    <property name="spacing">
     <number>10</number>
    </property>
@@ -146,6 +146,63 @@
     </layout>
    </item>
    <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_4" stretch="0">
+     <property name="spacing">
+      <number>10</number>
+     </property>
+     <item>
+      <widget class="QLabel" name="errorMessageLabel">
+       <property name="palette">
+        <palette>
+         <active>
+          <colorrole role="WindowText">
+           <brush brushstyle="SolidPattern">
+            <color alpha="255">
+             <red>239</red>
+             <green>41</green>
+             <blue>41</blue>
+            </color>
+           </brush>
+          </colorrole>
+         </active>
+         <inactive>
+          <colorrole role="WindowText">
+           <brush brushstyle="SolidPattern">
+            <color alpha="255">
+             <red>239</red>
+             <green>41</green>
+             <blue>41</blue>
+            </color>
+           </brush>
+          </colorrole>
+         </inactive>
+         <disabled>
+          <colorrole role="WindowText">
+           <brush brushstyle="SolidPattern">
+            <color alpha="255">
+             <red>190</red>
+             <green>190</green>
+             <blue>190</blue>
+            </color>
+           </brush>
+          </colorrole>
+         </disabled>
+        </palette>
+       </property>
+       <property name="font">
+        <font>
+         <weight>75</weight>
+         <bold>true</bold>
+        </font>
+       </property>
+       <property name="text">
+        <string/>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
@@ -194,9 +251,9 @@
   </layout>
  </widget>
  <tabstops>
-  <tabstop>passphraseEdit</tabstop>
-  <tabstop>chooseWalletButton</tabstop>
   <tabstop>walletFileEdit</tabstop>
+  <tabstop>chooseWalletButton</tabstop>
+  <tabstop>passphraseEdit</tabstop>
  </tabstops>
  <resources/>
  <connections>


### PR DESCRIPTION
This PR addresses the first two items in the "Next step improvements" of #932:

1. Show all the error messages, like "Wrong Password", "File not exist", "Invalid wallet file" etc., within the same dialog, and allow the user to make changes to their decisions in the same dialog when these errors occur.

![image](https://user-images.githubusercontent.com/87334822/132820190-1cbbf5fd-4d14-4317-a287-3aec378c4a41.png)

![image](https://user-images.githubusercontent.com/87334822/132820240-0a98e50a-43fe-4449-89e6-093af1f3533c.png)

2. Update the UX of menu action "Wallet -> Load" to also use this new Open Wallet dialog.
In this update, I also renamed the current menu item "Load" to "Open", and added a shortcut "Ctrl+O" for this menu item, which I believe is more consistent with the expectation of the UI from most users.