### PR TITLE
Update secp256k1 to latest upstream version.

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -255,8 +255,8 @@ libsecp256k1_build()
 
 libsecp256k1_install()
 {
-    secp256k1_lib_tar='f2d9aeae6d5a7c7fbbba8bbb38b1849b784beef7'
-    secp256k1_lib_sha="bdcb0373cc830271733841cf507ad2bb95d61be558f5334c8ad304d127ee4da9"
+    secp256k1_lib_tar='490022745164b56439688b0fc04f9bd43578e5c3'
+    secp256k1_lib_sha="4c87e32bff6815fb632a0ffd5bc89f2f7dfce11bd8501f1c779cf1e8e354c3c9"
     secp256k1_lib_url='https://github.com/bitcoin-core/secp256k1/archive'
     if ! dep_get "${secp256k1_lib_tar}.tar.gz" "${secp256k1_lib_sha}" "${secp256k1_lib_url}"; then
         return 1


### PR DESCRIPTION
This should also fix a build test failure I'm seeing:
```
========================================
   libsecp256k1 0.1: ./test-suite.log
========================================

# TOTAL: 2
# PASS:  1
# SKIP:  0
# XFAIL: 0
# FAIL:  1
# XPASS: 0
# ERROR: 0

.. contents:: :depth: 2

FAIL: tests
===========

test count = 64
random seed = 9b1ad3480dabdeae877243b1d687ed9a
Failure 10 on 30 0c 02 03 86 00 00 02 05 00 c4 1f 00 00 
src/tests.c:4996: test condition failed: ret == 0
FAIL tests (exit status: 134)
```