### PR TITLE
Taker stops cleanly if broadcast fails via RPC-API

### DIFF
--- a/jmclient/jmclient/wallet_rpc.py
+++ b/jmclient/jmclient/wallet_rpc.py
@@ -431,18 +431,11 @@ class JMWalletDaemon(Service):
         # It is also different in that the event loop must not shut down
         # when processing finishes.
 
-        # This assertion is making sure that the callback is not a non-final
-        # schedule entry (see the comment above as to why). We accept
-        # either False or 'unconfirmed' since they can arrive in either order.
-        assert fromtx is not True
-
         # reset our state on completion, we are no longer coinjoining:
         self.taker = None
 
         if not res:
             jlog.info("Coinjoin did not complete successfully.")
-        #Should usually be unreachable, unless conf received out of order;
-        #because we should stop on 'unconfirmed' for last (see above)
         else:
             jlog.info("Coinjoin completed correctly")
 


### PR DESCRIPTION
Fixes #1214.
Prior to this commit, if a broadcast of a transaction failed locally, or
failed after attempting remote broadcast then falling back to local via
the function jmclient.taker.Taker.handle_unbroadcast_transaction, then
the version of the on_finished_callback found in
jmclient.wallet_rpc.JMWalletDaemon incorrectly asserted that the fromtx
keyword argument must be True, thus failing to update the state of the
daemon to CJ_NOT_RUNNING.
After this commit that assertion is removed, and the coinjoin_in_process
value returned over the API is correctly False after either a
successful, or an unsuccessful, finishing of the coinjoin.