### PR TITLE
Recommend .onion IRC as default, add I2P options

### DIFF
--- a/jmclient/jmclient/configure.py
+++ b/jmclient/jmclient/configure.py
@@ -124,48 +124,85 @@ rpc_user = bitcoin
 rpc_password = password
 rpc_wallet_file =
 
+## SERVER 1/4) Darkscience IRC (Tor, IP)
+################################################################################
 [MESSAGING:server1]
-host = irc.darkscience.net
 channel = joinmarket-pit
 port = 6697
 usessl = true
-socks5 = false
+
+# for Tor (default & recommended):
+host = darkirc6tqgpnwd3blln3yfv5ckl47eg7llfxkmtovrv7c7iwohhb6ad.onion
+socks5 = true
 socks5_host = localhost
 socks5_port = 9050
 
-#for tor
-#host = darkirc6tqgpnwd3blln3yfv5ckl47eg7llfxkmtovrv7c7iwohhb6ad.onion
-#socks5 = true
+# for traditional IP (not recommended):
+#host = irc.darkscience.net
+#socks5 = false
 
+## SERVER 2/4) hackint IRC (Tor, IP)
+################################################################################
 [MESSAGING:server2]
-host = irc.hackint.org
 channel = joinmarket-pit
-port = 6697
-usessl = true
-socks5 = false
+
+# for Tor (default & recommended):
+host = ncwkrwxpq2ikcngxq3dy2xctuheniggtqeibvgofixpzvrwpa77tozqd.onion
+port = 6667
+usessl = false
+socks5 = true
 socks5_host = localhost
 socks5_port = 9050
 
-#for tor
-#host = ncwkrwxpq2ikcngxq3dy2xctuheniggtqeibvgofixpzvrwpa77tozqd.onion
-#port = 6667
-#usessl = false
-#socks5 = true
+# for traditional IP (not recommended):
+#host = irc.hackint.org
+#port = 6697
+#usessl = true
+#socks5 = false
 
+## SERVER 3/4) Anarplex IRC (Tor, I2P, IP)
+################################################################################
 [MESSAGING:server3]
-host = agora.anarplex.net
 channel = joinmarket-pit
-port = 14716
-usessl = true
-socks5 = false
+
+# for Tor (default & recommended):
+host = vxecvd6lc4giwtasjhgbrr3eop6pzq6i5rveracktioneunalgqlwfad.onion
+port = 6667
+usessl = false
+socks5 = true
 socks5_host = localhost
 socks5_port = 9050
 
-#for tor
-#host = vxecvd6lc4giwtasjhgbrr3eop6pzq6i5rveracktioneunalgqlwfad.onion
+# for I2P (alternative to Tor):
+#host = eplpiyfwgnq74wbfveughu2l2kdzvcriaovjjbgn5zwe7pgmtyzq.b32.i2p
 #port = 6667
 #usessl = false
 #socks5 = true
+#socks5_host = localhost
+#socks5_port = 4447
+
+# for traditional IP (not recommended):
+#host = agora.anarplex.net
+#port = 14716
+#usessl = true
+#socks5 = false
+
+## SERVER 4/4) ILITA IRC (Tor, I2P)
+################################################################################
+[MESSAGING:server4]
+channel = joinmarket-pit
+port = 6667
+usessl = false
+socks5 = true
+socks5_host = localhost
+
+# for Tor (default & recommended):
+host = ilitafrzzgxymv6umx2ux7kbz3imyeko6cnqkvy4nisjjj4qpqkrptid.onion
+socks5_port = 9050
+
+# for I2P (alternative to Tor):
+#host = irc.ilita.i2p # fallbacks: irc.acetone.i2p, irc.r4sas.i2p
+#socks5_port = 4447
 
 [LOGGING]
 # Set the log level for the output to the terminal/console
@@ -200,7 +237,7 @@ merge_algorithm = default
 
 # The fee estimate is based on a projection of how many satoshis
 # per kB are needed to get in one of the next N blocks, N set here
-# as the value of 'tx_fees'. This cost estimate is high if you set 
+# as the value of 'tx_fees'. This cost estimate is high if you set
 # N=1, so we choose 3 for a more reasonable figure, as our default.
 # You can also set your own fee/kb: any number higher than 1000 will
 # be interpreted as the fee in satoshi per kB that you wish to use


### PR DESCRIPTION
This is the next iteration of https://github.com/JoinMarket-Org/joinmarket-clientserver/pull/1038

- Make .onion IRC servers the default choice across networks
- Add Ilita (.onion): http://ilitafrzzgxymv6umx2ux7kbz3imyeko6cnqkvy4nisjjj4qpqkrptid.onion
- Add Ilita I2P alternative (see link above)
- Add Agora I2P alternative: https://anarplex.net/agorairc/connect/
- Clean up server list overall

(Does not include Irc2P I2P-only IRC server. Does not include OFTC.)
