### PR TITLE
Do not auto generate the QT UI code in setup.py

### DIFF
--- a/jmqtui/setup.py
+++ b/jmqtui/setup.py
@@ -13,4 +13,7 @@ setup(name='joinmarketui',
       python_requires='>=3.6',
       zip_safe=False)
 
-os.system('pyside2-uic jmqtui/open_wallet_dialog.ui -o jmqtui/open_wallet_dialog.py')
+# The following command should be executed whenever `open_wallet_dialog.ui` is updated.
+# We have commented out this command so that we wouldn't require every user of JoinMarket-qt
+# to install the correct version of pyside2-uic.
+# os.system('pyside2-uic jmqtui/open_wallet_dialog.ui -o jmqtui/open_wallet_dialog.py')


### PR DESCRIPTION
If the user has an incompatible version of PySide2 installed on their system, the generation process might fail.

Since we have already checked in the correct version of the generated QT UI code, we don't need to run the generation process for every user in the `setup.py`

Hopefully this fixes #1087 