### PR TITLE
Read only single line with `--wallet-password-stdin`

### DIFF
--- a/jmclient/jmclient/wallet_utils.py
+++ b/jmclient/jmclient/wallet_utils.py
@@ -1505,7 +1505,7 @@ def get_wallet_path(file_name, wallet_dir=None):
 
 
 def read_password_stdin():
-    return sys.stdin.read().encode('utf-8')
+    return sys.stdin.readline().replace('\n','').encode('utf-8')
 
 
 def wallet_tool_main(wallet_root_path):


### PR DESCRIPTION
We don't allow to enter multiline passphrases in other places anyway and this allows to feed other data via stdin to scripts afterwards.