### PR TITLE
Fix SNICKER daemon startup

### DIFF
--- a/jmclient/jmclient/client_protocol.py
+++ b/jmclient/jmclient/client_protocol.py
@@ -860,7 +860,8 @@ def start_reactor(host, port, factory=None, snickerfactory=None,
         # (See above) For now these other two are just on ports that are 1K offsets.
         if snickerfactory:
             snickerport, serverconn = start_daemon_on_port(port_a, sdfactory,
-                                                    "SNICKER", 1000) - 1000
+                                                    "SNICKER", 1000)
+            snickerport = snickerport - 1000
         if bip78:
             start_daemon_on_port(port_a, bip78factory, "BIP78", 2000)
 


### PR DESCRIPTION
Fixes #1067.

Bug was introduced with 7e73e4caa9d03b9237ad322cd5ba02e877778458 (part of #996) when return value of `start_daemon_on_port()` was changed from `int` to `tuple`.