### PR TITLE
Track txs which are unconf at process startup

### DIFF
--- a/jmclient/jmclient/wallet_service.py
+++ b/jmclient/jmclient/wallet_service.py
@@ -860,6 +860,14 @@ class WalletService(Service):
         script = hextobin(utxo['scriptPubKey'])
         value = int(Decimal(str(utxo['amount'])) * Decimal('1e8'))
         self.add_utxo(txid, int(utxo['vout']), script, value, height)
+        # if we start up with unconfirmed outputs, they must be
+        # put into the transaction monitor state, so we can recognize
+        # when they transition to confirmed.
+        if height is None:
+            txd = self.bci.get_deser_from_gettransaction(
+                self.bci.get_transaction(txid))
+            self.active_txs[utxo['txid']] = txd
+            self.processed_txids.add(utxo['txid'])
 
 
     """ The following functions mostly are not pure


### PR DESCRIPTION
Before this commit, if Joinmarket-Qt or any other long running script
was started when a new utxo had been created in the wallet, but was not
yet in a block, the transition from unconfirmed to confirmed state would
not be registered, because when confirmation happened and the event was
seen in the transaction monitor, that txid was not in the active_txs
dict. This is now fixed.