### PR TITLE
fix: improve NotEnoughCoinsForMaker error message

### DIFF
--- a/jmclient/jmclient/wallet_rpc.py
+++ b/jmclient/jmclient/wallet_rpc.py
@@ -318,7 +318,7 @@ class JMWalletDaemon(Service):
     def not_enough_coins(self, request, failure):
         # as above, 409 may not be ideal
         request.setResponseCode(409)
-        return self.err(request, "Maker could not start, no coins.")
+        return self.err(request, "Maker could not start, no confirmed coins.")
 
     @app.handle_errors(YieldGeneratorDataUnreadable)
     def yieldgenerator_report_unavailable(self, request, failure):


### PR DESCRIPTION
Changes the error message when the maker cannot start due to not enough coins from:
`"Maker could not start, no coins."` to `"Maker could not start, no confirmed coins."`

According to @AdamISZ [here](https://github.com/joinmarket-webui/joinmarket-webui/issues/34#issuecomment-1032558663) this could be an improvement for the user, as it might make it clear that coins need to mature.

Please just dismiss if you think it's not a good idea.



Edit: The newline change has been made by GitHub automatically.. :thinking: 