### PR TITLE
GitHub workflow update (test multiple Bitcoin Core versions)

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -4,12 +4,13 @@ on: [push, pull_request]
 
 jobs:
   build:
-    name: python ${{ matrix.python-version }} on ${{ matrix.os }}
+    name: python ${{ matrix.python-version }}, bitcoind ${{ matrix.bitcoind-version }} on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [macos-latest, ubuntu-latest]
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        bitcoind-version: ["0.18.0", "25.0"]
 
     steps:
       - uses: actions/checkout@v3
@@ -38,10 +39,13 @@ jobs:
         uses: actions/cache@v3
         env:
           cache-name: bitcoind
+          BITCOIND_VERSION: ${{ matrix.bitcoind-version }}
         with:
           path: ~/bitcoin/*/bin/bitcoin*
-          key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('test/testrunner/install_bitcoind.sh') }}
+          key: ${{ runner.os }}-${{ env.cache-name }}-${{ env.BITCOIND_VERSION }}-${{ hashFiles('test/testrunner/install_bitcoind.sh') }}
       - name: Install bitcoind
+        env:
+          BITCOIND_VERSION: ${{ matrix.bitcoind-version }}
         run: ./test/testrunner/install_bitcoind.sh
       - name: Cache miniircd
         uses: actions/cache@v3

--- a/test/testrunner/install_bitcoind.sh
+++ b/test/testrunner/install_bitcoind.sh
@@ -2,12 +2,19 @@
 
 set -ev
 
-export BITCOIND_VERSION=0.19.1
+if [[ -z "$BITCOIND_VERSION" ]]; then
+    echo "BITCOIND_VERSION must be set"
+    exit 1
+fi
 
 if [[ "$(uname)" == "Linux" ]]; then
     platform="x86_64-linux-gnu"
 elif [[ "$(uname)" == "Darwin" ]]; then
-    platform="osx64"
+    if [[ $BITCOIND_VERSION > 23.0 || $BITCOIND_VERSION == 23.0 ]]; then
+        platform="x86_64-apple-darwin"
+    else
+        platform="osx64"
+    fi
 else
     echo "Unsupported platform: $(uname)"
     exit 1


### PR DESCRIPTION
* <del>Remove Python 3.6 (EOL), add Python 3.10.</del><ins>Done in #1409</ins>
* Add support for testing against multiple Bitcoin Core versions, add 0.18.0 (oldest officially support for test suite) and <del>22.0</del><ins>25.0</ins> (latest stable release). Previously we tested against hardcoded 0.19.1. IMO testing against oldest supported and latest makes sense, if tests pass on both, they should pass on releases inbetween too, unless there is some behaviour affecting us changed twice.

Also changed Core downloads from bitcoin.org to bitcoincore.org.

For now, opening PR as a test and for discussion. <del>Will increase running time 2x.</del>