### PR TITLE
RPC maker/start returns 409 error if no coins

### DIFF
--- a/jmclient/jmclient/__init__.py
+++ b/jmclient/jmclient/__init__.py
@@ -61,7 +61,7 @@ from .wallet_utils import (
 from .wallet_service import WalletService
 from .maker import Maker
 from .yieldgenerator import YieldGenerator, YieldGeneratorBasic, ygmain, \
-     YieldGeneratorService, YieldGeneratorServiceSetupFailed
+     YieldGeneratorService
 from .snicker_receiver import SNICKERError, SNICKERReceiver, SNICKERReceiverService
 from .payjoin import (parse_payjoin_setup, send_payjoin,
                       JMBIP78ReceiverManager)

--- a/jmclient/jmclient/wallet-rpc-api.md
+++ b/jmclient/jmclient/wallet-rpc-api.md
@@ -287,7 +287,7 @@ Start the yield generator service.
 
 ##### Description
 
-Start the yield generator service with the configuration settings specified in the POST request. Note that if fidelity bonds are enabled in the wallet, and a timelock address has been generated, and then funded, the fidelity bond will automatically be advertised without any specific configuration in this request.
+Start the yield generator service with the configuration settings specified in the POST request. Note that if fidelity bonds are enabled in the wallet, and a timelock address has been generated, and then funded, the fidelity bond will automatically be advertised without any specific configuration in this request. Note that if the wallet does not have confirmed coins, or another taker or maker coinjoin service is already running, the maker will not start.
 
 ##### Parameters
 
@@ -303,6 +303,7 @@ Start the yield generator service with the configuration settings specified in t
 | 400 | Bad request format. |
 | 401 | Unable to authorise the credentials that were supplied. |
 | 404 | Item not found. |
+| 409 | Maker could not start without confirmed balance. |
 | 503 | The server is not ready to process the request. |
 
 ##### Security

--- a/jmclient/jmclient/wallet-rpc-api.yaml
+++ b/jmclient/jmclient/wallet-rpc-api.yaml
@@ -234,7 +234,7 @@ paths:
         - bearerAuth: []
       summary: Start the yield generator service.
       operationId: startmaker
-      description: Start the yield generator service with the configuration settings specified in the POST request. Note that if fidelity bonds are enabled in the wallet, and a timelock address has been generated, and then funded, the fidelity bond will automatically be advertised without any specific configuration in this request.
+      description: Start the yield generator service with the configuration settings specified in the POST request. Note that if fidelity bonds are enabled in the wallet, and a timelock address has been generated, and then funded, the fidelity bond will automatically be advertised without any specific configuration in this request. Note that if the wallet does not have confirmed coins, or another taker or maker coinjoin service is already running, the maker will not start.
       parameters:
         - name: walletname
           in: path
@@ -259,6 +259,8 @@ paths:
           $ref: '#/components/responses/401-Unauthorized'
         '404':
           $ref: '#/components/responses/404-NotFound'
+        '409':
+          $ref: '#/components/responses/409-No-Coins'
         '503':
           $ref: '#/components/responses/503-ServiceUnavailable'
   /wallet/{walletname}/maker/stop:
@@ -855,6 +857,12 @@ components:
             $ref: '#/components/schemas/ErrorMessage'
     409-TransactionFailed:
       description: Transaction failed to broadcast.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorMessage'
+    409-No-Coins:
+      description: Maker could not start without confirmed balance.
       content:
         application/json:
           schema:

--- a/jmclient/jmclient/yieldgenerator.py
+++ b/jmclient/jmclient/yieldgenerator.py
@@ -268,9 +268,6 @@ class YieldGeneratorBasic(YieldGenerator):
         cjoutmix = (input_mixdepth + 1) % (self.wallet_service.mixdepth + 1)
         return self.wallet_service.get_internal_addr(cjoutmix)
 
-class YieldGeneratorServiceSetupFailed(Exception):
-    pass
-
 class YieldGeneratorService(Service):
     def __init__(self, wallet_service, daemon_host, daemon_port, yg_config):
         self.wallet_service = wallet_service
@@ -292,8 +289,11 @@ class YieldGeneratorService(Service):
         no need to check this here.
         """
         for setup in self.setup_fns:
-            if not setup():
-                raise YieldGeneratorServiceSetupFailed
+            # we do not catch Exceptions in setup,
+            # deliberately; this must be caught and distinguished
+            # by whoever started the service.
+            setup()
+
         # TODO genericise to any YG class:
         self.yieldgen = YieldGeneratorBasic(self.wallet_service, self.yg_config)
         self.clientfactory = JMClientProtocolFactory(self.yieldgen, proto_type="MAKER")


### PR DESCRIPTION
Fixes #1120. As per the discussion in that issue, while
we can only return 'processing started' by default, and
the client must monitor progress/state to see if the maker
service has connected successfully, nevertheless if the
maker startup is immediately invalidated by the fact that
the already-synced wallet does not contain confirmed coins,
we can and should return an error message instead of a 202.
This commit does that, adding to the spec a 409-No-Coins
response type which indicates to the API client that the
setup of the maker failed for this specific reason.