### PR TITLE
Add support to build and autostart local Tor instance in jmvenv

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -89,7 +89,9 @@ tor_deps_install ()
         'libssl-dev' \
         'zlib1g-dev' )
 
-    # TODO: darwin_deps
+    darwin_deps=( \
+        'libevent' \
+        'zlib' )
 
     if [[ ${use_os_deps_check} != '1' ]]; then
         return 0
@@ -97,8 +99,8 @@ tor_deps_install ()
         deb_deps_install "${debian_deps[@]}"
         return "$?"
     elif [[ ${install_os} == 'darwin' ]]; then
-        echo "FixMe: Darwin deps not specified. Trying to build."
-        return 0
+        dar_deps_install "${darwin_deps[@]}"
+        return "$?"
     else
         return 0
     fi
@@ -137,17 +139,19 @@ dar_deps_install ()
         return 1
     fi
 
-    sudo_command=''
-    if [ "$with_sudo" == 1 ]; then
-        echo "
-            sudo password required to run :
+    if ! which virtualenv >/dev/null; then
+        sudo_command=''
+        if [ "$with_sudo" == 1 ]; then
+            echo "
+                sudo password required to run :
 
-            \`sudo pip3 install virtualenv\`
-            "
-        sudo_command="sudo"
-    fi
-    if $with_jmvenv && ! $sudo_command pip3 install virtualenv; then
-        return 1
+                \`sudo pip3 install virtualenv\`
+                "
+            sudo_command="sudo"
+        fi
+        if $with_jmvenv && ! $sudo_command pip3 install virtualenv; then
+            return 1
+        fi
     fi
 }
 

--- a/jmclient/jmclient/__init__.py
+++ b/jmclient/jmclient/__init__.py
@@ -26,7 +26,8 @@ from .configure import (load_test_config, process_shutdown,
     load_program_config, jm_single, get_network, update_persist_config,
     validate_address, is_burn_destination, get_irc_mchannels,
     get_blockchain_interface_instance, set_config, is_segwit_mode,
-    is_native_segwit_mode, JMPluginService, get_interest_rate, get_bondless_makers_allowance)
+    is_native_segwit_mode, JMPluginService, get_interest_rate,
+    get_bondless_makers_allowance, check_and_start_tor)
 from .blockchaininterface import (BlockchainInterface,
                                   RegtestBitcoinCoreInterface, BitcoinCoreInterface)
 from .snicker_receiver import SNICKERError, SNICKERReceiver

--- a/jmclient/jmclient/yieldgenerator.py
+++ b/jmclient/jmclient/yieldgenerator.py
@@ -14,7 +14,7 @@ from jmclient import (Maker, jm_single, load_program_config,
                       JMClientProtocolFactory, start_reactor, calc_cj_fee,
                       WalletService, add_base_options, SNICKERReceiver,
                       SNICKERClientProtocolFactory, FidelityBondMixin,
-                      get_interest_rate, fmt_utxo)
+                      get_interest_rate, fmt_utxo, check_and_start_tor)
 from .wallet_utils import open_test_wallet_maybe, get_wallet_path
 from jmbase.support import EXIT_ARGERROR, EXIT_FAILURE, get_jm_version_str
 import jmbitcoin as btc
@@ -400,6 +400,8 @@ def ygmain(ygclass, nickserv_password='', gaplimit=6):
         sys.exit(EXIT_ARGERROR)
 
     load_program_config(config_path=options["datadir"])
+
+    check_and_start_tor()
 
     # As per previous note, override non-default command line settings:
     for x in ["ordertype", "txfee_contribution", "txfee_contribution_factor",

--- a/scripts/joinmarket-qt.py
+++ b/scripts/joinmarket-qt.py
@@ -73,7 +73,7 @@ from jmclient import load_program_config, get_network, update_persist_config,\
     parse_payjoin_setup, send_payjoin, JMBIP78ReceiverManager, \
     detect_script_type, general_custom_change_warning, \
     nonwallet_custom_change_warning, sweep_custom_change_warning, EngineError,\
-    TYPE_P2WPKH
+    TYPE_P2WPKH, check_and_start_tor
 from jmclient.wallet import BaseWallet
 
 from qtsupport import ScheduleWizard, TumbleRestartWizard, config_tips,\
@@ -2375,6 +2375,8 @@ if not jm_single().config.get("POLICY", "segwit") == "true":
     sys.exit(EXIT_FAILURE)
 
 update_config_for_gui()
+
+check_and_start_tor()
 
 def onTabChange(i):
     """ Respond to change of tab.

--- a/scripts/obwatch/ob-watcher.py
+++ b/scripts/obwatch/ob-watcher.py
@@ -24,7 +24,7 @@ if sys.version_info < (3, 7):
 
 from jmbase.support import EXIT_FAILURE
 from jmbase import bintohex
-from jmclient import FidelityBondMixin, get_interest_rate
+from jmclient import FidelityBondMixin, get_interest_rate, check_and_start_tor
 from jmclient.fidelity_bond import FidelityBondProof
 
 import sybil_attack_calculations as sybil
@@ -803,6 +803,7 @@ def main():
                       default=62601)
     (options, args) = parser.parse_args()
     load_program_config(config_path=options.datadir)
+    check_and_start_tor()
     hostport = (options.host, options.port)
     mcs = [ObIRCMessageChannel(c) for c in get_irc_mchannels()]
     mcc = MessageChannelCollection(mcs)

--- a/scripts/sendpayment.py
+++ b/scripts/sendpayment.py
@@ -18,7 +18,7 @@ from jmclient import Taker, load_program_config, get_schedule,\
     get_sendpayment_parser, get_max_cj_fee_values, check_regtest, \
     parse_payjoin_setup, send_payjoin, general_custom_change_warning, \
     nonwallet_custom_change_warning, sweep_custom_change_warning, \
-    EngineError
+    EngineError, check_and_start_tor
 from twisted.python.log import startLogging
 from jmbase.support import get_log, jmprint, \
     EXIT_FAILURE, EXIT_ARGERROR
@@ -62,6 +62,8 @@ def main():
                 parser.error("Joinmarket sendpayment (coinjoin) needs arguments:"
                     " wallet, amount, destination address or wallet, bitcoin_uri.")
                 sys.exit(EXIT_ARGERROR)
+
+    check_and_start_tor()
 
     #without schedule file option, use the arguments to create a schedule
     #of a single transaction


### PR DESCRIPTION
See https://github.com/JoinMarket-Org/joinmarket-clientserver/pull/1000#issuecomment-957379435 for context.

This adds new option `--with-local-tor` to `install.sh` which builds Tor locally inside jmvenv. Then, when starting JM scripts that might need Tor connection, it is started automatically if nobody already listens on `127.0.0.1:9050`.

If no problems are found with his approach in testing, we could switch to this as a default and remove all clearnet IRC configs from default config.