### PR TITLE
Allow amounts below `DUST_THRESHOLD` (0.00027300 BTC) for non-cj direct sends

### DIFF
--- a/scripts/joinmarket-qt.py
+++ b/scripts/joinmarket-qt.py
@@ -834,7 +834,7 @@ class SpendTab(QWidget):
 
         # for coinjoin sends no point to send below dust threshold, likely
         # there will be no makers for such amount.
-        if amount != 0 and not self.checkAmount(amount):
+        if amount != 0 and makercount > 0 and not self.checkAmount(amount):
             return
 
         if makercount < jm_single().config.getint(

--- a/scripts/sendpayment.py
+++ b/scripts/sendpayment.py
@@ -111,7 +111,7 @@ def main():
                 jmprint("The required options for burning coins are zero makers"
                     + " (-N 0), sweeping (amount = 0) and not using BIP78 Payjoin", "info")
             sys.exit(EXIT_ARGERROR)
-        if sweeping == False and amount < jm_single().DUST_THRESHOLD:
+        if sweeping == False and options.makercount > 0 and amount < jm_single().DUST_THRESHOLD:
             jmprint('ERROR: Amount ' + btc.amount_to_str(amount) +
                 ' is below dust threshold ' +
                 btc.amount_to_str(jm_single().DUST_THRESHOLD) + '.', "error")


### PR DESCRIPTION
Don't see the reason why to enforce this lowest amount limit for non-collaborative transactions.

Note that lower amount sends were already allowed when doing sweeping.