### PR TITLE
Make commitmentlist be in datadir by default.

### DIFF
--- a/jmbase/jmbase/commands.py
+++ b/jmbase/jmbase/commands.py
@@ -34,7 +34,8 @@ class JMInit(JMCommand):
                  (b'irc_configs', JsonEncodable()),
                  (b'minmakers', Integer()),
                  (b'maker_timeout_sec', Integer()),
-                 (b'dust_threshold', Integer())]
+                 (b'dust_threshold', Integer()),
+                 (b'blacklist_location', Unicode())]
     errors = {DaemonNotReady: b'daemon is not ready'}
 
 class JMStartMC(JMCommand):

--- a/jmbase/test/test_commands.py
+++ b/jmbase/test/test_commands.py
@@ -44,9 +44,9 @@ class JMTestServerProtocol(JMBaseProtocol):
 
     @JMInit.responder
     def on_JM_INIT(self, bcsource, network, irc_configs, minmakers,
-                   maker_timeout_sec, dust_threshold):
+                   maker_timeout_sec, dust_threshold, blacklist_location):
         show_receipt("JMINIT", bcsource, network, irc_configs, minmakers,
-                     maker_timeout_sec, dust_threshold)
+                     maker_timeout_sec, dust_threshold, blacklist_location)
         d = self.callRemote(JMInitProto,
                             nick_hash_length=1,
                             nick_max_encoded=2,
@@ -140,7 +140,8 @@ class JMTestClientProtocol(JMBaseProtocol):
                             irc_configs=['dummy', 'irc', 'config'],
                             minmakers=7,
                             maker_timeout_sec=8,
-                            dust_threshold=1500)
+                            dust_threshold=1500,
+                            blacklist_location=".")
         self.defaultCallbacks(d)
 
     @JMInitProto.responder

--- a/jmclient/jmclient/client_protocol.py
+++ b/jmclient/jmclient/client_protocol.py
@@ -445,7 +445,8 @@ class JMMakerClientProtocol(JMClientProtocol):
                             irc_configs=irc_configs,
                             minmakers=minmakers,
                             maker_timeout_sec=maker_timeout_sec,
-                            dust_threshold=jm_single().DUST_THRESHOLD)
+                            dust_threshold=jm_single().DUST_THRESHOLD,
+                            blacklist_location=jm_single().commitment_list_location)
         self.defaultCallbacks(d)
 
     @commands.JMFidelityBondProofRequest.responder
@@ -616,7 +617,8 @@ class JMTakerClientProtocol(JMClientProtocol):
                             irc_configs=irc_configs,
                             minmakers=minmakers,
                             maker_timeout_sec=maker_timeout_sec,
-                            dust_threshold=jm_single().DUST_THRESHOLD)
+                            dust_threshold=jm_single().DUST_THRESHOLD,
+                            blacklist_location=jm_single().commitment_list_location)
         self.defaultCallbacks(d)
 
     def stallMonitor(self, schedule_index):

--- a/jmclient/jmclient/configure.py
+++ b/jmclient/jmclient/configure.py
@@ -383,6 +383,12 @@ accept_commitment_broadcasts = 1
 # and those you want to use in future), relative to the scripts directory.
 commit_file_location = cmtdata/commitments.json
 
+# Location of the file used by makers to keep track of used/blacklisted
+# commitments. For remote daemon, set to `.` to have it stored locally
+# (but note that *all* bots using the same code installation share it,
+# in this case, which can be bad in testing).
+commitment_list_location = cmtdata/commitmentlist
+
 ##############################
 # END OF ANTI-SNOOPING SETTINGS
 ##############################
@@ -726,6 +732,13 @@ def load_program_config(config_path="", bs=None, plugin_services=[]):
             "_commitments.json"
     set_commitment_file(os.path.join(config_path,
                                          global_singleton.commit_file_location))
+
+    if global_singleton.config.get("POLICY", "commitment_list_location") == ".":
+        # Exceptional case as explained in comment in joinmarket.cfg:
+        global_singleton.commitment_list_location = "."
+    else:
+        global_singleton.commitment_list_location = os.path.join(config_path,
+        global_singleton.config.get("POLICY", "commitment_list_location"))
 
     for p in plugin_services:
         # for now, at this config level, the only significance

