### PR TITLE
Always track new transactions until confirmed

### DIFF
--- a/jmclient/jmclient/wallet_service.py
+++ b/jmclient/jmclient/wallet_service.py
@@ -406,9 +406,11 @@ class WalletService(Service):
                         self.callbacks["unconfirmed"][txid] = callbacks
                     else:
                         self.callbacks["unconfirmed"].pop(txos, None)
-                    if self.callbacks["confirmed"].get(txid):
-                        # keep monitoring for conf > 0:
-                        self.active_txs[txid] = txd
+                    # we always add into active_txs, even if the caller
+                    # didn't create any confirmed callbacks, because we
+                    # need to trigger process_new_tx logic to update
+                    # the height of the utxo in UtxoManager
+                    self.active_txs[txid] = txd
                 elif confs > 0:
                     callbacks = [f for f in
                             self.callbacks["confirmed"].pop(txid, [])


### PR DESCRIPTION
Fixes #1212.
Before this commit, transactions were kept monitored in
WalletService.transaction_monitor after first being seen, only if the
list of confirmed callbacks was non empty, but this meant that the logic
is process_new_tx was not executed, meaning the height field of the utxo
was never updated from INF_HEIGHT, so the utxo would continue to be seen
as having zero confirmations, even after blocks are mined.
After this commit, we add any transaction that was seen to the
active_txs dict, so that the height field, and thus the number of
confirmations reported, is correct even if the caller never registered a
confirmed callback.