### PR TITLE
Don't throw when disabled socks config missing

### DIFF
--- a/jmclient/jmclient/configure.py
+++ b/jmclient/jmclient/configure.py
@@ -496,13 +496,22 @@ def get_irc_mchannels():
             irc_sections.append(s)
     assert irc_sections
 
-    fields = [("host", str), ("port", int), ("channel", str), ("usessl", str),
-              ("socks5", str), ("socks5_host", str), ("socks5_port", str)]
+    req_fields = [("host", str), ("port", int), ("channel", str), ("usessl", str)]
 
     configs = []
     for section in irc_sections:
         server_data = {}
-        for option, otype in fields:
+
+        # check if socks5 is enabled for tor and load relevant config if so
+        try:
+            server_data["socks5"] = jm_single().config.get(section, "socks5")
+        except NoOptionError:
+            server_data["socks5"] = "false"
+        if server_data["socks5"].lower() == 'true':
+            server_data["socks5_host"] = jm_single().config.get(section, "socks5_host")
+            server_data["socks5_port"] = jm_single().config.get(section, "socks5_port")
+
+        for option, otype in req_fields:
             val = jm_single().config.get(section, option)
             server_data[option] = otype(val)
         server_data['btcnet'] = get_network()

--- a/jmdaemon/jmdaemon/irc.py
+++ b/jmdaemon/jmdaemon/irc.py
@@ -93,8 +93,9 @@ class IRCMessageChannel(MessageChannel):
         self.hostid = configdata['host'] + str(configdata['port'])
         self.socks5 = configdata["socks5"]
         self.usessl = configdata["usessl"]
-        self.socks5_host = configdata["socks5_host"]
-        self.socks5_port = int(configdata["socks5_port"])
+        if self.socks5.lower() == 'true':
+            self.socks5_host = configdata["socks5_host"]
+            self.socks5_port = int(configdata["socks5_port"])
         self.channel = get_config_irc_channel(configdata["channel"],
                                               configdata["btcnet"])
         self.userrealname = (username, realname)


### PR DESCRIPTION
Previously, the default config file generated by JM causes an error due to not having `socks5_host` and `socks5_port`, which are commented out since `socks5` is disabled by default. This commit makes those fields optional when `socks5` is not set to `true` in the config. It also makes `socks5` default to `false` if it is not specified in the config for a given IRC server.