### PR TITLE
Add the command line option of "input-addrs"

### DIFF
--- a/jmclient/jmclient/cli_options.py
+++ b/jmclient/jmclient/cli_options.py
@@ -493,6 +493,12 @@ def get_sendpayment_parser():
                       dest='mixdepth',
                       help='mixing depth to spend from, default=0',
                       default=0)
+    parser.add_option('-i',
+                      '--input-addrs',
+                      action='append',
+                      dest='input_addrs',
+                      help='input addresses to spend from, must belong to the same mixing depth, default=[]',
+                      default=[])
     parser.add_option('-a',
                       '--amtmixdepths',
                       action='store',

--- a/jmclient/jmclient/taker.py
+++ b/jmclient/jmclient/taker.py
@@ -187,6 +187,10 @@ class Taker(object):
             self.mixdepth = si[0]
             self.cjamount = si[1]
             rounding = si[5]
+            self.input_addrs = None
+            if len(si) > 7:
+                self.input_addrs = si[7]
+
             #non-integer coinjoin amounts are treated as fractions
             #this is currently used by the tumbler algo
             if isinstance(self.cjamount, float):
@@ -334,8 +338,12 @@ class Taker(object):
             total_amount = self.cjamount + self.total_cj_fee + self.total_txfee
             jlog.info('total estimated amount spent = ' + btc.amount_to_str(total_amount))
             try:
-                self.input_utxos = self.wallet_service.select_utxos(self.mixdepth, total_amount,
-                                                        minconfs=1)
+                if self.input_addrs:
+                    self.input_utxos = self.wallet_service.select_utxos_from_addrs(
+                        self.mixdepth, self.input_addrs, total_amount)
+                else:
+                    self.input_utxos = self.wallet_service.select_utxos(self.mixdepth, total_amount,
+                                                                        minconfs=1)
             except Exception as e:
                 self.taker_info_callback("ABORT",
                                     "Unable to select sufficient coins: " + repr(e))

--- a/jmclient/jmclient/taker_utils.py
+++ b/jmclient/jmclient/taker_utils.py
@@ -24,7 +24,7 @@ Currently re-used by CLI script tumbler.py and joinmarket-qt
 def direct_send(wallet_service, amount, mixdepth, destination, answeryes=False,
                 accept_callback=None, info_callback=None, error_callback=None,
                 return_transaction=False, with_final_psbt=False,
-                optin_rbf=False, custom_change_addr=None):
+                optin_rbf=False, custom_change_addr=None, input_addrs=None):
     """Send coins directly from one mixdepth to one destination address;
     does not need IRC. Sweep as for normal sendpayment (set amount=0).
     If answeryes is True, callback/command line query is not performed.
@@ -118,7 +118,10 @@ def direct_send(wallet_service, amount, mixdepth, destination, answeryes=False,
         #not doing a sweep; we will have change
         #8 inputs to be conservative
         initial_fee_est = estimate_tx_fee(8,2, txtype=txtype, outtype=outtype)
-        utxos = wallet_service.select_utxos(mixdepth, amount + initial_fee_est)
+        if input_addrs:
+            utxos = wallet_service.select_utxos_from_addrs(mixdepth, input_addrs, amount + initial_fee_est)
+        else:
+            utxos = wallet_service.select_utxos(mixdepth, amount + initial_fee_est)
         if len(utxos) < 8:
             fee_est = estimate_tx_fee(len(utxos), 2, txtype=txtype, outtype=outtype)
         else:

--- a/jmclient/jmclient/wallet_service.py
+++ b/jmclient/jmclient/wallet_service.py
@@ -863,6 +863,12 @@ class WalletService(Service):
         else:
             return self.current_blockheight - minconfs + 1
 
+    def select_utxos_from_addrs(self, mixdepth, input_addrs, amount):
+        """ Request utxos from the specified addresses of the wallet to satisfy
+        a certain total amount.
+        """
+        return self.wallet.select_utxos_from_addrs(mixdepth, input_addrs, amount)
+
     def select_utxos(self, mixdepth, amount, utxo_filter=None, select_fn=None,
                      minconfs=None, includeaddr=False, require_auth_address=False):
         """ Request utxos from the wallet in a particular mixdepth to satisfy

--- a/scripts/sendpayment.py
+++ b/scripts/sendpayment.py
@@ -117,7 +117,7 @@ def main():
                 "error")
             sys.exit(EXIT_ARGERROR)
         schedule = [[options.mixdepth, amount, options.makercount,
-                     destaddr, 0.0, NO_ROUNDING, 0]]
+                     destaddr, 0.0, NO_ROUNDING, 0, options.input_addrs]]
     else:
         if len(args) > 1:
             parser.error("Schedule files are not compatible with "
@@ -244,7 +244,8 @@ def main():
     if options.makercount == 0 and not bip78url:
         tx = direct_send(wallet_service, amount, mixdepth, destaddr,
                          options.answeryes, with_final_psbt=options.with_psbt,
-                         optin_rbf=options.rbf, custom_change_addr=custom_change)
+                         optin_rbf=options.rbf, custom_change_addr=custom_change,
+                         input_addrs=options.input_addrs)
         if options.with_psbt:
             log.info("This PSBT is fully signed and can be sent externally for "
                      "broadcasting:")


### PR DESCRIPTION
With this new command line option, user can spend from specified addresses via the following command:

```
python sendpayment.py wallet.jmdat amount target_address -i spend_from_address_1 -i spend_from_address_2 -i spend_from_address_3
```

This is the first step of implementing #1010 