### PR TITLE
[WIP] Add separate documentation for Tor configuration

### DIFF
--- a/docs/PAYJOIN.md
+++ b/docs/PAYJOIN.md
@@ -227,7 +227,7 @@ bump the fee enough to add one input to the transaction, and this should be fine
 
 #### Using Joinmarket-wallet-to-Joinmarket-wallet payjoins
 
-This is now deprecated; if you still want to use it, use Joinmarket(-clientserver) version 0.7.0 or lower, and see the corresponding older version of this document.
+This can be done with the same [BIP78](https://github.com/bitcoin/bips/blob/master/bip-0078.mediawiki) workflow described above; the "old style" internal Joinmarket payjoins from 2019 are now deprecated.
 
 <a name="fees" />
 
@@ -329,50 +329,9 @@ it means of course the other case. Double check with your counterparty, somethin
 
 <a name="torconfig" />
 
-#### Configuring Tor to setup a hidden service
+#### Configuring Tor to setup an onion service
 
-(These steps were prepared using Ubuntu; you may have to adjust for your distro).
-
-First, ensure you have Tor installed:
-
-```
-sudo apt install tor
-```
-
-Don't start the tor daemon yet though, since we need to do some setup. Edit Tor's config file with sudo:
-
-```
-sudo vim /etc/tor/torrc
-```
-
-and uncomment these two lines to enable hidden service startup:
-
-```
-ControlPort 9051
-CookieAuthentication 1
-```
-
-However if you proceed at this point to try to run `receive-payjoin.py` as outlined above, you will almost certainly get an error like this:
-
-```
-Permission denied: '/var/run/tor/control.authcookie'
-```
-
-... because reading this file requires being a member of the group `debian-tor`. So add your user to this group:
-
-```
-sudo usermod -a -G debian-tor yourusername
-```
-
-... and then you must *restart the computer/server* for that change to take effect (check it with `groups yourusername`).
-
-Finally, after system restart, ensure Tor is started (it may be automatically, but anyway):
-
-```
-sudo service tor start
-```
-
- Once this is done, you should be able to run the BIP 78 receiver script, or [JoinmarketQt](#using-qt) and a hidden service will be automatically created for you from now on.
+Read about how to do this [here](./tor.md).
 
 <a name="using-qt" />
 

--- a/docs/onion-message-channels.md
+++ b/docs/onion-message-channels.md
@@ -24,11 +24,7 @@ albeit it was and remains E2E encrypted data, in either case)
 
 ### Tor
 
-As of Joinmarket 0.9.6, which introduces this feature, **Tor is now a requirement to run Joinmarket** (except in testing, which will not be explained here).
-
-(Technically, we could argue that this is not a new requirement - because the use of Payjoin already required the need to run such onion services, and connecting to IRC used a SOCKS5 proxy (used by almost all users) over Tor to a remote onion service.)
-
-If you don't currently have a Tor daemon running on your machine you can use the flag `--with-local-tor` appended to your invocation of `./install.sh` as per the installation instructions in the README.
+As of Joinmarket 0.9.6, which introduces this feature, **Tor is now a requirement to run Joinmarket** (except in testing, which will not be explained here). See [here](./tor.md) for more information about this).
 
 (Note however that taker bots will *not* be required to serve onions; they will only make outbound SOCKS connections, as they currently do on IRC).
 

--- a/docs/tor.md
+++ b/docs/tor.md
@@ -1,0 +1,84 @@
+### How to use Tor with Joinmarket
+
+(You've installed using the `install.sh` or similar as per instructions in the README before
+reading this).
+
+This document gives short notes on any necessary configuration steps for using Joinmarket as a Maker or a Taker, in coinjoins.
+The requirements for Takers are lesser.
+
+### Contents
+
+1. [Checking Tor is installed](#torinstall)
+
+2. [Using Tor as a Taker](#tortaker)
+
+3. [Using Tor as a Maker](#tormaker)
+
+   a. [Configuring Tor to setup an onion service](#torconfig)
+
+<a name="torinstall">
+
+### Checking Tor is installed
+
+(Insert sanity check advice for system `tor`.)
+
+If you don't currently have a Tor daemon running on your machine you can use the flag `--with-local-tor` appended to your invocation of `./install.sh` as per the installation instructions in the README.
+
+<a name="tortaker">
+
+### Using Tor as a Taker
+
+Insert basic instructions on checking Tor is functional and SOCKS port.
+
+<a name="toraaker>
+
+### Using Tor as a Maker
+
+Insert explanation of why Maker is different, before going on to:
+
+<a name="torconfig" />
+
+#### Configuring Tor to setup an onion service
+
+(These steps were prepared using Ubuntu; you may have to adjust for your distro).
+
+First, ensure you have Tor installed:
+
+```
+sudo apt install tor
+```
+
+Don't start the tor daemon yet though, since we need to do some setup. Edit Tor's config file with sudo:
+
+```
+sudo vim /etc/tor/torrc
+```
+
+and uncomment these two lines to enable onion service startup:
+
+```
+ControlPort 9051
+CookieAuthentication 1
+```
+
+However if you proceed at this point to try to start your yieldgenerator with `python yg-privacyenhanced.py wallet.jmdat` or similar, you will almost certainly get an error like this:
+
+```
+Permission denied: '/var/run/tor/control.authcookie'
+```
+
+... because reading this file requires being a member of the group `debian-tor`. So add your user to this group:
+
+```
+sudo usermod -a -G debian-tor yourusername
+```
+
+... and then you must *restart the computer/server* (or maybe just logout, login) for that change to take effect (check it with `groups yourusername`).
+
+Finally, after system restart, ensure Tor is started (it may be automatically, but anyway):
+
+```
+sudo service tor start
+```
+
+Once this is done, you should be able to start the yieldgenerator successfully.


### PR DESCRIPTION
Fixes #1277.
Adds a separate document tor.md detailing installation and configuration
requirements for both Makers and Takers, in particular details how to
configure for the serving of an ephemeral onion service.