### PR TITLE
Make Qt shutdown gracefully on reactor stop.

### DIFF
--- a/jmbase/jmbase/__init__.py
+++ b/jmbase/jmbase/__init__.py
@@ -12,7 +12,7 @@ from .support import (get_log, chunks, debug_silence, jmprint,
 from .proof_of_work import get_pow, verify_pow
 from .twisted_utils import (stop_reactor, is_hs_uri, get_tor_agent,
                             get_nontor_agent, JMHiddenService,
-                            JMHTTPResource)
+                            JMHTTPResource, set_custom_stop_reactor)
 from .bytesprod import BytesProducer
 from .commands import *
 


### PR DESCRIPTION
Fixes #1024.
Prior to this commit, if the RPC connection were lost
while JoinmarketQt was running, the reactor would be
stopped, but the qt5reactor shutdown does not stop
the Qt Application. This commit fixes that by injecting
a custom reactor stop function wrapper into jmbase,
which triggers the close event of the Qt main window.