### PR TITLE
Change defaults for fidelity bond settings.

### DIFF
--- a/docs/fidelity-bonds.md
+++ b/docs/fidelity-bonds.md
@@ -45,8 +45,8 @@ high enough (or if you think the sybil protection is too expensive then set the 
 lower, as always its your choice as a taker in the market).
 
 Takers will still choose makers equally (i.e. without taking into account fidelity bonds) with a
-small probability. By default this probability is 12.5%, so approximately 1-in-8 makers. This can
-be changed in the config file with the option `bondless_makers_allowance`.
+small probability. By default this probability is currently 37.5%, so approximately 3-in-8 makers. This can
+be changed in the config file with the option `bondless_makers_allowance`. The default is likely to change (reduce) in future, depending on fidelity bond adoption (but again, *it can be changed by the user*!).
 
 The previous algorithm for choosing makers without regards to fidelity bonds can still be used by
 passing the relevant CLI option when running a script (for example
@@ -179,12 +179,14 @@ JoinMarket itself.
 A fidelity bond is valuable as soon as the transaction creating it becomes confirmed. The
 simplified formula for a fidelity bond's value is:
 
-    bond_value = (locked_coins * (exp(interest_rate * locktime) - 1))^2
+    bond_value = (locked_coins * (exp(interest_rate * locktime) - 1))^x
+
+Here `x` is the 'exponent', a number larger than 1, for reasons we explain below.
 
 A few important things to notice:
-* The bond value goes as the _square_ of sacrificed value. For example if your sacrificed value is
-5 BTC then the fidelity bond value is 25 (because 5 x 5 = 25). If instead you sacrificed 6 BTC the
-value is 36 (because 6 x 6 = 36). The point of this is to create an incentive for makers to lump
+* The bond value goes as the (locked_coins)^x of sacrificed value. For example if `x` is 1.3, the current default, and your sacrificed value is
+5 BTC then the fidelity bond value is \~ 8.1. If instead you sacrificed 6 BTC the
+value is \~ 10.3. The point of this is to create an incentive for makers to lump
 all their coins into just one bot rather than spreading it over many bots. It makes a sybil attack
 much more expensive.
 * The longer you lock for the greater the value. The value increases as the `interest_rate`, which
@@ -193,9 +195,9 @@ annum and because of tyranny-of-the-default takers are unlikely to change it. Th
 not too far from the "real" interest rate, and the system still works fine even if the real rate
 is something like 3% or 0.1%.
 * The above formula would suggest that if you lock 3 BTC for 10000 years you get a fidelity
-bond worth `1.7481837557171304e+131` (17 followed by 130 zeros). This does not happen because the
+bond worth `2.03e+85` (\~ 2 followed by 85 zeros). This does not happen because the
 sacrificed value is capped at the value of the burned coins. So in this example the fidelity bond
-value would be just 9 (equal to 3x3 or 3 squared). This feature is not included in the above
+value would be just \~ 4.17. This feature is not included in the above
 simplified equation.
 * After the locktime expires and the coins are free to move, the fidelity bond will continue to be
 valuable, but its value will exponentially drop following the interest rate. So it would be good
@@ -210,8 +212,8 @@ At any time you can use the orderbook watcher script to see your own fidelity bo
 
 Consider also the [warning on the bitcoin wiki page on timelocks](https://en.bitcoin.it/wiki/Timelock#Far-future_locks).
 
-I would recommend locking as many bitcoins as you are comfortable with for a period of between 6
-months and 2 years. Perhaps at the very start lock for only 1 month or 2 months(?) It's a
+I would recommend locking as many bitcoins as you are comfortable with for a period of between 3
+months and 1 years. Perhaps at the very start lock for only 1 month or 2 months(?) It's a
 marketplace and the rules are known to all, so ultimately you'll have to make your own decision.
 
 ### Can my yield-generator use multiple timelocked addresses or UTXO?

--- a/jmclient/jmclient/configure.py
+++ b/jmclient/jmclient/configure.py
@@ -94,7 +94,7 @@ required_options = {'BLOCKCHAIN': ['blockchain_source', 'network'],
 
 _DEFAULT_INTEREST_RATE = "0.015"
 
-_DEFAULT_BONDLESS_MAKERS_ALLOWANCE = "0.125"
+_DEFAULT_BONDLESS_MAKERS_ALLOWANCE = "0.375"
 
 defaultconfig = \
     """
@@ -385,6 +385,11 @@ interest_rate = """ + _DEFAULT_INTEREST_RATE + """
 # This parameter sets how many makers on average will be chosen regardless of bonds
 # A real number, i.e. 1 = 100%, 0.125 = 1/8 = 1 in every 8 makers on average will be bondless
 bondless_makers_allowance = """ + _DEFAULT_BONDLESS_MAKERS_ALLOWANCE + """
+
+# To (strongly) disincentivize Sybil behaviour, the value assessment of the bond
+# is based on the (time value of the bond)^x where x is the bond_value_exponent here,
+# where x > 1. It is a real number (so written as a decimal).
+bond_value_exponent = 1.3
 
 ##############################
 # THE FOLLOWING SETTINGS ARE REQUIRED TO DEFEND AGAINST SNOOPERS.

--- a/jmclient/jmclient/wallet.py
+++ b/jmclient/jmclient/wallet.py
@@ -2557,7 +2557,8 @@ class FidelityBondMixin(object):
         t = current_time / YEAR
 
         a = max(0, min(1, exp(r*T) - 1) - min(1, exp(r*max(0, t-L)) - 1))
-        return utxo_value*utxo_value*a*a
+        exponent = float(jm_single().config.get("POLICY", "bond_value_exponent"))
+        return pow(utxo_value*a, exponent)
 
     @classmethod
     def get_validated_timelocked_fidelity_bond_utxo(cls, utxo, utxo_pubkey, locktime,


### PR DESCRIPTION
Closes #1247.
This consists of a change to the default value of
bondless_makers_allowance, an inclusion of the bond value exponent into
the config that the user can alter, and a change to the default of that
value from 2 (implicit by quadratic) to 1.3.
Also updates the fidelity bond documentation to account for those
changes.