### PR TITLE
Prevent amounts less than minsize being processed

### DIFF
--- a/jmclient/jmclient/configure.py
+++ b/jmclient/jmclient/configure.py
@@ -410,7 +410,8 @@ cjfee_r = 0.00002
 cjfee_factor = 0.1
 
 # [satoshis, any integer] / the average transaction fee you're adding to coinjoin transactions
-txfee_contribution = 100
+# (note: this will soon be deprecated; leave at zero)
+txfee_contribution = 0
 
 # [fraction, 0-1] / variance around the average fee. Ex: 1000 fee, 0.2 var = fee is btw 800-1200
 txfee_contribution_factor = 0.3

--- a/jmclient/jmclient/maker.py
+++ b/jmclient/jmclient/maker.py
@@ -215,7 +215,11 @@ class Maker(object):
         my_total_in = sum([va['value'] for va in utxos.values()])
         real_cjfee = calc_cj_fee(ordertype, cjfee, amount)
         expected_change_value = (my_total_in - amount - txfee + real_cjfee)
-        jlog.info('potentially earned = {}'.format(btc.amount_to_str(real_cjfee - txfee)))
+        potentially_earned = real_cjfee - txfee
+        if potentially_earned < 0:
+            return (False, "A negative earning was calculated: {}.".format(
+                potentially_earned))
+        jlog.info('potentially earned = {}'.format(btc.amount_to_str(potentially_earned)))
         jlog.info('mycjaddr, mychange = {}, {}'.format(cjaddr, changeaddr))
 
         #The remaining checks are needed to ensure

--- a/jmdaemon/jmdaemon/daemon_protocol.py
+++ b/jmdaemon/jmdaemon/daemon_protocol.py
@@ -771,9 +771,11 @@ class JMDaemonServerProtocol(amp.AMP, OrderbookWatch):
         offer_s = [o for o in self.offerlist if o['oid'] == oid]
         if len(offer_s) == 0:
             self.mcc.send_error(nick, 'oid not found')
+            return
         offer = offer_s[0]
         if amount < offer['minsize'] or amount > offer['maxsize']:
             self.mcc.send_error(nick, 'amount out of range')
+            return
         #prepare a pubkey for this valid transaction
         kp = init_keypair()
         try:


### PR DESCRIPTION
Prior to this commit, it was possible for a modified
taker client to get a maker to participate in a join
tx with a size less than their minsize, which could
burn up to an amount of the txfee contribution to
miner fees.
After this commit, the maker stops the coinjoin
coordination when the too-small coinjoin size is seen,
as intended.
Additionally, a check is now in place in the function
`Maker.verify_unsigned_transaction` that the earned
amount is positive, which otherwise could raise an
Exception (but should now be impossible in any case).
Also, changed the default txfee_contibution to zero
as it is of no value to have a nonzero amount.
Also return added for unrecognized orderid, for clearer
error messages.