### PR TITLE
doc: Document use of legacy wallet in USAGE.md

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -28,7 +28,7 @@ def local_command(command, bg=False, redirect=''):
         elif OS == 'Linux':
             command.extend(['>', '/dev/null', '2>&1'])
         else:
-            print("OS not recognised, quitting.")
+            pytest.exit("OS not recognised, quitting.")
     elif redirect:
         command.extend(['>', redirect])
 
@@ -122,8 +122,16 @@ def setup(request):
                        "-rpcuser=" + bitcoin_rpcusername,
                        "-rpcpassword=" + bitcoin_rpcpassword]
     # Bitcoin Core v0.21+ does not create default wallet
-    local_command(root_cmd + ["-rpcwait"] +
-        ["createwallet", "jm-test-wallet"])
+    # From Bitcoin Core 0.21.0 there is support for descriptor wallets, which
+    # are default from 23.x+ (including 22.99.0 development versions).
+    # We don't support descriptor wallets yet.
+    if bitcoind_version[0] >= 22:
+        local_command(root_cmd + ["-rpcwait"] + ["-named"] +
+            ["createwallet",
+                "wallet_name=jm-test-wallet", "descriptors=false"])
+    else:
+        local_command(root_cmd + ["-rpcwait"] +
+            ["createwallet", "jm-test-wallet"])
     local_command(root_cmd + ["loadwallet", "jm-test-wallet"])
     for i in range(2):
         cpe = local_command(root_cmd + ["-rpcwallet=jm-test-wallet"] +

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -122,6 +122,11 @@ With `bitcoind` running, do:
 bitcoin-cli -named createwallet wallet_name=jm_wallet descriptors=false
 ```
 
+If this command fails with error `Unknown named parameter descriptors`, it means you run Bitcoin Core version older than v0.21. In that case do the following instead (but it's recommended to upgrade Bitcoin Core to more recent version):
+```
+bitcoin-cli createwallet "jm_wallet"
+```
+
 The "jm_wallet" name is just an example. You can set any name. Alternative to this `bitcoin-cli` command: you can set a line with `wallet=..` in your
 `bitcoin.conf` before starting Core (see the Bitcoin Core documentation for details). At the moment, only legacy wallets (`descriptors=false`)
 work with Joinmarket. This means that Bitcoin Core needs to have been built with legacy wallet (Berkeley DB) support.

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -112,16 +112,19 @@ but it *stores addresses as watch-only in the Bitcoin Core wallet*, and the rele
 wallet they're talking to. As a result it's strongly recommended to use this feature, as it isolates those watch-only addresses
 being stored in Bitcoin Core, from any other usage you might have for that Core instance.
 
-If you don't do this, Joinmarket will use the default Core wallet `wallet.dat` to store these watch-only addresses in.
+If you don't do this, and there is one, Joinmarket will use the default Core wallet `wallet.dat` to store these watch-only addresses in.
+If there isn't one, start will fail with a JsonRpcError `Wallet file verification failed. Failed to load database path '…'. Path does not exist.`.
+Make sure to follow the following step.
 
 With `bitcoind` running, do:
 
 ```
-bitcoin-cli createwallet "jm_wallet"
+bitcoin-cli -named createwallet wallet_name=jm_wallet descriptors=false
 ```
 
 The "jm_wallet" name is just an example. You can set any name. Alternative to this `bitcoin-cli` command: you can set a line with `wallet=..` in your
-`bitcoin.conf` before starting Core (see the Bitcoin Core documentation for details).
+`bitcoin.conf` before starting Core (see the Bitcoin Core documentation for details). At the moment, only legacy wallets (`descriptors=false`)
+work with Joinmarket. This means that Bitcoin Core needs to have been built with legacy wallet (Berkeley DB) support.
 
 After you create the wallet in the Bitcoin Core, you should set it in the `joinmarket.cfg`:
 

--- a/jmclient/jmclient/blockchaininterface.py
+++ b/jmclient/jmclient/blockchaininterface.py
@@ -194,6 +194,14 @@ class BitcoinCoreInterface(BlockchainInterface):
             loaded_wallets = self._rpc("listwallets", [])
             if not wallet_name in loaded_wallets:
                 self._rpc("loadwallet", [wallet_name])
+            # We only support legacy wallets currently
+            wallet_info = self._rpc("getwalletinfo", [])
+            if "descriptors" in wallet_info and wallet_info["descriptors"]:
+                raise Exception(
+                    "JoinMarket currently does not support Bitcoin Core "
+                    "descriptor wallets, use legacy wallet (rpc_wallet_file "
+                    "setting in joinmarket.cfg) instead. See docs/USAGE.md "
+                    "for details.")
 
     def is_address_imported(self, addr):
         return len(self._rpc('getaddressinfo', [addr])['labels']) > 0


### PR DESCRIPTION
This is the same as #1063, I wasn't allowed to add extra commits to that one. Original PR description:

Mention the creation of a legacy wallet in USAGE.md. This is currently important because of the use of `importmulti` RPC which doesn't exist for the new descriptor wallets.