### PR TITLE
Change verbosity of on_nick_leave_directory log message from info to debug

### DIFF
--- a/jmdaemon/jmdaemon/onionmc.py
+++ b/jmdaemon/jmdaemon/onionmc.py
@@ -1074,8 +1074,8 @@ class OnionMessageChannel(MessageChannel):
         if not nick in self.active_directories:
             return
         if not dir_peer in self.active_directories[nick]:
-            log.info("Directory {} is telling us that {} has left, but we "
-                     "didn't know about them. Ignoring.".format(
+            log.debug("Directory {} is telling us that {} has left, but we "
+                      "didn't know about them. Ignoring.".format(
                          dir_peer.peer_location(), nick))
             return
         log.debug("Directory {} has lost connection to: {}".format(


### PR DESCRIPTION
As discussed in Telegram. This message does not seem to be too important.