### PR TITLE
Allow wallet lock in RPC-API without auth.

### DIFF
--- a/jmclient/jmclient/wallet-rpc-api.md
+++ b/jmclient/jmclient/wallet-rpc-api.md
@@ -50,36 +50,22 @@ Give the password for the specified (existing) wallet file, and it will be decry
 | 404 | Item not found. |
 | 409 | Unable to complete request because object already exists. |
 
-### /wallet/{walletname}/lock
+### /wallet/lock
 
 #### GET
 ##### Summary
 
-block access to a currently decrypted wallet
+block access to the currently decrypted wallet
 
 ##### Description
 
-After this (authenticated) action, the wallet will not be readable or writeable.
-
-##### Parameters
-
-| Name | Located in | Description | Required | Schema |
-| ---- | ---------- | ----------- | -------- | ---- |
-| walletname | path | name of wallet including .jmdat | Yes | string |
+After this action, the wallet will not be readable or writeable.
 
 ##### Responses
 
 | Code | Description |
 | ---- | ----------- |
-| 200 | wallet unlocked successfully |
-| 400 | Bad request format. |
-| 401 | Unable to authorise the credentials that were supplied. |
-
-##### Security
-
-| Security Schema | Scopes |
-| --- | --- |
-| bearerAuth | |
+| 200 | wallet locked successfully |
 
 ### /wallet/{walletname}/display
 

--- a/jmclient/jmclient/wallet-rpc-api.yaml
+++ b/jmclient/jmclient/wallet-rpc-api.yaml
@@ -53,27 +53,14 @@ paths:
             schema:
               $ref: '#/components/schemas/UnlockWalletRequest'
         description: wallet unlocking parameters
-  /wallet/{walletname}/lock:
+  /wallet/lock:
     get:
-      security:
-        - bearerAuth: []
-      summary: block access to a currently decrypted wallet
+      summary: block access to the currently decrypted wallet
       operationId: lockwallet
-      description: After this (authenticated) action, the wallet will not be readable or writeable.
-      parameters:
-        - name: walletname
-          in: path
-          description: name of wallet including .jmdat
-          required: true
-          schema:
-            type: string
+      description: After this action, the wallet will not be readable or writeable.
       responses:
         '200':
-          $ref: "#/components/responses/Unlock-200-OK"
-        '400':
-          $ref: '#/components/responses/400-BadRequest'
-        '401':
-          $ref: '#/components/responses/401-Unauthorized'
+          $ref: "#/components/responses/Lock-200-OK"
   /wallet/{walletname}/display:
     get:
       security:

--- a/jmclient/jmclient/wallet_rpc.py
+++ b/jmclient/jmclient/wallet_rpc.py
@@ -572,12 +572,9 @@ class JMWalletDaemon(Service):
             self.services["maker"].stopService()
             return make_jmwalletd_response(request, status=202)
 
-        @app.route('/wallet/<string:walletname>/lock', methods=['GET'])
-        def lockwallet(self, request, walletname):
+        @app.route('/wallet/lock', methods=['GET'])
+        def lockwallet(self, request):
             print_req(request)
-            self.check_cookie(request)
-            if self.wallet_service and not self.wallet_name == walletname:
-                raise InvalidRequestFormat()
             if not self.wallet_service:
                 jlog.warn("Called lock, but no wallet loaded")
                 # we could raise NoWalletFound here, but is
@@ -590,7 +587,7 @@ class JMWalletDaemon(Service):
                 self.wss_factory.valid_token = None
                 self.wallet_service = None
                 already_locked = False
-            return make_jmwalletd_response(request, walletname=walletname,
+            return make_jmwalletd_response(request, walletname=self.wallet_name,
                                            already_locked=already_locked)
 
         @app.route('/wallet/create', methods=["POST"])

--- a/jmclient/test/test_wallet_rpc.py
+++ b/jmclient/test/test_wallet_rpc.py
@@ -183,11 +183,11 @@ class TrialTestWRPC_DisplayWallet(WalletRPCTestBase, unittest.TestCase):
 
         # now *lock* the existing, which will shut down the wallet
         # service associated.
-        addr = root + "/wallet/" + self.daemon.wallet_name + "/lock"
+        addr = root + "/wallet/lock"
         addr = addr.encode()
         jlog.info("Using address: {}".format(addr))
         yield self.do_request(agent, b"GET", addr, None,
-                self.process_lock_response, token=self.jwt_token)
+                self.process_lock_response)
         # wallet service should now be stopped.
         addr = root + "/wallet/" + self.daemon.wallet_name + "/unlock"
         addr = addr.encode()


### PR DESCRIPTION
Fixes #1121. Prior to this commit, if a user
lost access to the authentication token for
a session with the wallet RPC, they would not
be able to lock the existing wallet before
authenticating again (getting a new token for
the same wallet, or a different one).
After this commit, the lock endpoint is no
longer authenticated, but will automatically
destroy the session for whatever wallet is
currently unlocked.