### PR TITLE
rpc-api: scheduler status flag in session

### DIFF
--- a/docs/api/wallet-rpc.yaml
+++ b/docs/api/wallet-rpc.yaml
@@ -713,6 +713,7 @@ components:
         - session
         - maker_running
         - coinjoin_in_process
+        - coinjoin_is_part_of_schedule
         - wallet_name
       properties:
         session:
@@ -720,6 +721,8 @@ components:
         maker_running:
           type: boolean
         coinjoin_in_process:
+          type: boolean
+        coinjoin_is_part_of_schedule:
           type: boolean
         wallet_name:
           type: string

--- a/docs/api/wallet-rpc.yaml
+++ b/docs/api/wallet-rpc.yaml
@@ -724,9 +724,11 @@ components:
         schedule:
           type: array
           items:
-            oneOf:
-              - type: string
-              - type: integer
+            type: array
+            items:
+              oneOf:
+                - type: string
+                - type: integer
         wallet_name:
           type: string
           example: wallet.jmdat
@@ -905,9 +907,11 @@ components:
         schedule:
           type: array
           items:
-            oneOf:
-              - type: string
-              - type: integer
+            type: array
+            items:
+              oneOf:
+                - type: string
+                - type: integer
     LockWalletResponse:
       type: object
       required:

--- a/docs/api/wallet-rpc.yaml
+++ b/docs/api/wallet-rpc.yaml
@@ -713,7 +713,6 @@ components:
         - session
         - maker_running
         - coinjoin_in_process
-        - coinjoin_is_part_of_schedule
         - wallet_name
       properties:
         session:
@@ -722,8 +721,12 @@ components:
           type: boolean
         coinjoin_in_process:
           type: boolean
-        coinjoin_is_part_of_schedule:
-          type: boolean
+        schedule:
+          type: array
+          items:
+            oneOf:
+              - type: string
+              - type: integer
         wallet_name:
           type: string
           example: wallet.jmdat

--- a/jmclient/jmclient/wallet_rpc.py
+++ b/jmclient/jmclient/wallet_rpc.py
@@ -580,18 +580,26 @@ class JMWalletDaemon(Service):
             session = not self.cookie==None
             maker_running = self.coinjoin_state == CJ_MAKER_RUNNING
             coinjoin_in_process = self.coinjoin_state == CJ_TAKER_RUNNING
-            coinjoin_is_part_of_schedule = self.coinjoin_state == CJ_TAKER_RUNNING and self.tumbler_options is not None
+            schedule = None
+
             if self.services["wallet"]:
                 if self.services["wallet"].isRunning():
                     wallet_name = self.wallet_name
+                    if self.coinjoin_state == CJ_TAKER_RUNNING and self.tumbler_options is not None:
+                        logsdir = os.path.join(os.path.dirname(jm_single().config_location), "logs")
+                        sfile = os.path.join(logsdir, self.tumbler_options['schedulefile'])
+                        res, schedule = get_schedule(sfile)
+                        if not res:
+                            schedule = None
                 else:
                     wallet_name = "not yet loaded"
             else:
                 wallet_name = "None"
+
             return make_jmwalletd_response(request,session=session,
                             maker_running=maker_running,
                             coinjoin_in_process=coinjoin_in_process,
-                            coinjoin_is_part_of_schedule=coinjoin_is_part_of_schedule,
+                            schedule=schedule,
                             wallet_name=wallet_name)
 
         @app.route('/wallet/<string:walletname>/taker/direct-send', methods=['POST'])

--- a/jmclient/jmclient/wallet_rpc.py
+++ b/jmclient/jmclient/wallet_rpc.py
@@ -586,10 +586,16 @@ class JMWalletDaemon(Service):
                 if self.services["wallet"].isRunning():
                     wallet_name = self.wallet_name
                     if self.coinjoin_state == CJ_TAKER_RUNNING and self.tumbler_options is not None:
-                        logsdir = os.path.join(os.path.dirname(jm_single().config_location), "logs")
-                        sfile = os.path.join(logsdir, self.tumbler_options['schedulefile'])
-                        res, schedule = get_schedule(sfile)
-                        if not res:
+                        auth_header = request.getHeader('Authorization')
+                        if auth_header is not None:
+                            # At this point if an `auth_header` is present, it has been checked
+                            # by the call to `check_cookie_if_present` above.
+                            logsdir = os.path.join(os.path.dirname(jm_single().config_location), "logs")
+                            sfile = os.path.join(logsdir, self.tumbler_options['schedulefile'])
+                            res, schedule = get_schedule(sfile)
+                            if not res:
+                                schedule = None
+                        else:
                             schedule = None
                 else:
                     wallet_name = "not yet loaded"

