### PR TITLE
Add RPC API endpoint for showseed

### DIFF
--- a/jmclient/jmclient/wallet-rpc-api.md
+++ b/jmclient/jmclient/wallet-rpc-api.md
@@ -438,6 +438,37 @@ Get the value of a specific config setting. Note values are always returned as s
 | --- | --- |
 | bearerAuth | |
 
+### /wallet/{walletname}/getseed
+
+#### GET
+##### Summary
+
+get the mnemonic recovery phrase with the optional passphrase
+
+##### Description
+
+Get the mnemonic recovery phrase with the optional passphrase. Not the response is a sentence with few line breaks.
+
+##### Parameters
+
+| Name | Located in | Description | Required | Schema |
+| ---- | ---------- | ----------- | -------- | ---- |
+| walletname | path | name of the wallet including .jmdat | Yes | string |
+
+##### Responses
+
+| Code | Description |
+| ---- | ----------- |
+| 200 | seedphrase retrieved successfully |
+| 400 | Bad request format. |
+| 401 | Unable to authorise the credentials that were supplied. |
+
+##### Security
+
+| Security Schema | Scopes |
+| --- | --- |
+| bearerAuth | |
+
 ### Models
 
 #### ConfigSetRequest
@@ -543,6 +574,12 @@ Get the value of a specific config setting. Note values are always returned as s
 | Name | Type | Description | Required |
 | ---- | ---- | ----------- | -------- |
 | txinfo | object |  | Yes |
+
+#### GetSeedResponse
+
+| Name | Type | Description | Required |
+| ---- | ---- | ----------- | -------- |
+| seedphrase | string |  | Yes |
 
 #### LockWalletResponse
 

--- a/jmclient/jmclient/wallet-rpc-api.yaml
+++ b/jmclient/jmclient/wallet-rpc-api.yaml
@@ -368,6 +368,32 @@ paths:
           $ref: "#/components/responses/401-Unauthorized"
         '409':
           $ref: '#/components/responses/409-NoConfig'
+  /wallet/{walletname}/getseed:
+    get:
+      security:
+        - bearerAuth: []
+      summary: get the mnemonic recovery phrase with the optional passphrase
+      operationId: getseed
+      description: Get the mnemonic recovery phrase with the optional passphrase. Not the response is a sentence with few line breaks.
+      parameters:
+        - name: walletname
+          in: path
+          description: name of the wallet including .jmdat
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/GetSeedResponse'
+      responses:
+        '200':
+          $ref: "#/components/responses/GetSeed-200-OK"
+        '400':
+          $ref: '#/components/responses/400-BadRequest'
+        '401':
+          $ref: "#/components/responses/401-Unauthorized"
 components:
   securitySchemes:
     bearerAuth:
@@ -628,6 +654,13 @@ components:
               type: number
             nVersion:
               type: number
+    GetSeedResponse:
+      type: object
+      required:
+        - seedphrase
+      properties:
+        seedphrase:
+          type: string
     LockWalletResponse:
       type: object
       required:
@@ -756,6 +789,12 @@ components:
         application/json:
           schema:
             $ref: "#/components/schemas/LockWalletResponse"
+    GetSeed-200-OK:
+      description: "seedphrase retrieved successfully"
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/GetSeedResponse"
     202-Accepted:
       description: The request has been submitted successfully for processing, but the processing has not been completed. 
     204-NoResultFound:

--- a/jmclient/jmclient/wallet_rpc.py
+++ b/jmclient/jmclient/wallet_rpc.py
@@ -846,3 +846,13 @@ class JMWalletDaemon(Service):
             _, self.coinjoin_connection = start_reactor(dhost, dport,
                                 self.clientfactory, rs=False)
             return make_jmwalletd_response(request, status=202)
+
+        @app.route('/wallet/<walletname>/getseed', methods=['GET'])
+        def getseed(self, request, walletname):
+            self.check_cookie(request)
+            if not self.wallet_service:
+                raise NoWalletFound()
+            if not self.wallet_name == walletname:
+                raise InvalidRequestFormat()
+            seedphrase, _ = self.wallet_service.get_mnemonic_words()
+            return make_jmwalletd_response(request, seedphrase=seedphrase)

--- a/jmclient/test/test_wallet_rpc.py
+++ b/jmclient/test/test_wallet_rpc.py
@@ -459,6 +459,24 @@ class TrialTestWRPC_DisplayWallet(WalletRPCTestBase, unittest.TestCase):
         self.addCleanup(clientconn.disconnect)
         self.addCleanup(self.scon.stopListening)
         assert json.loads(response.decode("utf-8")) == {}
+
+    @defer.inlineCallbacks
+    def test_get_seed(self):
+        self.daemon.auth_disabled = True
+        agent = get_nontor_agent()
+        addr = self.get_route_root()
+        addr += "/wallet/"
+        addr += self.daemon.wallet_name
+        addr += "/getseed"
+        addr = addr.encode()
+        yield self.do_request(agent, b"GET", addr, None,
+                              self.process_get_seed_response)
+
+    def process_get_seed_response(self, response, code):
+        assert code == 200
+        json_body = json.loads(response.decode('utf-8'))
+        assert json_body["seedphrase"]
+
 """
 Sample listutxos response for reference:
 


### PR DESCRIPTION
This simple API endpoint is useful for showing seed even after the wallet is created.

The response text contains few words other than the 12/13 word seedphrase but I decided to filter them on the frontend.