### PR TITLE
Allow RPC coinjoin taker_finished to accept unconf

### DIFF
--- a/jmclient/jmclient/wallet_rpc.py
+++ b/jmclient/jmclient/wallet_rpc.py
@@ -378,15 +378,22 @@ class JMWalletDaemon(Service):
         # TODO this may be updated.
         # It is also different in that the event loop must not shut down
         # when processing finishes.
-        assert fromtx is False
+
+        # This assertion is making sure that the callback is not a non-final
+        # schedule entry (see the comment above as to why). We accept
+        # either False or 'unconfirmed' since they can arrive in either order.
+        assert fromtx is not True
+
+        # reset our state on completion, we are no longer coinjoining:
+        self.taker = None
+
         if not res:
             jlog.info("Coinjoin did not complete successfully.")
         #Should usually be unreachable, unless conf received out of order;
         #because we should stop on 'unconfirmed' for last (see above)
         else:
             jlog.info("Coinjoin completed correctly")
-        # reset our state on completion, we are no longer coinjoining:
-        self.taker = None
+
         # Note; it's technically possible for this to return False if somehow
         # we are currently in inactive state, but it isn't an error:
         self.activate_coinjoin_state(CJ_NOT_RUNNING)


### PR DESCRIPTION
Fixes #1091.
Before this commit, if the unconfirmed transaction
event triggered the taker_finished callback in the
RPC-started coinjoin, the value of fromtx is
'unconfirmed' and not False, hence an assertion error
was raised unless the confirmed event came first
(which is only likely to happen on regtest). This
crashed the jmwalletd daemon backend.
After this commit, the assertion check is only that
the value is not True, which it must not be as long
as we only accept single-join schedules.