### PR TITLE
Increase max line length in OnionProtocol to 40kB

### DIFF
--- a/jmdaemon/jmdaemon/onionmc.py
+++ b/jmdaemon/jmdaemon/onionmc.py
@@ -154,6 +154,13 @@ class OnionCustomMessage(object):
         return cls(text, msgtype)
 
 class OnionLineProtocol(basic.LineReceiver):
+    # there are messages requiring more than LineReceiver's 16KB,
+    # specifically, large coinjoin transaction `pushtx` messages.
+    # 40K is finger in the air for: 500bytes per participant, 40
+    # participants, and a double base64 expansion (x1.33 and x1.33)
+    # which gives 35.5K, add a little breathing room.
+    MAX_LENGTH = 40000
+
     def connectionMade(self):
         self.factory.register_connection(self)
         basic.LineReceiver.connectionMade(self)


### PR DESCRIPTION
Fixes #1259.
This is done to support envisaged experimentation with significantly
larger counterparty counts than the current usually 10-12 maximum. IRC
notionally supports very large messages because we split messages into
chunks, but realistically, throttling usually causes
timeouts/interruptions if we try to use extremely large amounts of text.
In Joinmarket's communication protocol, the only time we need very large
messages is specifically to allow transfer of fully signed transactions
that need to be pushed to the bitcoin network. (See JMPushTx). So this
bump to the maximum allowable line length is specifically to support
that message, in case people want to try coinjoins with 20-40
participants. The comment indicates an extremely rough guesstimate of
maximum supported counterparty count based on this limit.
Note that users can always just broadcast the final tx themselves, of
course.