### PR TITLE
User instructed to install from release

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,19 +30,20 @@ For a quick introduction to Joinmarket you can watch [this demonstration](https:
 
 ### Quickstart - RECOMMENDED INSTALLATION METHOD (Linux and macOS only)
 
-Once you've downloaded this repo, either as a tar/zip file, and extracted it, or via `git clone`:
+Download the latest [release](https://github.com/Joinmarket-Org/joinmarket-clientserver/releases) as tar or zip, and extract it.
 
-Make sure to validate the signature on the tar/zip file provided on the [release page](https://github.com/Joinmarket-Org/joinmarket-clientserver/releases),
-or check the signature in git if you install that way using `git log --show-signature`.
+Make sure to validate the signature on the tar/zip file provided with the [release](https://github.com/Joinmarket-Org/joinmarket-clientserver/releases) (or check the signature in git if you install that way using `git log --show-signature`).
 
-**macOS users**: Make sure that you have Homebrew and Apple's Command Line Tools installed.
+(**macOS users**: Make sure that you have Homebrew and Apple's Command Line Tools installed.)
 
     ./install.sh
-    (follow instructions on screen; provide sudo password when prompted)
+
+(There are options you can apply to the installation - see `./install.sh -?`. But the defaults should work.)
+
+Follow instructions on screen; provide sudo password when prompted, then when finished:
+
     source jmvenv/bin/activate
     cd scripts
-
-(You can add `--develop` as an extra flag to `install.sh` to make the Joinmarket code editable in-place.)
 
 You can optionally install a Qt GUI application, you will be prompted to choose this during installation.
 


### PR DESCRIPTION
Proposed as an alternative to #1257 (although it is not attempt to do exactly the same thing, it's an attempt to fix the same issue, kind of!).

So a couple of points:

* No need to give instructions on cloning the repo; for the people that want to do that, they are devs/tech people and already know how. For users that's just confusing.
* Point to the generic releases link for obvious reasons.
* Not yet explicitly mentioning `--with-local-tor` but mentioning that options exist for install.sh. I believe that as part of the release of 0.9.6, after which users need to have Tor installed, we explicitly add this to the README, and to USAGE.md at least (would be nice to have a tor.md also but not strictly necessary).

