### PR TITLE
Ensure all displayed addresses are imported

### DIFF
--- a/jmclient/jmclient/wallet_service.py
+++ b/jmclient/jmclient/wallet_service.py
@@ -887,11 +887,13 @@ class WalletService(Service):
                                                    include_disabled=include_disabled,
                                                    maxheight=maxheight)
 
-    def get_internal_addr(self, mixdepth):
+    def import_addr(self, addr):
         if self.bci is not None and hasattr(self.bci, 'import_addresses'):
-            addr = self.wallet.get_internal_addr(mixdepth)
-            self.bci.import_addresses([addr],
-                                      self.wallet.get_wallet_name())
+            self.bci.import_addresses([addr], self.wallet.get_wallet_name())
+
+    def get_internal_addr(self, mixdepth):
+        addr = self.wallet.get_internal_addr(mixdepth)
+        self.import_addr(addr)
         return addr
 
     def collect_addresses_init(self):
@@ -944,10 +946,8 @@ class WalletService(Service):
         return addresses
 
     def get_external_addr(self, mixdepth):
-        if self.bci is not None and hasattr(self.bci, 'import_addresses'):
-            addr = self.wallet.get_external_addr(mixdepth)
-            self.bci.import_addresses([addr],
-                                      self.wallet.get_wallet_name())
+        addr = self.wallet.get_external_addr(mixdepth)
+        self.import_addr(addr)
         return addr
 
     def __getattr__(self, attr):

--- a/test/ygrunner.py
+++ b/test/ygrunner.py
@@ -217,7 +217,7 @@ def get_addr_and_fund(yg):
         return
     if yg.wallet_service.timelock_funded:
         return
-    addr = wallet_gettimelockaddress(yg.wallet_service.wallet, "2021-11")
+    addr = wallet_gettimelockaddress(yg.wallet_service.wallet, "2023-11")
     print("Got timelockaddress: {}".format(addr))
 
     # pay into it; amount is randomized for now.


### PR DESCRIPTION
Fixes #1143 (and possibly others). Before this commit,
(index plus gap limit) addresses are imported on sync,
and addresses used by maker/taker in coinjoin are imported,
but when a deposit occurred, bumping the index, further
addresses were not imported. The effect was that it was
possible, if doing a series of deposits to multiple
external addresses in a Qt session, to end up depositing
to an address that was not yet imported. And this results
in the user needing to rescan for Core+JM to recognize the
coins.
After this commit, we ensure all 'gap limit forwards'
addresses, which are displayed as potential deposit addresses
in Joinmarket-Qt, are imported before the display.