### PR TITLE
Allow signmessage to work with any index

### DIFF
--- a/jmclient/jmclient/wallet.py
+++ b/jmclient/jmclient/wallet.py
@@ -940,11 +940,13 @@ class BaseWallet(object):
         args:
             message: bytes
             path: path tuple
-        returns:
+        returns as tuple:
+            address of key that signed
             signature as base64-encoded string
         """
         priv, engine = self._get_key_from_path(path)
-        return engine.sign_message(priv, message)
+        addr = engine.privkey_to_address(priv)
+        return addr, engine.sign_message(priv, message)
 
     def get_wallet_name(self):
         """ Returns the name used as a label for this

--- a/jmclient/jmclient/wallet_utils.py
+++ b/jmclient/jmclient/wallet_utils.py
@@ -1117,8 +1117,7 @@ def wallet_signmessage(wallet, hdpath, message, out_str=True):
         return "Error: no message specified"
 
     path = wallet.path_repr_to_path(hdpath)
-    sig = wallet.sign_message(msg, path)
-    addr = wallet.get_address_from_path(path)
+    addr, sig = wallet.sign_message(msg, path)
     if not out_str:
         return (sig, message, addr)
     return ("Signature: {}\nMessage: {}\nAddress: {}\n"


### PR DESCRIPTION
Fixes #1043.
Prior to this commit, only keys/scripts/addresses
inside the scope of the current wallet script_map
(the keys cached by sync, according to persisted
index in wallet file, including gap limit) would
allow a successful signing operation, otherwise
an assertion was raised.
After this commit, signing can be done with any
arbitrary height index in the wallet (assuming a
valid path for this wallet).