### PR TITLE
Allow re-unlock of wallets via /unlock

### DIFF
--- a/jmclient/jmclient/wallet-rpc-api.yaml
+++ b/jmclient/jmclient/wallet-rpc-api.yaml
@@ -69,7 +69,7 @@ paths:
             type: string
       responses:
         '200':
-          $ref: "#/components/responses/Unlock-200-OK"
+          $ref: "#/components/responses/Lock-200-OK"
         '400':
           $ref: '#/components/responses/400-BadRequest'
         '401':


### PR DESCRIPTION
Fixes #1121.
Prior to this commit, if a user
lost access to the authentication token for
a session with the wallet RPC, they would not
be able to lock the existing wallet before
authenticating again (getting a new token for
the same wallet, or a different one).
After this commit, a call to the /unlock endpoint
will succeed even if an existing wallet is currently
unlocked (whether a different one or the same one).
The existing wallet service, if present, is shut down,
if the attempt to authenticate a new wallet, with a
password is successful (otherwise nothing happens).
A test is added to make sure that this re-unlock can work.