### PR TITLE
Remove coincurve dependency, use python-bitcointx

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -5,7 +5,7 @@ The Issues list is for specific bugs or feature requests.
 
 * PEP8 compliance.
 * Details which may or may not be included in PEP8 might be, consistent variable naming conventions, and use of single/double quotes.
-* ~~Porting to Python 3~~. This is done in that we are now Py2 and Py3 compatible as of 0.5.0; but we may deprecate Py2 soon.
+* ~~Porting to Python 3~~. This is done in that we are now Py2 and Py3 compatible as of 0.5.0; ~~but we may deprecate Py2 soon~~ Python2 is now deprecated, as is Python3 below 3.6.
 
 ~~A note on the above - took a look at it last December, but had problems in particular with some twisted elements, specifically `txsocksx`~~ Done as of 0.4.2, now switched to txtorcon.
 
@@ -76,9 +76,11 @@ Windows binaries are now being built in an automated way via #641. The same proc
 
 Some minor progress on this can be seen in #670 and in the repo https://github.com/JoinMarket-Org/jmcontrolcenter
 
+Much more progress after merge of #996, we have a full RPC-API including a spec definition. There is now more than one independent web interface under development, see https://github.com/joinmarket-webui/jm-web-client and https://github.com/manasgandy/joinmarket-gui.
+
 ### Bitcoin
 
-We use coincurve as a binding to libsecp256k1.
+~~We use coincurve as a binding to libsecp256k1.~~
 ~~The current jmbitcoin package morphed over many iterations from the original pybitcointools base code.~~
 ~~We need to rework it considerably as it is very messy architecturally, particularly in regard to data types.~~
 ~~A full rewrite is likely the best option, including in particular the removal of data type flexibility; use binary~~
