### PR TITLE
Do not call stopService at exit in RPC daemon

### DIFF
--- a/jmclient/jmclient/wallet_rpc.py
+++ b/jmclient/jmclient/wallet_rpc.py
@@ -2,7 +2,6 @@ from jmbitcoin import *
 import datetime
 import os
 import json
-import atexit
 from io import BytesIO
 from jmclient.wallet_utils import wallet_showutxos
 from twisted.internet import reactor, ssl
@@ -159,8 +158,6 @@ class JMWalletDaemon(Service):
         # keep track of client side connections so they
         # can be shut down cleanly:
         self.coinjoin_connection = None
-        # ensure shut down does not leave dangling services:
-        atexit.register(self.stopService)
 
     def activate_coinjoin_state(self, state):
         """ To be set when a maker or taker
@@ -238,7 +235,7 @@ class JMWalletDaemon(Service):
         # if the wallet-daemon is shut down, all services
         # it encapsulates must also be shut down.
         for name, service in self.services.items():
-            if service:
+            if service and service.running == 1:
                 service.stopService()
         # these Services cannot be guaranteed to be
         # re-startable (the WalletService for example,

--- a/jmclient/jmclient/wallet_service.py
+++ b/jmclient/jmclient/wallet_service.py
@@ -143,7 +143,7 @@ class WalletService(Service):
         should *not* be restarted, instead a new
         WalletService instance should be created.
         """
-        if self.monitor_loop:
+        if self.monitor_loop and self.monitor_loop.running:
             self.monitor_loop.stop()
         self.wallet.close()
         super().stopService()

--- a/jmclient/test/test_wallet_rpc.py
+++ b/jmclient/test/test_wallet_rpc.py
@@ -100,7 +100,8 @@ class WalletRPCTestBase(object):
     def tearDown(self):
         self.clean_out_wallet_files()
         for dc in reactor.getDelayedCalls():
-            dc.cancel()        
+            if not dc.cancelled:
+                dc.cancel()
         d1 = defer.maybeDeferred(self.listener_ws.stopListening)
         d2 = defer.maybeDeferred(self.listener_rpc.stopListening)
         if self.client_connector:


### PR DESCRIPTION
Fixes #1166.
Fixes #1173.
Prior to this commit, in tests, we were calling
JMWalletDaemon.stopService at exit of the python script,
outside the pytest context, leading to various errors because
the test framework had gone through tear down.
After this commit, no attempt to call stopService is made
at exit (this is not necessary, we already call wallet close
and there is no other persistence necessary).