### PR TITLE
Update link to RaspiBolt installation guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Alternative to this "quickstart": follow the [install guide](docs/INSTALL.md).
 * [Installation on Windows](docs/INSTALL.md#installation-on-windows).
 * [Installation with Docker](docs/INSTALL.md#docker-installation)
 * [Installation guide for RaspiBlitz](https://github.com/openoms/bitcoin-tutorials/blob/master/joinmarket/README.md).
-* [Installation guide for RaspiBolt](https://github.com/kristapsk/raspibolt-extras/blob/master/joinmarket.md).
+* [Installation guide for RaspiBolt](https://raspibolt.org/guide/bonus/bitcoin/joinmarket.html).
 * [Installation guide for Qubes+Whonix](https://github.com/qubenix/qubes-whonix-bitcoin/blob/master/1_joinmarket.md).
 * [Youtube video installation tutorial for Ubuntu](https://www.youtube.com/watch?v=zTCC86IUzWo).
 


### PR DESCRIPTION
Installation instructions for RaspiBolt v3 is now integrated into main guide.