### PR TITLE
Add /taker/stop endpoint to RPC

### DIFF
--- a/jmclient/jmclient/wallet-rpc-api.md
+++ b/jmclient/jmclient/wallet-rpc-api.md
@@ -268,6 +268,7 @@ create and broadcast a transaction (without coinjoin)
 | ---- | ----------- |
 | 200 | transaction broadcast OK. |
 | 400 | Bad request format. |
+| 404 | Item not found. |
 | 401 | Unable to authorise the credentials that were supplied. |
 | 409 | Transaction failed to broadcast. |
 
@@ -301,6 +302,7 @@ Start the yield generator service with the configuration settings specified in t
 | 202 | The request has been submitted successfully for processing, but the processing has not been completed. |
 | 400 | Bad request format. |
 | 401 | Unable to authorise the credentials that were supplied. |
+| 404 | Item not found. |
 | 503 | The server is not ready to process the request. |
 
 ##### Security
@@ -333,6 +335,7 @@ stop the yield generator service
 | 202 | The request has been submitted successfully for processing, but the processing has not been completed. |
 | 400 | Bad request format. |
 | 401 | Unable to authorise the credentials that were supplied. |
+| 404 | Item not found. |
 
 ##### Security
 
@@ -367,6 +370,38 @@ initiate a coinjoin as taker
 | 404 | Item not found. |
 | 409 | Unable to complete request because config settings are missing. |
 | 503 | The server is not ready to process the request. |
+
+##### Security
+
+| Security Schema | Scopes |
+| --- | --- |
+| bearerAuth | |
+
+### /wallet/{walletname}/taker/stop
+
+#### GET
+##### Summary
+
+stop a running coinjoin attempt
+
+##### Description
+
+stop a running coinjoin attempt
+
+##### Parameters
+
+| Name | Located in | Description | Required | Schema |
+| ---- | ---------- | ----------- | -------- | ---- |
+| walletname | path | name of wallet including .jmdat | Yes | string |
+
+##### Responses
+
+| Code | Description |
+| ---- | ----------- |
+| 202 | The request has been submitted successfully for processing, but the processing has not been completed. |
+| 400 | Bad request format. |
+| 401 | Unable to authorise the credentials that were supplied. |
+| 404 | Item not found. |
 
 ##### Security
 

--- a/jmclient/jmclient/wallet-rpc-api.yaml
+++ b/jmclient/jmclient/wallet-rpc-api.yaml
@@ -224,6 +224,8 @@ paths:
           $ref: '#/components/responses/400-BadRequest'
         '401':
           $ref: '#/components/responses/401-Unauthorized'
+        '404':
+          $ref: '#/components/responses/404-NotFound'
         '409':
           $ref: '#/components/responses/409-TransactionFailed'
   /wallet/{walletname}/maker/start:
@@ -255,6 +257,8 @@ paths:
           $ref: '#/components/responses/400-BadRequest'
         '401':
           $ref: '#/components/responses/401-Unauthorized'
+        '404':
+          $ref: '#/components/responses/404-NotFound'
         '503':
           $ref: '#/components/responses/503-ServiceUnavailable'
   /wallet/{walletname}/maker/stop:
@@ -278,6 +282,8 @@ paths:
           $ref: '#/components/responses/400-BadRequest'
         '401':
           $ref: "#/components/responses/401-Unauthorized"
+        '404':
+          $ref: '#/components/responses/404-NotFound'
   /wallet/{walletname}/taker/coinjoin:
     post:
       security:
@@ -311,6 +317,29 @@ paths:
           $ref: '#/components/responses/409-NoConfig'
         '503':
           $ref: '#/components/responses/503-ServiceUnavailable'
+  /wallet/{walletname}/taker/stop:
+    get:
+      security:
+        - bearerAuth: []
+      summary: stop a running coinjoin attempt
+      operationId: stopcoinjoin
+      description: stop a running coinjoin attempt
+      parameters:
+        - name: walletname
+          in: path
+          description: name of wallet including .jmdat
+          required: true
+          schema:
+            type: string
+      responses:
+        '202':
+          $ref: "#/components/responses/202-Accepted"
+        '400':
+          $ref: '#/components/responses/400-BadRequest'
+        '401':
+          $ref: "#/components/responses/401-Unauthorized"
+        '404':
+          $ref: '#/components/responses/404-NotFound'
   /wallet/{walletname}/configset:
     post:
       security:

--- a/jmclient/jmclient/wallet_rpc.py
+++ b/jmclient/jmclient/wallet_rpc.py
@@ -780,8 +780,21 @@ class JMWalletDaemon(Service):
             utxos_response = self.get_listutxos_response(utxos)
             return make_jmwalletd_response(request, utxos=utxos_response)
 
+        # route to abort a currently running coinjoin
+        @app.route('/wallet/<string:walletname>/taker/stop', methods=['GET'])
+        def stopcoinjoin(self, request, walletname):
+            self.check_cookie(request)
+            if not self.wallet_service:
+                raise NoWalletFound()
+            if not self.wallet_name == walletname:
+                raise InvalidRequestFormat()
+            if not self.coinjoin_state == CJ_TAKER_RUNNING:
+                raise ServiceNotStarted()
+            self.taker_finished(False)
+            return make_jmwalletd_response(request, status=202)
+
         #route to start a coinjoin transaction
-        @app.route('/wallet/<string:walletname>/taker/coinjoin',methods=['POST'])
+        @app.route('/wallet/<string:walletname>/taker/coinjoin', methods=['POST'])
         def docoinjoin(self, request, walletname):
             self.check_cookie(request)
             if not self.wallet_service:


### PR DESCRIPTION
Prior to this commit, if a user has attempted
a coinjoin with /taker/coinjoin but a problem
occurs (such as an unresponsive maker), they
are not able to abort the protocol but must wait
until the taker_finished event is triggered.
After this commit a GET request to the endpoint
defined as /wallet/walletname/taker/stop will
force-stop the coinjoin attempt (similar to
quitting the script in CLI). This will reset the
wallet daemon state to CJ_NOT_RUNNING.