### PR TITLE
Add RPC API endpoint for tumbler

### DIFF
--- a/docs/api/wallet-rpc.yaml
+++ b/docs/api/wallet-rpc.yaml
@@ -343,6 +343,61 @@ paths:
           $ref: '#/components/responses/409-NoConfig'
         '503':
           $ref: '#/components/responses/503-ServiceUnavailable'
+  /wallet/{walletname}/taker/schedule:
+    post:
+      security:
+        - bearerAuth: []
+      summary: create and run a schedule of transactions
+      operationId: runschedule
+      description: Creates and then starts a schedule of transactions.
+      parameters:
+        - name: walletname
+          in: path
+          description: name of wallet including .jmdat
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RunScheduleRequest'
+        description: taker side schedule parameters
+      responses:
+        '202':
+          $ref: "#/components/responses/RunSchedule-202-OK"
+        '400':
+          $ref: '#/components/responses/400-BadRequest'
+        '401':
+          $ref: '#/components/responses/401-Unauthorized'
+        '404':
+          $ref: '#/components/responses/404-NotFound'
+        '409':
+          $ref: '#/components/responses/409-NoConfig'
+        '503':
+          $ref: '#/components/responses/503-ServiceUnavailable'
+    get:
+      security:
+        - bearerAuth: []
+      summary: get the schedule that is currently running
+      operationId: getschedule
+      description: Get the current transaction schedule if one is running.
+      parameters:
+        - name: walletname
+          in: path
+          description: name of the wallet including .jmdat
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          $ref: "#/components/responses/GetSchedule-200-OK"
+        '400':
+          $ref: '#/components/responses/400-BadRequest'
+        '401':
+          $ref: "#/components/responses/401-Unauthorized"
+        '404':
+          $ref: '#/components/responses/404-NotFound'
   /wallet/{walletname}/taker/stop:
     get:
       security:
@@ -545,7 +600,16 @@ components:
         destination:
           type: string
           example: "bcrt1qujp2x2fv437493sm25gfjycns7d39exjnpptzw"
-            
+    RunScheduleRequest:
+      type: object
+      required:
+        - destinations
+      properties:
+        destinations:
+          type: array
+          items:
+            type: string
+            example: "bcrt1qujp2x2fv437493sm25gfjycns7d39exjnpptzw"
     StartMakerRequest:
       type: object
       required:
@@ -762,6 +826,17 @@ components:
       properties:
         seedphrase:
           type: string
+    GetScheduleResponse:
+      type: object
+      required:
+        - schedule
+      properties:
+        schedule:
+          type: array
+          items:
+            oneOf:
+              - type: string
+              - type: integer
     LockWalletResponse:
       type: object
       required:
@@ -902,6 +977,18 @@ components:
         application/json:
           schema:
             $ref: "#/components/schemas/FreezeResponse"
+    RunSchedule-202-OK:
+      description: "schedule started successfully"
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/GetScheduleResponse"
+    GetSchedule-200-OK:
+      description: "schedule retrieved successfully"
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/GetScheduleResponse"
     YieldGenReport-200-OK:
       description: "get list of coinjoins taken part in as maker (across all wallets)"
       content:


### PR DESCRIPTION
Adds an API endpoint for the tumbler as laid out by @dergigi in #1239:

```
/wallet/{walletname}/taker/schedule
```

- New endpoint which creates and executes a schedule, given multiple destination addresses (mimicking what the `tumbler.py` script does)
- Use default options as defined in the tumbler scripts CLI parser
- Provides a way for clients to retrieve and monitor progress

This can be seen as a minimal v1 of the tumbler API. Possible future updates would include: Restart support, fee estimation, support for custom schedules, etc.

We've discussed several options internally and also in #1239 and https://github.com/joinmarket-webui/joinmarket-webui/issues/179 but ended up going with the most simple, minimally invasive approach for now.

We haven't added test (yet) but could definitely do so if needed once we agreed on the approach.

Let us know what you think and if you have any feedback on the approach taken. 🙏 

---

Edit: We've tested the endpoint on regtest using the Jam Web UI and [this branch](https://github.com/joinmarket-webui/joinmarket-webui/compare/tumbler-test). Anyone interested feel free to give it a spin.