### PR TITLE
Don't start maker via RPC-API with frozen coins

### DIFF
--- a/jmclient/jmclient/wallet_rpc.py
+++ b/jmclient/jmclient/wallet_rpc.py
@@ -612,8 +612,9 @@ class JMWalletDaemon(Service):
                 # sync has already happened (this is different from CLI yg).
                 # note: an edge case of dusty amounts is lost here; it will get
                 # picked up by Maker.try_to_create_my_orders().
-                if not len(self.services["wallet"].get_balance_by_mixdepth(
-                    verbose=False, minconfs=1)) > 0:
+                gbbm = self.services["wallet"].get_balance_by_mixdepth(
+                    verbose=False, minconfs=1)
+                if len(gbbm) == 0 or all([v==0 for v in gbbm.values()]):
                     # note: this raise will prevent the setup
                     # of the service (and therefore the startup) from
                     # proceeding:


### PR DESCRIPTION
Fixes #1213.
Prior to this commit, if the YieldGeneratorService were started via a
call to /maker/start over the RPC-API, the early check of whether coins
were present in the wallet to allow starting the maker, incorrectly read
the contents of the dict returned by
jmclient.wallet.UTXOManager.get_balance_by_mixdepth, which returns
entries for mixdepths with coins which are all frozen, with a total
value of zero, even if the include_disabled keyword argument is set to
False. Thus only checking for whether the length of the returned dict
was zero was incorrect.
After this commit, we will stop early, as intended, for a wallet which
has no mixdepths with any non-frozen coins.