### PR TITLE
Print which option is invalid in shell scripts

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -393,6 +393,9 @@ parse_flags ()
                 break
                 ;;
             *)
+                if [[ $1 != '-h' ]] && [[ $1 != '--help' ]]; then
+                    echo "Invalid option $1"
+                fi
                 echo "
 Usage: "${0}" [options]
 

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -122,6 +122,9 @@ parse_flags ()
                 break
                 ;;
             *)
+                if [[ $1 != '-h' ]] && [[ $1 != '--help' ]]; then
+                    echo "Invalid option $1"
+                fi
                 echo "
 Usage: "${0}" [options]
 


### PR DESCRIPTION
To save time when you have a typo in single of them in a long list.