### PR TITLE
Fixes Crash (Unicode in joinmarket.cfg)

### DIFF
--- a/jmclient/jmclient/configure.py
+++ b/jmclient/jmclient/configure.py
@@ -179,7 +179,7 @@ socks5 = false
 #socks5_host = localhost
 #socks5_port = 9050
 
-## SERVER 4/4) ILITA IRC (Tor — disabled by default)
+## SERVER 4/4) ILITA IRC (Tor - disabled by default)
 ################################################################################
 #[MESSAGING:server4]
 #channel = joinmarket-pit


### PR DESCRIPTION
Executing with `0.9.4` now results in a crash when attempting to generate a new `joinmarket.cfg`. The issue is likely related to my terminal emulator or something - but a easily fix is to remove the superfluous unicode dash from the generated configuration file.

```
$ python wallet-tool.py generate
User data location: /home/blah/.joinmarket/
Traceback (most recent call last):
  File "wallet-tool.py", line 6, in <module>
    jmprint(wallet_tool_main("wallets"), "success")
  File "/opt/joinmarket/joinmarket-clientserver/jmclient/jmclient/wallet_utils.py", line 1502, in wallet_tool_main
    load_program_config(config_path=options.datadir)
  File "/opt/joinmarket/joinmarket-clientserver/jmclient/jmclient/configure.py", line 635, in load_program_config
    configfile.write(defaultconfig)
UnicodeEncodeError: 'latin-1' codec can't encode character '\u2014' in position 2701: ordinal not in range(256)
```