### PR TITLE
Allow utxo address validation with script

### DIFF
--- a/jmclient/jmclient/blockchaininterface.py
+++ b/jmclient/jmclient/blockchaininterface.py
@@ -387,13 +387,8 @@ class BitcoinCoreInterface(BlockchainInterface):
             if ret is None:
                 result.append(None)
             else:
-                if ret['scriptPubKey'].get('addresses'):
-                    address = ret['scriptPubKey']['addresses'][0]
-                else:
-                    address = None
                 result_dict = {'value': int(Decimal(str(ret['value'])) *
                                             Decimal('1e8')),
-                               'address': address,
                                'script': hextobin(ret['scriptPubKey']['hex'])}
                 if includeconf:
                     result_dict['confirms'] = int(ret['confirmations'])

--- a/jmclient/test/test_wallets.py
+++ b/jmclient/test/test_wallets.py
@@ -50,7 +50,7 @@ def test_query_utxo_set(setup_wallets):
         includeconf=True, includeunconf=True)
     assert len(res1) == 1
     assert len(res2) == 2
-    assert all([x in res1[0] for x in ['script', 'address', 'value']])
+    assert all([x in res1[0] for x in ['script', 'value']])
     assert not 'confirms' in res1[0]
     assert 'confirms' in res2[0]
     assert 'confirms' in res2[1]


### PR DESCRIPTION
Prior to this commit, the sendtomany.py script
would sometimes fail based on the output of the
RPC call gettxout returning only a script, and not
an address. After this commit, the validation will
still work correctly in these cases using the
chosen cryptoengine to convert from script to address.