### PR TITLE
Document rpc_cookie_file and rpc_wallet_file in default config

### DIFF
--- a/jmclient/jmclient/configure.py
+++ b/jmclient/jmclient/configure.py
@@ -120,8 +120,16 @@ network = mainnet
 rpc_host = localhost
 # default ports are 8332 for mainnet, 18443 for regtest, 18332 for testnet, 38332 for signet
 rpc_port =
+
+# Use either rpc_user / rpc_password pair or rpc_cookie_file.
 rpc_user = bitcoin
 rpc_password = password
+#rpc_cookie_file =
+
+# rpc_wallet_file is Bitcoin Core wallet which is used for address and
+# transaction monitoring (it is watchonly, no private keys are stored there).
+# It must be created manually if does not exist, see docs/USAGE.md for more
+# information.
 rpc_wallet_file =
 
 ## SERVER 1/4) Darkscience IRC (Tor, IP)


### PR DESCRIPTION
RPC cookie auth was added in #128 (Mar 2018), but never documented anywhere. This adds it to default generated `joinmarket.cfg`. Also added detailed comment about `rpc_wallet_file`, as it also sometimes confuses new users.