--- a/jmclient/test/test_client_protocol.py
+++ b/jmclient/test/test_client_protocol.py
@@ -168,9 +168,9 @@ class JMTestServerProtocol(JMBaseProtocol):
 
     @JMInit.responder
     def on_JM_INIT(self, bcsource, network, irc_configs, minmakers,
-                   maker_timeout_sec, dust_threshold):
+                   maker_timeout_sec, dust_threshold, blacklist_location):
         show_receipt("JMINIT", bcsource, network, irc_configs, minmakers,
-                     maker_timeout_sec, dust_threshold)
+                     maker_timeout_sec, dust_threshold, blacklist_location)
         d = self.callRemote(JMInitProto,
                             nick_hash_length=1,
                             nick_max_encoded=2,

--- a/jmdaemon/jmdaemon/daemon_protocol.py
+++ b/jmdaemon/jmdaemon/daemon_protocol.py
@@ -66,6 +66,12 @@ def taker_only(func):
         return None
     return func_wrapper
 
+# the location of the file
+blacklist_location = None
+def set_blacklist_location(location):
+    global blacklist_location
+    blacklist_location = location
+
 def check_utxo_blacklist(commitment, persist=False):
     """Compare a given commitment with the persisted blacklist log file,
     which is hardcoded to this directory and name 'commitmentlist' (no
@@ -75,7 +81,7 @@ def check_utxo_blacklist(commitment, persist=False):
     If flagged, persist the usage of this commitment to the above file.
     """
     #TODO format error checking?
-    fname = "commitmentlist"
+    fname = blacklist_location
     if os.path.isfile(fname):
         with open(fname, "rb") as f:
             blacklisted_commitments = [x.decode('ascii').strip() for x in f.readlines()]
@@ -498,7 +504,7 @@ class JMDaemonServerProtocol(amp.AMP, OrderbookWatch):
 
     @JMInit.responder
     def on_JM_INIT(self, bcsource, network, irc_configs, minmakers,
-                   maker_timeout_sec, dust_threshold):
+                   maker_timeout_sec, dust_threshold, blacklist_location):
         """Reads in required configuration from client for a new
         session; feeds back joinmarket messaging protocol constants
         (required for nick creation).
@@ -507,6 +513,7 @@ class JMDaemonServerProtocol(amp.AMP, OrderbookWatch):
         """
         self.maker_timeout_sec = maker_timeout_sec
         self.minmakers = minmakers
+        set_blacklist_location(blacklist_location)
         self.dust_threshold = int(dust_threshold)
         #(bitcoin) network only referenced in channel name construction
         self.network = network

--- a/jmdaemon/test/test_daemon_protocol.py
+++ b/jmdaemon/test/test_daemon_protocol.py
@@ -66,7 +66,8 @@ class JMTestClientProtocol(JMBaseProtocol):
                             irc_configs=irc,
                             minmakers=2,
                             maker_timeout_sec=3,
-                            dust_threshold=27300)
+                            dust_threshold=27300,
+                            blacklist_location=".")
         self.defaultCallbacks(d)
 
     @JMInitProto.responder
@@ -212,7 +213,7 @@ class JMDaemonTestServerProtocol(JMDaemonServerProtocol):
 
     @JMInit.responder
     def on_JM_INIT(self, bcsource, network, irc_configs, minmakers,
-                   maker_timeout_sec, dust_threshold):
+                   maker_timeout_sec, dust_threshold, blacklist_location):
         self.maker_timeout_sec = maker_timeout_sec
         self.dust_threshold = int(dust_threshold)
         self.minmakers = minmakers


### PR DESCRIPTION
Prior to this commit, the file commitmentlist, which stores
commitments (podle) for makers to let them blacklist/prevent
reuse was stored in the local directory for the script, which
allowed remote running of jmdaemon but was very unhelpful for
any situation where multiple bots are running at once, e.g.
in testing or using multiple wallets against the same codebase.
This could result in incorrect rejection of coinjoins.
After this commit, by default, the commitmentlist file is stored
in datadir/cmtdata/commitmentlist, so it will be local to any
custom data directory as would be the case for running multiple
wallets on the same machine. A user can set the POLICY variable
commitment_list_location to "." to revert to the previous behaviour.