### PR TITLE
test: Bump pytest version to 6.2.5

### DIFF
--- a/requirements/testing.txt
+++ b/requirements/testing.txt
@@ -3,7 +3,7 @@
 # numpy
 pexpect
 coverage==5.2.1
-pytest==5.3.5
+pytest==6.2.5
 pytest-cov>=2.4.0,<2.6
 python-coveralls
 mock


### PR DESCRIPTION
Got this error when trying to run tests under Python 3.10:
```
...
Successfully installed joinmarketbase-0.9.9.dev0 joinmarketbitcoin-0.9.9.dev0 joinmarketclient-0.9.9.dev0 joinmarketdaemon-0.9.9.dev0
Traceback (most recent call last):
  File "/usr/lib/python3.10/runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/lib/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "/home/user/git/joinmarket-clientserver/jmvenv/lib/python3.10/site-packages/pytest/__main__.py", line 7, in <module>
    raise SystemExit(pytest.main())
  File "/home/user/git/joinmarket-clientserver/jmvenv/lib/python3.10/site-packages/_pytest/config/__init__.py", line 73, in main
    config = _prepareconfig(args, plugins)
  File "/home/user/git/joinmarket-clientserver/jmvenv/lib/python3.10/site-packages/_pytest/config/__init__.py", line 223, in _prepareconfig
    return pluginmanager.hook.pytest_cmdline_parse(
  File "/home/user/git/joinmarket-clientserver/jmvenv/lib/python3.10/site-packages/pluggy/hooks.py", line 286, in __call__
    return self._hookexec(self, self.get_hookimpls(), kwargs)
  File "/home/user/git/joinmarket-clientserver/jmvenv/lib/python3.10/site-packages/pluggy/manager.py", line 93, in _hookexec
    return self._inner_hookexec(hook, methods, kwargs)
  File "/home/user/git/joinmarket-clientserver/jmvenv/lib/python3.10/site-packages/pluggy/manager.py", line 84, in <lambda>
    self._inner_hookexec = lambda hook, methods, kwargs: hook.multicall(
  File "/home/user/git/joinmarket-clientserver/jmvenv/lib/python3.10/site-packages/pluggy/callers.py", line 203, in _multicall
    gen.send(outcome)
  File "/home/user/git/joinmarket-clientserver/jmvenv/lib/python3.10/site-packages/_pytest/helpconfig.py", line 89, in pytest_cmdline_parse
    config = outcome.get_result()
  File "/home/user/git/joinmarket-clientserver/jmvenv/lib/python3.10/site-packages/pluggy/callers.py", line 80, in get_result
    raise ex[1].with_traceback(ex[2])
  File "/home/user/git/joinmarket-clientserver/jmvenv/lib/python3.10/site-packages/pluggy/callers.py", line 187, in _multicall
    res = hook_impl.function(*args)
  File "/home/user/git/joinmarket-clientserver/jmvenv/lib/python3.10/site-packages/_pytest/config/__init__.py", line 794, in pytest_cmdline_parse
    self.parse(args)
  File "/home/user/git/joinmarket-clientserver/jmvenv/lib/python3.10/site-packages/_pytest/config/__init__.py", line 1000, in parse
    self._preparse(args, addopts=addopts)
  File "/home/user/git/joinmarket-clientserver/jmvenv/lib/python3.10/site-packages/_pytest/config/__init__.py", line 948, in _preparse
    self.pluginmanager.load_setuptools_entrypoints("pytest11")
  File "/home/user/git/joinmarket-clientserver/jmvenv/lib/python3.10/site-packages/pluggy/manager.py", line 299, in load_setuptools_entrypoints
    plugin = ep.load()
  File "/usr/lib/python3.10/importlib/metadata/__init__.py", line 171, in load
    module = import_module(match.group('module'))
  File "/usr/lib/python3.10/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1050, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
  File "<frozen importlib._bootstrap>", line 992, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "<frozen importlib._bootstrap>", line 1050, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1006, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 688, in _load_unlocked
  File "/home/user/git/joinmarket-clientserver/jmvenv/lib/python3.10/site-packages/_pytest/assertion/rewrite.py", line 134, in exec_module
    source_stat, co = _rewrite_test(fn, self.config)
  File "/home/user/git/joinmarket-clientserver/jmvenv/lib/python3.10/site-packages/_pytest/assertion/rewrite.py", line 321, in _rewrite_test
    co = compile(tree, fn, "exec", dont_inherit=True)
```

Solution is to upgrade pytest to 6.2.5, see https://github.com/pytest-dev/pytest/discussions/9195. There are also more recent 7.x releases for pytest, but they require at least Python 3.7 (we still officially support Python 3.6).