### PR TITLE
Display the account xpub in QT interface

### DIFF
--- a/jmclient/jmclient/__init__.py
+++ b/jmclient/jmclient/__init__.py
@@ -21,7 +21,8 @@ from .wallet import (Mnemonic, estimate_tx_fee, WalletError, BaseWallet, ImportW
 from .storage import (Argon2Hash, Storage, StorageError, RetryableStorageError,
                       StoragePasswordError, VolatileStorage)
 from .cryptoengine import (BTCEngine, BTC_P2PKH, BTC_P2SH_P2WPKH, BTC_P2WPKH, EngineError,
-                           TYPE_P2PKH, TYPE_P2SH_P2WPKH, TYPE_P2WPKH, detect_script_type)
+                           TYPE_P2PKH, TYPE_P2SH_P2WPKH, TYPE_P2WPKH, detect_script_type,
+                           is_extended_public_key)
 from .configure import (load_test_config, process_shutdown,
     load_program_config, jm_single, get_network, update_persist_config,
     validate_address, is_burn_destination, get_mchannels,

--- a/jmclient/jmclient/cryptoengine.py
+++ b/jmclient/jmclient/cryptoengine.py
@@ -23,6 +23,11 @@ NET_MAP = {'mainnet': NET_MAINNET, 'testnet': NET_TESTNET,
 WIF_PREFIX_MAP = {'mainnet': b'\x80', 'testnet': b'\xef', 'signet': b'\xef'}
 BIP44_COIN_MAP = {'mainnet': 2**31, 'testnet': 2**31 + 1, 'signet': 2**31 + 1}
 
+BIP32_PUB_PREFIX = "xpub"
+BIP49_PUB_PREFIX = "ypub"
+BIP84_PUB_PREFIX = "zpub"
+TESTNET_PUB_PREFIX = "tpub"
+
 def detect_script_type(script_str):
     """ Given a scriptPubKey, decide which engine
     to use, one of: p2pkh, p2sh-p2wpkh, p2wpkh.
@@ -49,6 +54,12 @@ def detect_script_type(script_str):
         return TYPE_P2WSH
     raise EngineError("Unknown script type for script '{}'"
                       .format(bintohex(script_str)))
+
+
+def is_extended_public_key(key_str):
+    return any([key_str.startswith(prefix) for prefix in [
+        BIP32_PUB_PREFIX, BIP49_PUB_PREFIX, BIP84_PUB_PREFIX, TESTNET_PUB_PREFIX]])
+
 
 class classproperty(object):
     """


### PR DESCRIPTION
The account xpub is available when you run `python wallet-tool.py wallet.jmdat`, but it's not available in the QT interface.

This PR shows the account xpub in the QT interface as well so that users can also access it from joinmarket-qt.