### PR TITLE
Bump local Tor to latest version (0.4.7.8)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -381,9 +381,9 @@ tor_build ()
 
 tor_install ()
 {
-    tor_version='tor-0.4.6.10'
+    tor_version='tor-0.4.7.8'
     tor_tar="${tor_version}.tar.gz"
-    tor_sha='94ccd60e04e558f33be73032bc84ea241660f92f58cfb88789bda6893739e31c'
+    tor_sha='9e9a5c67ad2acdd5f0f8be14ed591fed076b1708abf8344066990a0fa66fe195'
     tor_url='https://dist.torproject.org'
 
     if ! dep_get "${tor_tar}" "${tor_sha}" "${tor_url}"; then


### PR DESCRIPTION
1) It is recommended upgrade, contains several bugfixes. See [ChangeLog](https://gitweb.torproject.org/tor.git/plain/ChangeLog?h=tor-0.4.7.8).

2) With 0.4.6.10 and shellcheck 0.8.0 installed on local machine, got this build error (which is fixed in 0.4.7.8):
```
./scripts/maint/checkShellScripts.sh
/usr/bin/shellcheck
/usr/bin/realpath
Unusual pattern permitted.h in ./scripts/maint/practracker/testdata

In /home/user/git/joinmarket-clientserver/deps/tor-0.4.6.10/src/test/test_rust.sh line 6:
export LSAN_OPTIONS=suppressions=${abs_top_srcdir:-../../..}/src/test/rust_supp.txt
                                 ^-------------------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
export LSAN_OPTIONS=suppressions="${abs_top_srcdir:-../../..}"/src/test/rust_supp.txt

gmake[2]: Entering directory '/home/user/git/joinmarket-clientserver/deps/tor-0.4.6.10'
SKIP: src/test/test_keygen.sh
SKIP: src/test/fuzz_static_testcases.sh
SKIP: src/test/test_key_expiration.sh
SKIP: src/test/test_zero_length_keys.sh
For more information:
  https://www.shellcheck.net/wiki/SC2086 -- Double quote to prevent globbing ...
gmake[1]: *** [Makefile:24755: shellcheck] Error 1
gmake[1]: *** Waiting for unfinished jobs....
...
gmake: *** [Makefile:22315: check-am] Error 2
Building local Tor was requested, but not built. Exiting.
```