### PR TITLE
Allow to not specify rpc_port in config, use network's default then

### DIFF
--- a/jmclient/jmclient/configure.py
+++ b/jmclient/jmclient/configure.py
@@ -119,7 +119,7 @@ blockchain_source = bitcoin-rpc
 network = mainnet
 rpc_host = localhost
 # default ports are 8332 for mainnet, 18443 for regtest, 18332 for testnet, 38332 for signet
-rpc_port = 8332
+rpc_port =
 rpc_user = bitcoin
 rpc_password = password
 rpc_wallet_file =
@@ -740,6 +740,17 @@ def get_blockchain_interface_instance(_config):
     if source in ('bitcoin-rpc', 'regtest', 'bitcoin-rpc-no-history'):
         rpc_host = _config.get("BLOCKCHAIN", "rpc_host")
         rpc_port = _config.get("BLOCKCHAIN", "rpc_port")
+        if rpc_port == '':
+            if network == 'mainnet':
+                rpc_port = 8332
+            elif network == 'regtest':
+                rpc_port = 18443
+            elif network == 'testnet':
+                rpc_port = 18332
+            elif network == 'signet':
+                rpc_port = 38332
+            else:
+                raise ValueError('wrong network configured: ' + network)
         rpc_user, rpc_password = get_bitcoin_rpc_credentials(_config)
         rpc_wallet_file = _config.get("BLOCKCHAIN", "rpc_wallet_file")
         rpc = JsonRpc(rpc_host, rpc_port, rpc_user, rpc_password,

--- a/jmclient/jmclient/jsonrpc.py
+++ b/jmclient/jmclient/jsonrpc.py
@@ -161,7 +161,8 @@ class JsonRpc(object):
             #Failure means keepalive timed out, just make a new one
             self.conn = http.client.HTTPConnection(self.host, self.port)
         if not response_received:
-            raise JsonRpcConnectionError("Unable to connect over RPC")
+            raise JsonRpcConnectionError("Unable to connect over RPC to " +
+                self.host + ":" + str(self.port))
         if response["id"] != currentId:
             raise JsonRpcConnectionError("invalid id returned by query")
 


### PR DESCRIPTION
I regularly switch between mainnet and signet on my development laptop, this will save little bit of time, one setting less to change each time.