### PR TITLE
Add status, label and extradata to RPC display

### DIFF
--- a/jmclient/jmclient/wallet-rpc-api.yaml
+++ b/jmclient/jmclient/wallet-rpc-api.yaml
@@ -613,7 +613,11 @@ components:
                                 type: string
                               amount: 
                                 type: string
-                              labels: 
+                              status:
+                                type: string
+                              label:
+                                type: string
+                              extradata:
                                 type: string
 
     CreateWalletResponse:

--- a/jmclient/jmclient/wallet_utils.py
+++ b/jmclient/jmclient/wallet_utils.py
@@ -187,7 +187,9 @@ class WalletViewEntry(WalletViewBase):
         return {"hd_path": self.wallet_path_repr,
                 "address": self.serialize_address(),
                 "amount": self.serialize_amounts(),
-                "labels": self.serialize_extra_data()}
+                "status": self.serialize_status(),
+                "label": self.serialize_label(),
+                "extradata": self.serialize_extra_data()}
 
     def serialize_wallet_position(self):
         return self.wallet_path_repr.ljust(20)


### PR DESCRIPTION
Fixes #1118.
Before this commit, the json serializtion of a
WalletEntry object was incorrect and missing some
fields. This is now fixed, and the WalletDisplayResponse
in the RPC spec .yaml file correctly reflects the
fields that are returned by the JMWalletDaemon in response
to the /display request.