### PR TITLE
Rename `WalletViewEntry.used` to `WalletViewEntry.status`

### DIFF
--- a/jmclient/jmclient/wallet_utils.py
+++ b/jmclient/jmclient/wallet_utils.py
@@ -147,7 +147,7 @@ class WalletViewBase(object):
 
 class WalletViewEntry(WalletViewBase):
     def __init__(self, wallet_path_repr, account, address_type, aindex, addr, amounts,
-                 used = 'new', serclass=str, priv=None, custom_separator=None,
+                 status = 'new', serclass=str, priv=None, custom_separator=None,
                  label=None):
         super().__init__(wallet_path_repr, serclass=serclass,
                          custom_separator=custom_separator)
@@ -163,7 +163,7 @@ class WalletViewEntry(WalletViewBase):
         self.unconfirmed_amount, self.confirmed_amount = amounts
         #note no validation here
         self.private_key = priv
-        self.used = used
+        self.status = status
         self.label = label
 
     def get_balance(self, include_unconf=True):
@@ -177,11 +177,11 @@ class WalletViewEntry(WalletViewBase):
         left = self.serialize_wallet_position()
         addr = self.serialize_address()
         amounts = self.serialize_amounts()
-        used = self.serialize_used()
+        status = self.serialize_status()
         label = self.serialize_label()
         extradata = self.serialize_extra_data()
         return self.serclass(self.separator.join([
-            left, addr, amounts, used, label, extradata]))
+            left, addr, amounts, status, label, extradata]))
 
     def serialize_json(self):
         return {"hd_path": self.wallet_path_repr,
@@ -203,8 +203,8 @@ class WalletViewEntry(WalletViewBase):
                                       "not yet implemented.")
         return self.serclass("{0:.08f}".format(self.unconfirmed_amount/1e8))
 
-    def serialize_used(self):
-        return self.serclass(self.used)
+    def serialize_status(self):
+        return self.serclass(self.status)
 
     def serialize_label(self):
         if self.label:
@@ -373,14 +373,14 @@ def get_imported_privkey_branch(wallet_service, m, showprivkey):
             include_disabled=True)[m].values():
             if script == data['script']:
                 balance += data['value']
-        used = ('used' if balance > 0.0 else 'empty')
+        status = ('used' if balance > 0.0 else 'empty')
         if showprivkey:
             wip_privkey = wallet_service.get_wif_path(path)
         else:
             wip_privkey = ''
         entries.append(WalletViewEntry(wallet_service.get_path_repr(path), m, -1,
                                        0, addr, [balance, balance],
-                                       used=used, priv=wip_privkey))
+                                       status=status, priv=wip_privkey))
 
     if entries:
         return WalletViewBranch("m/0", m, -1, branchentries=entries)
@@ -495,17 +495,17 @@ def wallet_display(wallet_service, showprivkey, displayall=False,
                 path = wallet_service.get_path(m, address_type, k)
                 addr = wallet_service.get_address_from_path(path)
                 label = wallet_service.get_address_label(addr)
-                balance, used = get_addr_status(
+                balance, status = get_addr_status(
                     path, utxos[m], k >= unused_index, address_type)
                 if showprivkey:
                     privkey = wallet_service.get_wif_path(path)
                 else:
                     privkey = ''
                 if (displayall or balance > 0 or
-                        (used == 'new' and address_type == 0)):
+                        (status == 'new' and address_type == 0)):
                     entrylist.append(WalletViewEntry(
                         wallet_service.get_path_repr(path), m, address_type, k, addr,
-                        [balance, balance], priv=privkey, used=used, label=label))
+                        [balance, balance], priv=privkey, status=status, label=label))
             wallet_service.set_next_index(m, address_type, unused_index)
             path = wallet_service.get_path_repr(wallet_service.get_path(m, address_type))
             branchlist.append(WalletViewBranch(path, m, address_type, entrylist,
@@ -531,7 +531,7 @@ def wallet_display(wallet_service, showprivkey, displayall=False,
                 if displayall or balance > 0:
                     entrylist.append(WalletViewEntry(
                         wallet_service.get_path_repr(path), m, address_type, k,
-                        addr, [balance, balance], priv=privkey, used=status,
+                        addr, [balance, balance], priv=privkey, status=status,
                         label=label))
             xpub_key = wallet_service.get_bip32_pub_export(m, address_type)
             path = wallet_service.get_path_repr(wallet_service.get_path(m, address_type))
@@ -571,7 +571,7 @@ def wallet_display(wallet_service, showprivkey, displayall=False,
                 if displayall or balance > 0:
                     entrylist.append(WalletViewEntryBurnOutput(path_repr, m,
                         address_type, k, output, [balance, balance],
-                        priv=privkey, used=status))
+                        priv=privkey, status=status))
             wallet_service.set_next_index(m, address_type, unused_index)
 
             xpub_key = wallet_service.get_bip32_pub_export(m, address_type)

--- a/scripts/joinmarket-qt.py
+++ b/scripts/joinmarket-qt.py
@@ -1452,7 +1452,7 @@ class JMWalletTab(QWidget):
 
     def getHeaders(self):
         '''Function included in case dynamic in future'''
-        return ['Address', 'Index', 'Balance', 'Used/New', 'Label']
+        return ['Address', 'Index', 'Balance', 'Status', 'Label']
 
     def create_menu(self, position):
         item = self.walletTree.currentItem()
@@ -2293,7 +2293,7 @@ def get_wallet_printout(wallet_service):
     We retrieve a WalletView abstraction, and iterate over
     sub-objects to arrange the per-mixdepth and per-address lists.
     The format of the returned data is:
-    rows: is of format [[[addr,index,bal,used,label],[addr,...]]*5,
+    rows: is of format [[[addr,index,bal,status,label],[addr,...]]*5,
     [[addr, index,..], [addr, index..]]*5]
     mbalances: is a simple array of 5 mixdepth balances
     xpubs: [[xpubext, xpubint], ...]
@@ -2314,7 +2314,7 @@ def get_wallet_printout(wallet_service):
                 rows[-1][i].append([entry.serialize_address(),
                                     entry.serialize_wallet_position(),
                                     entry.serialize_amounts(),
-                                    entry.serialize_used(),
+                                    entry.serialize_status(),
                                     entry.serialize_label()])
     # in case the wallet is not yet synced, don't return an incorrect
     # 0 balance, but signal incompleteness:


### PR DESCRIPTION
The field name "used" is outdated.

The content of this field, in addition to "new" or "used", can also be "change-out", "cj-out", "non-cj-change", or even a date if it's a TimeLocked FB address.

Renaming this field to "status" so that it's more accurate. And also update the QT display from "Used/New" to "Status"