### PR TITLE
Update local Tor config

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -385,9 +385,12 @@ tor_install ()
     pushd "${tor_version}"
     if tor_build; then
         $make install
-        # Create blank tor config, it will default to running socks5 proxy
-        # at 127.0.0.1:9050 and should be enough for us.
-        > "${jm_root}/etc/tor/torrc"
+        echo "# Default JoinMarket Tor configuration
+Log warn stderr
+SOCKSPort 9050 IsolateDestAddr IsolateDestPort
+ControlPort 9051
+CookieAuthentication 1
+        " > "${jm_root}/etc/tor/torrc"
     else
         return 1
     fi


### PR DESCRIPTION
* Change loglevel to "warn" to have less verbose output (it still outputs some "notice" level messages for me but less than without this).
* Add [stream isolation](https://github.com/JoinMarket-Org/joinmarket-clientserver/issues/583).
```
IsolateDestPort Don’t share circuits with streams targeting a different destination port.

IsolateDestAddr Don’t share circuits with streams targeting a different destination address.
```
* Cookie authentication.