### PR TITLE
feat: validate auth header in session request if provided

### DIFF
--- a/docs/api/wallet-rpc.yaml
+++ b/docs/api/wallet-rpc.yaml
@@ -105,12 +105,17 @@ paths:
           $ref: '#/components/responses/404-NotFound'
   /session:
     get:
+      security:
+        - {}
+        - bearerAuth: []
       summary: get current status of backend
       operationId: session
-      description: get whether a wallet is loaded and whether coinjoin/maker are happening.
+      description: get whether a wallet is loaded and whether coinjoin/maker are happening. if an auth token is provided, which is optional, it will be validated.
       responses:
         '200':
           $ref: "#/components/responses/Session-200-OK"
+        '401':
+          $ref: '#/components/responses/401-Unauthorized'
         '404':
           $ref: '#/components/responses/404-NotFound'
   /wallet/all:

--- a/jmclient/jmclient/wallet_rpc.py
+++ b/jmclient/jmclient/wallet_rpc.py
@@ -342,6 +342,11 @@ class JMWalletDaemon(Service):
             jlog.warn("Invalid cookie: " + str(
                 request_cookie) + ", request rejected.")
             raise NotAuthorized()
+    
+    def check_cookie_if_present(self, request):
+        auth_header = request.getHeader('Authorization')
+        if auth_header is not None:
+            self.check_cookie(request)
 
     def set_token(self, wallet_name):
         """ This function creates a new JWT token and sets it as our
@@ -502,6 +507,10 @@ class JMWalletDaemon(Service):
             to the client what the current status of the wallet
             and services is. TODO: add more data to send to client.
             """
+            #validate auth header if provided
+            #this lets caller know if cookie is invalid or outdated
+            self.check_cookie_if_present(request)
+
             #if no wallet loaded then clear frontend session info
             #when no wallet status is false
             session = not self.cookie==None


### PR DESCRIPTION
Closes #1244.

Before this PR, the `/session` endpoint ignores a potentially provided token in the `Authorization` header.
After this PR, the `/session` endpoint validates a token provided in the `Authorization` header and will respond with `401 Unauthorized` if the token is invalid.

See #1244 on why this might be beneficial for API users. Summary: It seems like a good alternative to polling an authenticated endpoint and a less error-prone solution than relying on websocket server closes.