### PR TITLE
Change payjoin default binding port

### DIFF
--- a/docs/PAYJOIN.md
+++ b/docs/PAYJOIN.md
@@ -174,7 +174,7 @@ Before you do such coinjoins, you may want to:
 
 ```
 [PAYJOIN]
-# for the majority of situations, the defaults
+# For the majority of situations, the defaults
 # need not be altered - they will ensure you don't pay
 # a significantly higher fee.
 # MODIFICATION OF THESE SETTINGS IS DISADVISED.
@@ -182,7 +182,7 @@ Before you do such coinjoins, you may want to:
 # Payjoin protocol version; currently only '1' is supported.
 payjoin_version = 1
 
-# servers can change their destination address by default (0).
+# Servers can change their destination address by default (0).
 # if '1', they cannot. Note that servers can explicitly request
 # that this is activated, in which case we respect that choice.
 disable_output_substitution = 0
@@ -198,19 +198,30 @@ disable_output_substitution = 0
 # to that of our change output, unless there is none in which case this is disabled.
 max_additional_fee_contribution = default
 
-# this is the minimum satoshis per vbyte we allow in the payjoin
+# This is the minimum sats/vbyte we allow in the payjoin
 # transaction; note it is decimal, not integer.
 min_fee_rate = 1.1
 
-# for payjoin onion service creation, the tor control configuration:
-tor_control_host = localhost
-# or, to use a UNIX socket
-# control_host = unix:/var/run/tor/control
-tor_control_port = 9051
-
-# for payjoins to hidden service endpoints, the socks5 configuration:
+# For payjoins as sender (i.e. client) to hidden service endpoints,
+# the socks5 configuration:
 onion_socks5_host = localhost
 onion_socks5_port = 9050
+
+# For payjoin onion service creation:
+# the tor control configuration:
+tor_control_host = localhost
+
+# or, to use a UNIX socket
+# control_host = unix:/var/run/tor/control
+# note: port needs to be provided (but is ignored for UNIX socket)
+tor_control_port = 9051
+
+# the host/port actually serving the hidden service
+# (note the *virtual port*, that the client uses,
+# is hardcoded to 80):
+onion_serving_host = 127.0.0.1
+onion_serving_port = 8082
+
 # in some exceptional case the HS may be SSL configured,
 # this feature is not yet implemented in code, but here for the
 # future:

--- a/jmclient/jmclient/configure.py
+++ b/jmclient/jmclient/configure.py
@@ -477,7 +477,7 @@ tor_control_port = 9051
 # (note the *virtual port*, that the client uses,
 # is hardcoded to 80):
 onion_serving_host = 127.0.0.1
-onion_serving_port = 8080
+onion_serving_port = 8082
 
 # in some exceptional case the HS may be SSL configured,
 # this feature is not yet implemented in code, but here for the

--- a/test/payjoinclient.py
+++ b/test/payjoinclient.py
@@ -38,7 +38,7 @@ if __name__ == "__main__":
             pjurl = "http://" + serverport
     else:
         # hardcoded port for tests:
-        pjurl = "https://127.0.0.1:8080"
+        pjurl = "https://127.0.0.1:8082"
     bip21uri = "bitcoin:2N7CAdEUjJW9tUHiPhDkmL9ukPtcukJMoxK?amount=0.3&pj=" + pjurl
 
     wallet_path = get_wallet_path(wallet_name, None)

--- a/test/payjoinserver.py
+++ b/test/payjoinserver.py
@@ -84,8 +84,8 @@ def test_start_payjoin_server(setup_payjoin_server):
     else:
         # TODO for now, just sticking with TLS test as non-encrypted
         # is unlikely to be used, but add that option.
-        reactor.listenSSL(8080, site, contextFactory=get_ssl_context())
-        #endpoint = endpoints.TCP4ServerEndpoint(reactor, 8080)
+        reactor.listenSSL(8082, site, contextFactory=get_ssl_context())
+        #endpoint = endpoints.TCP4ServerEndpoint(reactor, 8082)
         #endpoint.listen(site)
     reactor.run()
 


### PR DESCRIPTION
https://github.com/JoinMarket-Org/joinmarket-clientserver/issues/1371

Payjoin port was chosen because it is less used, so changes affecting default port will possibly be rare.

Also changed payjoin tests port for uniformity.

And included the updated config to docs/PAYJOIN.md