### PR TITLE
Default 3rd argument of gettxout should be True

### DIFF
--- a/jmclient/jmclient/maker.py
+++ b/jmclient/jmclient/maker.py
@@ -82,7 +82,7 @@ class Maker(object):
         #finally, check that the proffered utxo is real, old enough, large enough,
         #and corresponds to the pubkey
         res = jm_single().bc_interface.query_utxo_set([cr_dict['utxo']],
-                                                      includeconf=True)
+                                                      includeconfs=True)
         if len(res) != 1 or not res[0]:
             reason = "authorizing utxo is not valid"
             return reject(reason)

--- a/jmclient/jmclient/wallet.py
+++ b/jmclient/jmclient/wallet.py
@@ -2564,7 +2564,7 @@ class FidelityBondMixin(object):
     def get_validated_timelocked_fidelity_bond_utxo(cls, utxo, utxo_pubkey, locktime,
             cert_expiry, current_block_height):
 
-        utxo_data = jm_single().bc_interface.query_utxo_set(utxo, includeconf=True)
+        utxo_data = jm_single().bc_interface.query_utxo_set(utxo, includeconfs=True)
         if utxo_data[0] == None:
             return None
         if utxo_data[0]["confirms"] <= 0:

--- a/jmclient/test/commontest.py
+++ b/jmclient/test/commontest.py
@@ -72,7 +72,7 @@ class DummyBlockchainInterface(BlockchainInterface):
     def reset_confs(self):
         self.confs_for_qus = {}
 
-    def query_utxo_set(self, txouts, includeconf=False):
+    def query_utxo_set(self, txouts, includeconfs=False):
         if self.qusfail:
             #simulate failure to find the utxo
             return [None]
@@ -97,8 +97,8 @@ class DummyBlockchainInterface(BlockchainInterface):
                        'fd9711a2ef340750db21efb761f5f7d665d94b312332dc354e252c77e9c48349:0': [50000000, 6]}
         wallet_outs = dictchanger(wallet_outs)
         
-        if includeconf and set(txouts).issubset(set(wallet_outs)):
-            #includeconf used as a trigger for a podle check;
+        if includeconfs and set(txouts).issubset(set(wallet_outs)):
+            #includeconfs used as a trigger for a podle check;
             #here we simulate a variety of amount/age returns
             results = []
             for to in txouts:
@@ -116,7 +116,7 @@ class DummyBlockchainInterface(BlockchainInterface):
             result_dict = {'value': 200000000,
                            'address': "mrcNu71ztWjAQA6ww9kHiW3zBWSQidHXTQ",
                            'script': hextobin('76a91479b000887626b294a914501a4cd226b58b23598388ac')}
-            if includeconf:
+            if includeconfs:
                 if t in self.confs_for_qus:
                     confs = self.confs_for_qus[t]
                 else:

--- a/jmclient/test/test_wallets.py
+++ b/jmclient/test/test_wallets.py
@@ -44,10 +44,10 @@ def test_query_utxo_set(setup_wallets):
     txid2 = do_tx(wallet_service, 20000000)
     print("Got txs: ", txid, txid2)
     res1 = jm_single().bc_interface.query_utxo_set(
-        (txid, 0), includeunconf=True)
+        (txid, 0), include_mempool=True)
     res2 = jm_single().bc_interface.query_utxo_set(
         [(txid, 0), (txid2, 1)],
-        includeconf=True, includeunconf=True)
+        includeconfs=True, include_mempool=True)
     assert len(res1) == 1
     assert len(res2) == 2
     assert all([x in res1[0] for x in ['script', 'value']])


### PR DESCRIPTION
Fixes #1294.
Before this commit, calls to query_utxo_set with default arguments
would ignore the mempool and thus return utxos which were spent in
unconfirmed transactions. Thus, takers would continue negotiation of
coinjoins with makers who sent them already-spent utxos, leading to
failure at broadcast time. This was not intended behaviour; we want
takers to reject utxos that are double spent in the mempool.
This commit changes that default argument to True so that utxo set
changes in the mempool are accounted for. All current calls to this
function use the default value of the includeunconf argument.