--- a/jmclient/jmclient/wallet_rpc.py
+++ b/jmclient/jmclient/wallet_rpc.py
@@ -592,8 +592,6 @@ class JMWalletDaemon(Service):
                             # by the call to `check_cookie_if_present` above.
                             if self.taker is not None and not self.taker.aborted:
                                 schedule = self.taker.schedule
-                        else:
-                            schedule = None
                 else:
                     wallet_name = "not yet loaded"
             else:

--- a/jmclient/jmclient/wallet_rpc.py
+++ b/jmclient/jmclient/wallet_rpc.py
@@ -580,6 +580,7 @@ class JMWalletDaemon(Service):
             session = not self.cookie==None
             maker_running = self.coinjoin_state == CJ_MAKER_RUNNING
             coinjoin_in_process = self.coinjoin_state == CJ_TAKER_RUNNING
+            coinjoin_is_part_of_schedule = self.coinjoin_state == CJ_TAKER_RUNNING and self.tumbler_options is not None
             if self.services["wallet"]:
                 if self.services["wallet"].isRunning():
                     wallet_name = self.wallet_name
@@ -590,6 +591,7 @@ class JMWalletDaemon(Service):
             return make_jmwalletd_response(request,session=session,
                             maker_running=maker_running,
                             coinjoin_in_process=coinjoin_in_process,
+                            coinjoin_is_part_of_schedule=coinjoin_is_part_of_schedule,
                             wallet_name=wallet_name)
 
         @app.route('/wallet/<string:walletname>/taker/direct-send', methods=['POST'])
@@ -1102,7 +1104,7 @@ class JMWalletDaemon(Service):
             self.check_cookie(request)
 
             if self.coinjoin_state is not CJ_NOT_RUNNING or self.tumbler_options is not None:
-                # Tumbler or taker seems to be running already.
+                # Tumbler, taker, or maker seems to be running already.
                 return make_jmwalletd_response(request, status=409)
 
             if not self.services["wallet"]:

--- a/jmclient/jmclient/wallet_rpc.py
+++ b/jmclient/jmclient/wallet_rpc.py
@@ -590,11 +590,8 @@ class JMWalletDaemon(Service):
                         if auth_header is not None:
                             # At this point if an `auth_header` is present, it has been checked
                             # by the call to `check_cookie_if_present` above.
-                            logsdir = os.path.join(os.path.dirname(jm_single().config_location), "logs")
-                            sfile = os.path.join(logsdir, self.tumbler_options['schedulefile'])
-                            res, schedule = get_schedule(sfile)
-                            if not res:
-                                schedule = None
+                            if self.taker is not None and not self.taker.aborted:
+                                schedule = self.taker.schedule
                         else:
                             schedule = None
                 else:


### PR DESCRIPTION
This adds an additional status flag to the `/session` endpoint that allows consumers of the API to differentiate whether a currently running coinjoin is part of a schedule of coinjoins or if it is a "single coinjoin".

## Behavior

**Single CJ:**

- `coinjoin_in_process`: `true`
- `coinjoin_is_part_of_schedule`: `false`

**Schedule of CJs:**

- `coinjoin_in_process`: `true`
- `coinjoin_is_part_of_schedule`: `true`

## Reasoning

I'm aware that fundamentally there's no difference between a CJ that's part of a schedule or a single CJ. They're both just  instantiating the `Taker` who takes care of the appropriate logic.
Still for no other reasons than UI, it can be important to be able to differentiate the two on the client side.
In Jam, for example, we have one flow that takes care of running a schedule of transactions and another for making single collaborative transactions (aka "single CJs").
While a schedule is running, we'd like to indicate that in the UI in a way so that the user knows that the current transaction is not just a single CJ.
That's were a flag like this comes in handy.
We could of course try to retrieve the schedule via `GET /taker/schedule` and depending on the response determine if a schedule is setup to run. But this would be a rather clumsy approach.

## Implementation

I decided to keep the semantics of the existing `coinjoin_in_process` intact and add an additional flag that further qualifies whether the CJ is part of a larger schedule of CJs.
Another way to do this would've been to introduce two distinct flags: one `single_coinjoin_in_process` and the other `schedule_in_process`. But this would have suggested that there are different types of CJs which is not really true as discussed above. Also, it would've technically been a breaking change. Therefore, I decided to go with the slightly less obvious, but probably more correct way.

Let me know what you think! Any feedback welcome. If we could get that in, it would help us a lot making the UI for Jam more intuitive.