### PR TITLE
fix: enable addr status in regtest

### DIFF
--- a/jmclient/jmclient/wallet_utils.py
+++ b/jmclient/jmclient/wallet_utils.py
@@ -10,10 +10,12 @@ from numbers import Integral
 from collections import Counter
 from itertools import islice, chain
 from jmclient import (get_network, WALLET_IMPLEMENTATIONS, Storage, podle,
-    jm_single, BitcoinCoreInterface, WalletError, BaseWallet,
-    VolatileStorage, StoragePasswordError, is_segwit_mode, SegwitLegacyWallet,
-    LegacyWallet, SegwitWallet, FidelityBondMixin, FidelityBondWatchonlyWallet,
+    jm_single, WalletError, BaseWallet, VolatileStorage,
+    StoragePasswordError, is_segwit_mode, SegwitLegacyWallet, LegacyWallet,
+    SegwitWallet, FidelityBondMixin, FidelityBondWatchonlyWallet,
     is_native_segwit_mode, load_program_config, add_base_options, check_regtest)
+from jmclient.blockchaininterface import (BitcoinCoreInterface,
+    BitcoinCoreNoHistoryInterface)
 from jmclient.wallet_service import WalletService
 from jmbase.support import (get_password, jmprint, EXIT_FAILURE,
                             EXIT_ARGERROR, utxo_to_utxostr, hextobin, bintohex,
@@ -506,7 +508,7 @@ def wallet_display(wallet_service, showprivkey, displayall=False,
             #the function should either be removed or added to bci
             #or possibly add some kind of `gettransaction` function
             # to bci
-            if jm_single().bc_interface.__class__ == BitcoinCoreInterface:
+            if not isinstance(jm_single().bc_interface, BitcoinCoreNoHistoryInterface):
                 is_coinjoin, cj_amount, cj_n = \
                     get_tx_info(utxo[0])[:3]
                 if is_coinjoin and utxodata['value'] == cj_amount:

--- a/jmclient/test/test_wallet_rpc.py
+++ b/jmclient/test/test_wallet_rpc.py
@@ -340,7 +340,7 @@ class TrialTestWRPC_DisplayWallet(WalletRPCTestBase, unittest.TestCase):
         # and the direct-send tx above:
         assert wia[0]["branches"][0]["entries"][0]["label"] == "test-wallet-rpc-label"
         assert wia[0]["branches"][0]["entries"][0]["hd_path"] == "m/84'/1'/0'/0/0"
-        assert wia[1]["branches"][0]["entries"][1]["status"] == "used"
+        assert wia[1]["branches"][0]["entries"][1]["status"] == "deposit"
         assert wia[1]["branches"][0]["entries"][1]["extradata"] == ""
         # currently this test only produces output with available_balance = balance,
         # at every level in the tree (no freeze here), but could add TODO


### PR DESCRIPTION
Before this commit, address states like "cj-out", "change-out", "non-cj-change" and "deposit" where only available when using `bitcoin-rpc` as chain source.
After this commit, states will be available for `bitcoin-rpc` _and_ `regtest` (but not for `bitcoin-rpc-no-history`).

Tested only in regtest.
~~The TODO comment has been slightly adapted but kept, as it is still valid.~~