### PR TITLE
Update docker base

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:buster-slim
+FROM debian:bullseye-slim
 
 RUN mkdir -p /jm/clientserver
 WORKDIR /jm/clientserver

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,9 @@ WORKDIR /jm/clientserver
 COPY . .
 
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates=* curl=* \
-  python3-pip=* \
+  python3-pip=* python3=* \
   && pip3 install 'wheel>=0.35.1' \
   && ./install.sh --docker-install \
+  && apt-get purge -y --autoremove python3-pip \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
* Update base image from buster to current stable bullseye (resulting in python3 upgrade 3.7.3 -> 3.9.2)
* Remove python3-pip from image