### PR TITLE
Allow to run `install.sh` from any current working directory

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+cd "$(dirname "$0")"
+
 check_exists() {
     command -v "$1" > /dev/null
 }


### PR DESCRIPTION
Person [porting JoinMarket guide from RaspiBolt v2 to RaspiBolt v3](https://github.com/raspibolt/raspibolt/pull/1085) tried to do `./joinmarket/install.sh` instead of `cd joinmarket; ./install.sh`, but that ends in GPG validation error, because third-party pubkeys are imported using relative paths. Don't see the reason why not allow to run `install.sh` from any cwd.