### PR TITLE
docs: link to latest version of start-dn.py script

### DIFF
--- a/docs/onion-message-channels.md
+++ b/docs/onion-message-channels.md
@@ -158,7 +158,7 @@ who would like to help by running a directory node. You can ignore it if that do
 This requires a long running bot. It should be on a server you can keep running permanently, so perhaps a VPS,
 but in any case, very high uptime. For reliability it also makes sense to configure to run as a systemd service.
 
-The currently suggested way to run a directory node is to use the script found [here](https://github.com/JoinMarket-Org/custom-scripts/blob/0eda6154265e012b907c43e2ecdacb895aa9e3ab/start-dn.py); you can place it in your `joinmarket-clientserver/scripts` directory and run it *without* arguments, but with one option flag: `--datadir=/your/chosen/datadir` (as you'll see below).
+The currently suggested way to run a directory node is to use the [`start-dn.py` script](https://github.com/JoinMarket-Org/custom-scripts/blob/master/start-dn.py); you can place it in your `joinmarket-clientserver/scripts` directory and run it *without* arguments, but with one option flag: `--datadir=/your/chosen/datadir` (as you'll see below).
 
 This slightly unobvious approach is based on the following ideas: we run a Joinmarket script, with a Joinmarket python virtualenv, so that we are able to parse messages; this means that the directory node *can* be a bot, e.g. a maker bot, but need not be - and here it is basically a "crippled" maker bot that cannot do anything. This 'crippling' is actually very useful because (a) we use the `no-blockchain` argument (it is forced in-code; you don't need to set it) so we don't need a running Bitcoin node (of whatever flavour), and (b) we don't need a wallet either.
 


### PR DESCRIPTION
As the title says, it changes the link in file `docs/onion-message-channels.md` to latest version of `start-dn.py` script.

Script has been updated in the meantime. Is it a good idea to link to the head of branch `add-directory-node`?
Also mentioned the script's name in the link again for someone doing full-text search.