### PR TITLE
Add additional IRC servers (incl. I2P) — pending until #1049 is clarified

### DIFF
--- a/jmclient/jmclient/configure.py
+++ b/jmclient/jmclient/configure.py
@@ -124,48 +124,96 @@ rpc_user = bitcoin
 rpc_password = password
 rpc_wallet_file =
 
+## SERVER 1/5) Darkscience IRC (IP, Tor):
+################################################################################
 [MESSAGING:server1]
-host = irc.darkscience.net
 channel = joinmarket-pit
 port = 6697
 usessl = true
-socks5 = false
-socks5_host = localhost
-socks5_port = 9050
 
-#for tor
+# for IP (default):
+host = irc.darkscience.net
+socks5 = false
+
+# for Tor:
 #host = darkirc6tqgpnwd3blln3yfv5ckl47eg7llfxkmtovrv7c7iwohhb6ad.onion
 #socks5 = true
+#socks5_host = localhost
+#socks5_port = 9050
 
+## SERVER 2/5) hackint IRC (IP, Tor):
+################################################################################
 [MESSAGING:server2]
-host = irc.hackint.org
 channel = joinmarket-pit
+
+# for IP (default):
+host = irc.hackint.org
 port = 6697
 usessl = true
 socks5 = false
-socks5_host = localhost
-socks5_port = 9050
 
-#for tor
+# for Tor:
 #host = ncwkrwxpq2ikcngxq3dy2xctuheniggtqeibvgofixpzvrwpa77tozqd.onion
 #port = 6667
 #usessl = false
 #socks5 = true
+#socks5_host = localhost
+#socks5_port = 9050
 
+## SERVER 3/5) Anarplex IRC (IP, Tor, I2P):
+################################################################################
 [MESSAGING:server3]
-host = agora.anarplex.net
 channel = joinmarket-pit
+
+# for IP (default):
+host = agora.anarplex.net
 port = 14716
 usessl = true
 socks5 = false
-socks5_host = localhost
-socks5_port = 9050
 
-#for tor
+# for Tor:
 #host = vxecvd6lc4giwtasjhgbrr3eop6pzq6i5rveracktioneunalgqlwfad.onion
 #port = 6667
 #usessl = false
 #socks5 = true
+#socks5_host = localhost
+#socks5_port = 9050
+
+# for I2P (instead of Tor):
+#host = eplpiyfwgnq74wbfveughu2l2kdzvcriaovjjbgn5zwe7pgmtyzq.b32.i2p
+#port = 6667
+#usessl = false
+#socks5 = true
+#socks5_host = localhost
+#socks5_port = 4447
+
+## SERVER 4/5) ILITA IRC (Tor, I2P):
+################################################################################
+#[MESSAGING:server4]
+#channel = joinmarket-pit
+#port = 6667
+#usessl = false
+#socks5 = true
+#socks5_host = localhost
+
+# for Tor:
+#host = ilitafrzzgxymv6umx2ux7kbz3imyeko6cnqkvy4nisjjj4qpqkrptid.onion
+#socks5_port = 9050
+
+# for I2P (instead of Tor):
+#host = irc.ilita.i2p # fallbacks: irc.acetone.i2p, irc.r4sas.i2p
+#socks5_port = 4447
+
+## SERVER 5/5) Irc2P (I2P only):
+################################################################################
+#[MESSAGING:server5]
+#channel = joinmarket-pit
+#host = irc.postman.i2p
+#port = 6667
+#usessl = false
+#socks5 = true
+#socks5_host = localhost
+#socks5_port = 4447
 
 [LOGGING]
 # Set the log level for the output to the terminal/console
@@ -200,7 +248,7 @@ merge_algorithm = default
 
 # The fee estimate is based on a projection of how many satoshis
 # per kB are needed to get in one of the next N blocks, N set here
-# as the value of 'tx_fees'. This cost estimate is high if you set 
+# as the value of 'tx_fees'. This cost estimate is high if you set
 # N=1, so we choose 3 for a more reasonable figure, as our default.
 # You can also set your own fee/kb: any number higher than 1000 will
 # be interpreted as the fee in satoshi per kB that you wish to use


### PR DESCRIPTION
**ON HOLD — Let's first figure out the more focused PR here: #1049** 

Should we try this? More redundancy means more resiliency, right?

FYI, it seems that the Agora server is down, as of today.
However, their website says: "disabled currently, will be fixed"

- Agora: https://anarplex.net/agorairc/connect/
- Ilita (Tor): http://ilitafrzzgxymv6umx2ux7kbz3imyeko6cnqkvy4nisjjj4qpqkrptid.onion
- Ilita (Tor2web): https://irc.acetone.onion.ws/
- Irc2P: https://geti2p.net/en/docs/applications/irc
