### PR TITLE
Report offerlist in /session call if possible

### DIFF
--- a/docs/api/wallet-rpc.yaml
+++ b/docs/api/wallet-rpc.yaml
@@ -749,6 +749,8 @@ components:
                 type: integer
               cjfee:
                 type: string
+        nickname:
+          type: string
     ListUtxosResponse:
       type: object
       properties:

--- a/docs/api/wallet-rpc.yaml
+++ b/docs/api/wallet-rpc.yaml
@@ -732,6 +732,23 @@ components:
         wallet_name:
           type: string
           example: wallet.jmdat
+        offer_list:
+          type: array
+          items:
+            type: object
+            properties:
+              oid:
+                type: integer
+              ordertype:
+                type: string
+              minsize:
+                type: integer
+              maxsize:
+                type: integer
+              txfee:
+                type: integer
+              cjfee:
+                type: string
     ListUtxosResponse:
       type: object
       properties:


### PR DESCRIPTION
This partially addresses #1326. If the maker service is running,
we return the offerlist in the /session API call, as suggested there.