### PR TITLE
unused and missing vars in jmbitcoin tx code

### DIFF
--- a/jmbitcoin/jmbitcoin/secp256k1_transaction.py
+++ b/jmbitcoin/jmbitcoin/secp256k1_transaction.py
@@ -214,7 +214,6 @@ def mk_freeze_script(pub, locktime):
         raise TypeError("locktime must be int")
     if not isinstance(pub, bytes):
         raise TypeError("pubkey must be in bytes")
-    usehex = False
     if not is_valid_pubkey(pub, require_compressed=True):
         raise ValueError("not a valid public key")
     return CScript([locktime, OP_CHECKLOCKTIMEVERIFY, OP_DROP, pub,
@@ -227,7 +226,7 @@ def mk_burn_script(data):
     """
     if not isinstance(data, bytes):
         raise TypeError("data must be in bytes")
-    return CScript([btc.OP_RETURN, data])
+    return CScript([OP_RETURN, data])
 
 def sign(tx, i, priv, hashcode=SIGHASH_ALL, amount=None, native=False):
     """

--- a/jmbitcoin/test/test_tx_signing.py
+++ b/jmbitcoin/test/test_tx_signing.py
@@ -35,7 +35,6 @@ def test_sign_standard_txs(addrtype):
     amount_less_fee = int(amount - btc.coins_to_satoshi(0.01))
     
     # Create a destination to send the coins.
-    destination_address = address
     target_scriptPubKey = scriptPubKey
     
     # Create the unsigned transaction.


### PR DESCRIPTION
Just noticed these while reading the code for some reason or other.

The `btc.OP_RETURN` was presumably not fixed before because that code (burn addresses) is now entirely unused.

However, this should be in the tests somewhere. We are missing tests for a lot of the functions in `secp256k1_transaction`. A PR should be opened by someone at some point to add those.