### PR TITLE
Fixed so tumbler can restart if no utxos in depth 0

### DIFF
--- a/scripts/tumbler.py
+++ b/scripts/tumbler.py
@@ -138,8 +138,8 @@ def main():
                             max_mix_depth)
     for i in range(options['mixdepthsrc'], max_mix_to_tumble):
         total_tumble_amount += wallet_service.get_balance_by_mixdepth()[i]
-        if total_tumble_amount == 0:
-            raise ValueError("No confirmed coins in the selected mixdepth(s). Quitting")
+    if total_tumble_amount == 0:
+        raise ValueError("No confirmed coins in the selected mixdepth(s). Quitting")
     exp_tx_fees_ratio = (involved_parties * fee_per_cp_guess) \
         / total_tumble_amount
     if exp_tx_fees_ratio > 0.05:


### PR DESCRIPTION
After a crash, tumbler.py was failing to restart with --restart
I de-indented "if total_tumble_amount == 0" so it is checked after the for loop, when all mixdepths have been checked