### PR TITLE
Allow `bitcoin:` prefix for addresses with `sendpayment.py`

### DIFF
--- a/scripts/sendpayment.py
+++ b/scripts/sendpayment.py
@@ -96,6 +96,12 @@ def main():
                 sweeping = True
             destaddr = args[2]
         mixdepth = options.mixdepth
+        if btc.is_bip21_uri(args[2]):
+            parsed = btc.decode_bip21_uri(args[2])
+            if 'amount' in parsed:
+                parser.error("Specify amount as a separate argument or amount in BIP21 URI, not both.")
+                sys.exit(EXIT_ARGERROR)
+            destaddr = parsed['address']
         addr_valid, errormsg = validate_address(destaddr)
         command_to_burn = (is_burn_destination(destaddr) and sweeping and
             options.makercount == 0)


### PR DESCRIPTION
Before this change there were two ways of using `sendpayment.py` - you could either specify amount as a first argument and destination address as a second argument or just provide BIP21 URI. This allows to also specify amount as a first argument and BIP21 URI as a second argument, unless it contains amount. Useful, because a lots of wallets (in my case it was Blue Wallet) will give you BIP21 URI instead of pure Bitcoin address when using "Receive" even if you don't specify amount. And when you double click that URI, it will select all of it, not just address. So, basically, this allows to just paste adress with `bitcoin:` prefix too. Was already possible with Qt GUI after BIP21 / BIP78 payjoin functionality was added.