### PR TITLE
Make unconf unspent display default in jmwalletd

### DIFF
--- a/scripts/jmwalletd.py
+++ b/scripts/jmwalletd.py
@@ -30,6 +30,10 @@ def jmwalletd_main():
                    "blockchain source.")
         sys.exit(EXIT_FAILURE)
 
+    # if nothing was configured, we override bitcoind's options so that
+    # unconfirmed balance is included in the wallet display by default
+    if 'listunspent_args' not in jm_single().config.options('POLICY'):
+        jm_single().config.set('POLICY','listunspent_args', '[0]')
     jlog.info("Starting jmwalletd on port: " + str(options.port))
     jm_wallet_daemon = JMWalletDaemon(options.port, options.wss_port)
     jm_wallet_daemon.startService()


### PR DESCRIPTION
Fixes #1162.
Prior to this commit, the default argument [] was provided
to the bitcoind RPC listunspent call, which means only confirmed
unspent coins are returned. This is in contrast to the display
in wallet_tool, which deliberately updates listunspent_args to [0]
in order to default to showing unconfirmed coins, as users will
expect.
This commit adds the same listunspent_args = [0] in case the user
has not edited this variable in the config, for the same reason.