### PR TITLE
Add configurable miner fee randomization factor

### DIFF
--- a/jmclient/jmclient/configure.py
+++ b/jmclient/jmclient/configure.py
@@ -206,10 +206,13 @@ merge_algorithm = default
 # be interpreted as the fee in satoshi per kB that you wish to use
 # example: N=30000 will use 30000 sat/kB as a fee, while N=5
 # will use the estimate from your selected blockchain source
-# Note that there will be a 20% variation around any manually chosen
-# values, so if you set N=10000, it might use any value between
-# 8000 and 12000 for your transactions.
 tx_fees = 3
+
+# Transaction fee rate variance factor, 0.2 means 20% variation around
+# any manually chosen values, so if you set tx_fees=10000 and
+# tx_fees_factor=0.2, it might use any value between 8000 and 12000 for
+# your transactions.
+tx_fees_factor = 0.2
 
 # For users getting transaction fee estimates over an API,
 # place a sanity check limit on the satoshis-per-kB to be paid.


### PR DESCRIPTION
Defaults to previously hardcoded 0.2 (+/- 20%).

Resolves #1009.

What I don't like is that we now have `tx_fees` and `tx_fees_factor` under `[POLICY]` and `txfee` and `txfee_factor` under `[YIELDGENERATOR]`, which may be confusing, but I don't see a good solution to that (apart from getting rid of yg txfee configs).