@@ -88,14 +90,16 @@ We use coincurve as a binding to libsecp256k1.
 ~~probable need to support taproot and Schnorr (without yet implementing it).~~
 
 This was all done in the switch to [python-bitcointx](https://github.com/Simplexum/python-bitcointx) included in 0.7.0 via #536 .
-Complete removal of coincurve for all functions is still to be done.
+~~Complete removal of coincurve for all functions is still to be done.~~ Now done via #1134
+
+Taproot support needs to be added, see #1084.
 
 
 ### Extra features.
 
 PayJoin is already implemented, ~~though not in GUI, that could be added.~~ Full BIP78 Payjoin now in GUI also.
 
-Maker functionality is not in GUI, that could quite plausibly be added and is quite widely requested. - See #487, this is now largely functional but still needs work.
+Maker functionality is not in GUI, that could quite plausibly be added and is quite widely requested. - See #487, this is now largely functional but still needs work. However this is probably superseded by work on the RPC-API, see above under "Alternative implementations".
 
 ~~SNICKER exists currently as a proposed code update but is not quite ready, see #403.~~ "Full" SNICKER functionality is now merged via #768, albeit it will need more testing before it can be auto-switched on for mainnet yieldgenerators.
 

--- a/jmbitcoin/jmbitcoin/__init__.py
+++ b/jmbitcoin/jmbitcoin/__init__.py
@@ -1,5 +1,3 @@
-import coincurve as secp256k1
-
 # If user has compiled and installed libsecp256k1 via
 # JM installation script install.sh, use that;
 # if not, it is assumed to be present at the system level

--- a/jmbitcoin/jmbitcoin/secp256k1_ecies.py
+++ b/jmbitcoin/jmbitcoin/secp256k1_ecies.py
@@ -1,10 +1,10 @@
-import coincurve as secp256k1
 import base64
 import hmac
 import hashlib
 import pyaes
 import os
 import jmbitcoin as btc
+from bitcointx.core.key import CPubKey
 
 ECIES_MAGIC_BYTES = b'BIE1'
 
@@ -68,9 +68,8 @@ def ecies_decrypt(privkey, encrypted):
     if magic != ECIES_MAGIC_BYTES:
         raise ECIESDecryptionError()
     ephemeral_pubkey = encrypted[4:37]
-    try:
-        testR = secp256k1.PublicKey(ephemeral_pubkey)
-    except:
+    testR = CPubKey(ephemeral_pubkey)
+    if not testR.is_fullyvalid():
         raise ECIESDecryptionError()
     ciphertext = encrypted[37:-32]
     mac = encrypted[-32:]

--- a/jmbitcoin/setup.py
+++ b/jmbitcoin/setup.py
@@ -10,5 +10,5 @@ setup(name='joinmarketbitcoin',
       license='GPL',
       packages=['jmbitcoin'],
       python_requires='>=3.6',
-      install_requires=['coincurve', 'python-bitcointx>=1.1.1.post0', 'pyaes', 'urldecode'],
+      install_requires=['python-bitcointx>=1.1.1.post0', 'pyaes', 'urldecode'],
       zip_safe=False)

--- a/jmbitcoin/test/test_ecc_signing.py
+++ b/jmbitcoin/test/test_ecc_signing.py
@@ -4,6 +4,7 @@ signature conversion.'''
 
 import jmbitcoin as btc
 import binascii
+from jmbase import bintohex
 import json
 import pytest
 import os
@@ -14,7 +15,11 @@ def test_valid_sigs(setup_ecc):
     for v in vectors['vectors']:
         msg, sig, priv = (binascii.unhexlify(
             v[a]) for a in ["msg", "sig", "privkey"])
-        assert sig == btc.ecdsa_raw_sign(msg, priv, rawmsg=True)+ b'\x01'
+        res = btc.ecdsa_raw_sign(msg, priv, rawmsg=True)+ b'\x01'
+        if not sig == res:
+            print("failed on sig {} from msg {} with priv {}".format(bintohex(sig), bintohex(msg), bintohex(priv)))
+            print("we got instead: {}".format(bintohex(res)))
+            assert False
         # check that the signature verifies against the key(pair)
         pubkey = btc.privkey_to_pubkey(priv)
         assert btc.ecdsa_raw_verify(msg, pubkey, sig[:-1], rawmsg=True)

--- a/jmbitcoin/test/test_ecdh.py
+++ b/jmbitcoin/test/test_ecdh.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-'''Tests coincurve binding to libsecp256k1 ecdh module code'''
+'''Tests python-bitcointx binding to libsecp256k1 ecdh module code'''
 
 import hashlib
 import jmbitcoin as btc
@@ -15,7 +15,7 @@ def test_ecdh():
     2. Calculate the corresponding public keys.
     3. Do ECDH on the cartesian product (x, Y), with x private
     and Y public keys, for all combinations.
-    4. Compare the result from CoinCurve with the manual
+    4. Compare the result from secp256k1_main.ecdh with the manual
     multiplication xY following by hash (sha256). Note that
     sha256(xY) is the default hashing function used for ECDH
     in libsecp256k1.
@@ -31,15 +31,15 @@ def test_ecdh():
             key, hex_key, prop_dict = a
             if prop_dict["isPrivkey"]:
                 c, k = btc.read_privkey(hextobin(hex_key))
-                extracted_privkeys.append(k)
+                extracted_privkeys.append(k + b"\x01")
     extracted_pubkeys = [btc.privkey_to_pubkey(x) for x in extracted_privkeys]
     for p in extracted_privkeys:
         for P in extracted_pubkeys:
             c, k = btc.read_privkey(p)
-            shared_secret = btc.ecdh(k, P)
+            shared_secret = btc.ecdh(k + b"\x01", P)
             assert len(shared_secret) == 32
             # try recreating the shared secret manually:
-            pre_secret = btc.multiply(p, P)
+            pre_secret = btc.multiply(k, P)
             derived_secret = hashlib.sha256(pre_secret).digest()
             assert derived_secret == shared_secret
 

--- a/jmbitcoin/test/test_ecies.py
+++ b/jmbitcoin/test/test_ecies.py
@@ -10,18 +10,9 @@ import json
 testdir = os.path.dirname(os.path.realpath(__file__))
 
 def test_ecies():
-    """Using private key test vectors from Bitcoin Core.
-    1. Import a set of private keys from the json file.
-    2. Calculate the corresponding public keys.
-    3. Do ECDH on the cartesian product (x, Y), with x private
-    and Y public keys, for all combinations.
-    4. Compare the result from CoinCurve with the manual
-    multiplication xY following by hash (sha256). Note that
-    sha256(xY) is the default hashing function used for ECDH
-    in libsecp256k1.
-
-    Since there are about 20 private keys in the json file, this
-    creates around 400 test cases (note xX is still valid).
+    """Tests encryption and decryption of random messages using
+    the ECIES module.
+    TODO these tests are very minimal.
     """
     with open(os.path.join(testdir,"base58_keys_valid.json"), "r") as f:
         json_data = f.read()


### PR DESCRIPTION
This commit changes the underlying functions used in
jmbitcoin from the private and public key primitives
in coincurve and replaces them with equivalent
primitives CKey and CPubKey from python-bitcointx,
this removes the need to install coincurve and its
own bundled libsecp256k1 dynamic library.
Note that an additional pubkey_tweak_mul function
is exposed with ctypes from python-bitcointx's
bundled libsecp256k1 library.