### PR TITLE
Pin python-qrcode to a specific version

### DIFF
--- a/requirements/gui.txt
+++ b/requirements/gui.txt
@@ -3,7 +3,7 @@ pywin32; platform_system == "Windows"
 # https://bugreports.qt.io/browse/QTBUG-88688
 PySide2!=5.15.0,!=5.15.1,!=5.15.2,!=6.0
 PyQt5!=5.15.0,!=5.15.1,!=5.15.2,!=6.0
-qrcode[pil]
+qrcode[pil]==7.3.1
 https://github.com/sunu/qt5reactor/archive/58410aaead2185e9917ae9cac9c50fe7b70e4a60.zip#egg=qt5reactor
 
 -e ./jmqtui


### PR DESCRIPTION
There have been some [takeover of qr.js NPM account recently](https://github.com/zpao/qrcode.react/issues/168). Let's remove potential attack vector here by pinning `qrcode` to a specific (latest) version.

It seems that PyPI does not allow overwrite of already uploaded files, so, unless PyPI itself is hacked, this is safe, it can't be replaced with something else so easy (although using package hashes would be better, of course).