### PR TITLE
upgrade to python-bitcointx 1.1.3

### DIFF
--- a/jmbitcoin/setup.py
+++ b/jmbitcoin/setup.py
@@ -10,5 +10,5 @@ setup(name='joinmarketbitcoin',
       license='GPL',
       packages=['jmbitcoin'],
       python_requires='>=3.6',
-      install_requires=['python-bitcointx>=1.1.1.post0', 'pyaes', 'urldecode'],
+      install_requires=['python-bitcointx==1.1.3', 'pyaes', 'urldecode'],
       zip_safe=False)


### PR DESCRIPTION
See https://github.com/Simplexum/python-bitcointx/releases/tag/python-bitcointx-v1.1.3 , this is for spending to taproot specifically (so #1084 ), but should also address problems like mentioned [here](https://github.com/JoinMarket-Org/joinmarket-clientserver/issues/1139#issuecomment-1006217963).