### PR TITLE
Adds table of contents on readme page.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,23 @@
 ![Release workflow status](https://github.com/JoinMarket-Org/joinmarket-clientserver/actions/workflows/unittests.yml/badge.svg)
+# Table of contents
+---
+* [Table of contents](#table-of-contents)
+* [joinmarket-clientserver](#joinmarket-clientserver)
+* [Wallet features](#wallet-features)
+* [Quickstart - RECOMMENDED INSTALLATION METHOD (Linux and macOS only)](#quickstart---recommended-installation-method-linux-and-macos-only)
+* [More installation guides](#more-installation-guides)
+* [Usage](#usage)
+* [PayJoin](#payjoin)
+* [Joinmarket-Qt](#joinmarket-qt)
+* [Architecture notes](#architecture-notes)
+* [Testing](#testing)
+* [Community](#community)
+* [Support JoinMarket and bitcoin privacy](#support-joinmarket-and-bitcoin-privacy)
+* [Other useful links](#other-useful-links)
+
 
 # joinmarket-clientserver
+---
 
 JoinMarket is software to create a special kind of bitcoin transaction called a CoinJoin transaction. Its aim is to improve the confidentiality and privacy of bitcoin transactions.
 
@@ -13,6 +30,7 @@ Widespread use of JoinMarket improves bitcoin's fungibility and privacy. This im
 For a quick introduction to Joinmarket you can watch [this demonstration](https://youtu.be/hwmvZVQ4C4M) of installation and usage given by [Adam Gibson](https://github.com/AdamISZ) during the [Understanding Bitcoin conference](https://understandingbtc.com/) on April 6 2019.
 
 ### Wallet features
+---
 
 * Segwit addresses (native bech32 ('bc1') by default; p2sh wrapped ('3') optionally).
 * Multiple "mixdepths" or pockets (by default 5) for better coin isolation
@@ -29,6 +47,8 @@ For a quick introduction to Joinmarket you can watch [this demonstration](https:
 * Address labeling
 
 ### Quickstart - RECOMMENDED INSTALLATION METHOD (Linux and macOS only)
+---
+
 
 Once you've downloaded this repo, either as a tar/zip file, and extracted it, or via `git clone`:
 
@@ -53,6 +73,8 @@ You should now be able to run the scripts like `python wallet-tool.py` etc., jus
 Alternative to this "quickstart": follow the [install guide](docs/INSTALL.md).
 
 ### More installation guides
+---
+
 
 * [Installation on Windows](docs/INSTALL.md#installation-on-windows).
 * [Installation guide for RaspiBlitz](https://github.com/openoms/bitcoin-tutorials/blob/master/joinmarket/README.md).
@@ -61,6 +83,8 @@ Alternative to this "quickstart": follow the [install guide](docs/INSTALL.md).
 * [Youtube video installation tutorial for Ubuntu](https://www.youtube.com/watch?v=zTCC86IUzWo).
 
 ### Usage
+---
+
 
 If you are new, follow and read the links in the [usage guide](docs/USAGE.md).
 
@@ -68,14 +92,17 @@ If you are running Joinmarket-Qt, you can instead use the [walkthrough](docs/JOI
 
 If you used the old version of Joinmarket, the notes in the [scripts readme](scripts/README.md) help to understand what has and hasn't changed about the scripts (warning: this refers to changes from several years ago, so may be slightly outdated).
 
-If you are looking for the available makers, run the [orderbook](docs/orderbook.md). 
+If you are looking for the available makers, run the [orderbook](docs/orderbook.md).
 Public mainnet mirror: [JoinMarket Browser Interface Orderbook](https://nixbitcoin.org/orderbook) [(🧅 tor)](http://qvzlxbjvyrhvsuyzz5t63xx7x336dowdvt7wfj53sisuun4i4rdtbzid.onion/orderbook)
 
 ### PayJoin
+---
+
 
 If you want to use the PayJoin feature to pay/receive money to/from another [BIP78]((https://github.com/bitcoin/bips/blob/master/bip-0078.mediawiki))-supporting wallet, read [this guide](docs/PAYJOIN.md).
 
 ### Joinmarket-Qt
+---
 
 Provides single join and multi-join/tumbler functionality (i.e. "Taker") only, in a GUI.
 
@@ -90,14 +117,17 @@ After this, the command `python joinmarket-qt.py` from within the `scripts` subd
 There is a [walkthrough](docs/JOINMARKET-QT-GUIDE.md) for what to do next.
 
 ### Architecture notes
+---
 
 See [architecture-notes.md](docs/architecture-notes.md).
 
 ### TESTING
+---
 
 Instructions for developers for testing [here](docs/TESTING.md). If you want to help improve the project, please have a read of [this todo list](docs/TODO.md) and the [Help Wanted tag](https://github.com/JoinMarket-Org/joinmarket-clientserver/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22) on the issue tracker.
 
 ### Community
+---
 
 + IRC: `#joinmarket` on irc.libera.chat https://kiwiirc.com/nextclient/irc.libera.chat#joinmarket (logs can be found [here](https://gnusha.org/joinmarket/))
 
@@ -114,8 +144,14 @@ Instructions for developers for testing [here](docs/TESTING.md). If you want to 
 + Telegram: https://t.me/joinmarketorg
 
 ### Support JoinMarket and bitcoin privacy
+---
 
 Donate to help make JoinMarket even better: [Obtain a bitcoin address here](https://bitcoinprivacy.me/joinmarket-donations)
 
 JoinMarket is an open source project which does not have a funding model, fortunately the project itself has very low running costs as it is almost-fully decentralized and available to everyone for free. Developers contribute only as volunteers and donations are divided amongst them. Many developers have also been important in advocating for privacy and educating the wider bitcoin user base. Be part of the effort to improve bitcoin privacy and fungibility. Every donated coin helps us spend more time on JoinMarket instead of doing other stuff.
+
+### Other useful links
+---
+1. [Visit In-detail documentation on Github pages](https://joinmarket-org.github.io/joinmarket-clientserver/)
+2. [Visit RPC-API documentation](https://joinmarket-org.github.io/joinmarket-clientserver/api/)
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@ For a quick introduction to Joinmarket you can watch [this demonstration](https:
 * [Testing](#testing)
 * [Community](#community)
 * [Support JoinMarket and bitcoin privacy](#support-joinmarket-and-bitcoin-privacy)
-* [Other useful links](#other-useful-links)
 
 ### Documentation
 ---

--- a/README.md
+++ b/README.md
@@ -1,9 +1,18 @@
 ![Release workflow status](https://github.com/JoinMarket-Org/joinmarket-clientserver/actions/workflows/unittests.yml/badge.svg)
 
+JoinMarket is software to create a special kind of bitcoin transaction called a CoinJoin transaction. Its aim is to improve the confidentiality and privacy of bitcoin transactions.
+
+A CoinJoin transaction requires other people to take part. The right resources (coins) have to be in the right place, at the right time, in the right quantity. This isn't a software or tech problem, it's an economic problem. JoinMarket works by creating a new kind of market that would allocate these resources in the best way.
+
+One group of participants (called market makers) will always be available to take part in CoinJoins at any time. Other participants (called market takers) can create a CoinJoin at any time. The takers pay a fee which incentivizes the makers. A form of smart contract is created, meaning the private keys will never be broadcasted outside of your computer, resulting in virtually zero risk of loss (aside from malware or bugs). As a result of free-market forces the fees will eventually be next to nothing.
+
+Widespread use of JoinMarket improves bitcoin's fungibility and privacy. This implementation of JoinMarket also implements [PayJoin](https://en.bitcoin.it/wiki/PayJoin).
+
+For a quick introduction to Joinmarket you can watch [this demonstration](https://youtu.be/hwmvZVQ4C4M) of installation and usage given by [Adam Gibson](https://github.com/AdamISZ) during the [Understanding Bitcoin conference](https://understandingbtc.com/) on April 6 2019.
+
 # Table of contents
 ---
 
-* [Joinmarket](#joinmarket)
 * [Documentation](#documentation)
 * [Wallet features](#wallet-features)
 * [Quickstart - RECOMMENDED INSTALLATION METHOD (Linux and macOS only)](#quickstart---recommended-installation-method-linux-and-macos-only)
@@ -16,20 +25,6 @@
 * [Community](#community)
 * [Support JoinMarket and bitcoin privacy](#support-joinmarket-and-bitcoin-privacy)
 * [Other useful links](#other-useful-links)
-
-
-# Joinmarket
----
-
-JoinMarket is software to create a special kind of bitcoin transaction called a CoinJoin transaction. Its aim is to improve the confidentiality and privacy of bitcoin transactions.
-
-A CoinJoin transaction requires other people to take part. The right resources (coins) have to be in the right place, at the right time, in the right quantity. This isn't a software or tech problem, it's an economic problem. JoinMarket works by creating a new kind of market that would allocate these resources in the best way.
-
-One group of participants (called market makers) will always be available to take part in CoinJoins at any time. Other participants (called market takers) can create a CoinJoin at any time. The takers pay a fee which incentivizes the makers. A form of smart contract is created, meaning the private keys will never be broadcasted outside of your computer, resulting in virtually zero risk of loss (aside from malware or bugs). As a result of free-market forces the fees will eventually be next to nothing.
-
-Widespread use of JoinMarket improves bitcoin's fungibility and privacy. This implementation of JoinMarket also implements [PayJoin](https://en.bitcoin.it/wiki/PayJoin).
-
-For a quick introduction to Joinmarket you can watch [this demonstration](https://youtu.be/hwmvZVQ4C4M) of installation and usage given by [Adam Gibson](https://github.com/AdamISZ) during the [Understanding Bitcoin conference](https://understandingbtc.com/) on April 6 2019.
 
 ### Documentation
 ---

--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 ![Release workflow status](https://github.com/JoinMarket-Org/joinmarket-clientserver/actions/workflows/unittests.yml/badge.svg)
+
 # Table of contents
 ---
-* [Table of contents](#table-of-contents)
-* [joinmarket-clientserver](#joinmarket-clientserver)
+
+* [Joinmarket](#joinmarket)
+* [Documentation](#documentation)
 * [Wallet features](#wallet-features)
 * [Quickstart - RECOMMENDED INSTALLATION METHOD (Linux and macOS only)](#quickstart---recommended-installation-method-linux-and-macos-only)
 * [More installation guides](#more-installation-guides)
@@ -16,7 +18,7 @@
 * [Other useful links](#other-useful-links)
 
 
-# joinmarket-clientserver
+# Joinmarket
 ---
 
 JoinMarket is software to create a special kind of bitcoin transaction called a CoinJoin transaction. Its aim is to improve the confidentiality and privacy of bitcoin transactions.
@@ -28,6 +30,12 @@ One group of participants (called market makers) will always be available to tak
 Widespread use of JoinMarket improves bitcoin's fungibility and privacy. This implementation of JoinMarket also implements [PayJoin](https://en.bitcoin.it/wiki/PayJoin).
 
 For a quick introduction to Joinmarket you can watch [this demonstration](https://youtu.be/hwmvZVQ4C4M) of installation and usage given by [Adam Gibson](https://github.com/AdamISZ) during the [Understanding Bitcoin conference](https://understandingbtc.com/) on April 6 2019.
+
+### Documentation
+---
+
+1. [Visit In-detail documentation on Github pages](https://joinmarket-org.github.io/joinmarket-clientserver/)
+2. [Visit RPC-API documentation](https://joinmarket-org.github.io/joinmarket-clientserver/api/)
 
 ### Wallet features
 ---
@@ -149,9 +157,3 @@ Instructions for developers for testing [here](docs/TESTING.md). If you want to 
 Donate to help make JoinMarket even better: [Obtain a bitcoin address here](https://bitcoinprivacy.me/joinmarket-donations)
 
 JoinMarket is an open source project which does not have a funding model, fortunately the project itself has very low running costs as it is almost-fully decentralized and available to everyone for free. Developers contribute only as volunteers and donations are divided amongst them. Many developers have also been important in advocating for privacy and educating the wider bitcoin user base. Be part of the effort to improve bitcoin privacy and fungibility. Every donated coin helps us spend more time on JoinMarket instead of doing other stuff.
-
-### Other useful links
----
-1. [Visit In-detail documentation on Github pages](https://joinmarket-org.github.io/joinmarket-clientserver/)
-2. [Visit RPC-API documentation](https://joinmarket-org.github.io/joinmarket-clientserver/api/)
-


### PR DESCRIPTION
This PR fixes: #1161 
Adds table of contents on readme page and also adds two useful links for Github pages documentation & RPC-API documentation.

Thank you