### PR TITLE
ob-watcher: tackle stale orders by first removing all of them

### DIFF
--- a/scripts/obwatch/ob-watcher.py
+++ b/scripts/obwatch/ob-watcher.py
@@ -684,6 +684,9 @@ class OrderbookPageRequestHeader(http.server.SimpleHTTPRequestHandler):
         if self.path not in pages:
             return
         if self.path == '/refreshorderbook':
+            with self.taker.dblock:
+                self.taker.db.execute("DELETE FROM orderbook;")
+                self.taker.db.execute("DELETE FROM fidelitybonds;")
             self.taker.msgchan.request_orderbook()
             time.sleep(5)
             self.path = '/'
@@ -768,7 +771,6 @@ def on_privmsg(inst, nick, message):
         except:
             pass
 
-        
 def get_dummy_nick():
     """In Joinmarket-CS nick creation is negotiated
     between client and server/daemon so as to allow


### PR DESCRIPTION
When checking for timed-out counterparties (or refreshing the orderbook), stale entries are preserved because those peers disconnected prematurely leading to the watcher being unable to remove the (now stale) entry.

This fix prevents that issue by first removing all orderbook and fidelity bond entries before refreshing the orderbook.