### PR TITLE
Don't disallow the stallMonitor in RPC tumbler

### DIFF
--- a/jmclient/jmclient/wallet_rpc.py
+++ b/jmclient/jmclient/wallet_rpc.py
@@ -1247,8 +1247,6 @@ class JMWalletDaemon(Service):
                                tdestaddrs=destaddrs)
             self.clientfactory = self.get_client_factory()
 
-            self.taker.testflag = True
-
             dhost, dport = self.check_daemon_ready()
 
             _, self.coinjoin_connection = start_reactor(dhost,


### PR DESCRIPTION
Prior to this commit, the 'testflag' was set for the Taker object that was created in running the tumbler via the RPC API. This flag prevents the function client_protocol.JMTakerClientProtocol.stallMonitor from running (which is useful in certain cases), which was not intended. After this commit, this flag is not set, so that when a transaction fails to go through, the stallMonitor will wake up after some time and retry the transaction, as should occur.