### PR TITLE
fix(ob-watcher): consistent orderbook.json response

### DIFF
--- a/scripts/obwatch/ob-watcher.py
+++ b/scripts/obwatch/ob-watcher.py
@@ -210,11 +210,9 @@ class OrderbookPageRequestHeader(http.server.SimpleHTTPRequestHandler):
         with self.taker.dblock:
             rows = self.taker.db.execute('SELECT * FROM orderbook;').fetchall()
             fbonds = self.taker.db.execute("SELECT * FROM fidelitybonds;").fetchall()
-        if not rows or not fbonds:
-            return []
 
         fidelitybonds = []
-        if jm_single().bc_interface != None:
+        if fbonds and jm_single().bc_interface != None:
             (fidelity_bond_data, fidelity_bond_values, bond_outpoint_conf_times) =\
                 get_fidelity_bond_data(self.taker)
             fidelity_bond_values_dict = dict([(bond_data.maker_nick, bond_value)


### PR DESCRIPTION
Closes #1327.

Before this commit the `orderbook.json` response was inconsistent depending on which data is present (see #1327 for details).
After the commit, the response data has a consistent format.

This is only an issue when no fidelity bonds are present and hence mostly concerning non-`mainnet` networks, especially `regtest`.

#### on empty orderbook
##### before
```
$ curl localhost:62601/orderbook.json
[]
```

##### after
```
$ curl localhost:62601/orderbook.json
{"offers": [], "fidelitybonds": []}
```

#### offers present, no fidelity bonds
##### before
```
$ curl localhost:62601/orderbook.json
[]
```

##### after
```
$ curl localhost:62601/orderbook.json
{"offers": [{"counterparty": "J52crzXFM4o8Jyum", "oid": 0, "ordertype": "sw0absoffer", "minsize": 27300, "maxsize": 23
7499972700, "txfee": 0, "cjfee": 250, "fidelity_bond_value": 0}], "fidelitybonds": []}
```