### PR TITLE
Ensure OnionDirectoryPeerNotFound is raised

### DIFF
--- a/jmdaemon/jmdaemon/onionmc.py
+++ b/jmdaemon/jmdaemon/onionmc.py
@@ -1012,7 +1012,10 @@ class OnionMessageChannel(MessageChannel):
         adn = self.active_directories[nick]
         if len(adn) == 0:
             raise OnionDirectoryPeerNotFound
-        return random.choice([x for x in list(adn) if adn[x] is True])
+        candidates = [x for x in list(adn) if adn[x] is True]
+        if len(candidates) == 0:
+            raise OnionDirectoryPeerNotFound
+        return random.choice(candidates)
 
     def forward_pubmsg_to_peers(self, msg: str, from_nick: str) -> None:
         """ Used by directory nodes currently. Takes a received


### PR DESCRIPTION
Fixes #1306.
Prior to this commit, it was possible (unlikely) for a peer to exist in
the active_directories nick in OnionMessageChannel, but to have False
entries (i.e. disconnected) for every directory, meaning that the random
choice from those directories raised an Exception which was not caught,
causing a crash.
This is now fixed by checking whether the list of directories to be
chosen from randomly, is empty, and if so raising the correct Exception
type, namely OnionDirectoryPeerNotFound.