### PR TITLE
Use `fidelity_bond_weighted_order_choose` in Qt

### DIFF
--- a/jmclient/jmclient/__init__.py
+++ b/jmclient/jmclient/__init__.py
@@ -3,6 +3,7 @@ import logging
 
 from .support import (calc_cj_fee, choose_sweep_orders, choose_orders,
                       cheapest_order_choose, weighted_order_choose,
+                      fidelity_bond_weighted_order_choose,
                       rand_norm_array, rand_exp_array,
                       rand_weighted_choice, select,
                       select_gradual, select_greedy, select_greediest,

--- a/jmclient/jmclient/taker.py
+++ b/jmclient/jmclient/taker.py
@@ -9,7 +9,7 @@ from twisted.internet import reactor, task
 import jmbitcoin as btc
 from jmclient.configure import jm_single, validate_address, get_interest_rate
 from jmbase import get_log, bintohex, hexbin
-from jmclient.support import (calc_cj_fee, weighted_order_choose, choose_orders,
+from jmclient.support import (calc_cj_fee, fidelity_bond_weighted_order_choose, choose_orders,
                               choose_sweep_orders)
 from jmclient.wallet import estimate_tx_fee, compute_tx_locktime, FidelityBondMixin
 from jmclient.podle import generate_podle, get_podle_commitments
@@ -47,7 +47,7 @@ class Taker(object):
                  wallet_service,
                  schedule,
                  max_cj_fee,
-                 order_chooser=weighted_order_choose,
+                 order_chooser=fidelity_bond_weighted_order_choose,
                  callbacks=None,
                  tdestaddrs=None,
                  custom_change_address=None,

--- a/scripts/joinmarket-qt.py
+++ b/scripts/joinmarket-qt.py
@@ -61,7 +61,7 @@ from jmbase.support import EXIT_FAILURE, utxo_to_utxostr,\
 import jmbitcoin as btc
 from jmclient import load_program_config, get_network, update_persist_config,\
     open_test_wallet_maybe, get_wallet_path,\
-    jm_single, validate_address, weighted_order_choose, Taker,\
+    jm_single, validate_address, fidelity_bond_weighted_order_choose, Taker,\
     JMClientProtocolFactory, start_reactor, get_schedule, schedule_to_text,\
     get_blockchain_interface_instance, direct_send, WalletService,\
     RegtestBitcoinCoreInterface, tumbler_taker_finished_update,\
@@ -890,7 +890,7 @@ class SpendTab(QWidget):
         self.taker = Taker(mainWindow.wallet_service,
                            self.spendstate.loaded_schedule,
                            maxcjfee,
-                           order_chooser=weighted_order_choose,
+                           order_chooser=fidelity_bond_weighted_order_choose,
                            callbacks=[check_offers_callback,
                                       self.takerInfo,
                                       self.takerFinished],


### PR DESCRIPTION
1. Replace `weighted_order_choose` with `fidelity_bond_weighted_order_choose` when coinjoin via Qt
2. Set `fidelity_bond_weighted_order_choose` as the default order chooser for a Taker