### PR TITLE
Add derivation path to output of wallet_showutxos

### DIFF
--- a/jmclient/jmclient/wallet-rpc-api.yaml
+++ b/jmclient/jmclient/wallet-rpc-api.yaml
@@ -492,6 +492,10 @@ components:
                 type: string
               address: 
                 type: string
+              path:
+                type: string
+              label:
+                type: string
               value: 
                 type: integer
               tries: 

--- a/jmclient/jmclient/wallet_utils.py
+++ b/jmclient/jmclient/wallet_utils.py
@@ -408,6 +408,7 @@ def wallet_showutxos(wallet_service, showprivkey):
             tries_remaining = max(0, max_tries - tries)
             mixdepth = wallet_service.wallet.get_details(av['path'])[0]
             unsp[us] = {'address': av['address'],
+                       'path': wallet_service.get_path_repr(av['path']),
                        'label': av['label'] if av['label'] else "",
                        'value': av['value'],
                        'tries': tries, 'tries_remaining': tries_remaining,


### PR DESCRIPTION
We display it at other places, makes sense to also output it here.

Also added missing `label` for `ListUtxosResponse` in `wallet-rpc-api.yaml`.