### PR TITLE
Log IRC connection attempts when using SOCKS5 proxy or TLS too

### DIFF
--- a/jmdaemon/jmdaemon/irc.py
+++ b/jmdaemon/jmdaemon/irc.py
@@ -151,10 +151,14 @@ class IRCMessageChannel(MessageChannel):
             ctx = ClientContextFactory()
         if self.usessl.lower() == 'true' and not self.socks5.lower() == 'true':
             factory = TxIRCFactory(self)
+            wlog('build_irc: ', self.serverport[0], str(self.serverport[1]),
+                self.channel)
             reactor.connectSSL(self.serverport[0], self.serverport[1],
                                factory, ctx)
         elif self.socks5.lower() == 'true':
             factory = TxIRCFactory(self)
+            wlog('build_irc: ', self.serverport[0], str(self.serverport[1]),
+                self.channel, str(self.socks5_host), self.socks5_port)
             #str() casts needed else unicode error
             torEndpoint = TCP4ClientEndpoint(reactor, str(self.socks5_host),
                                              self.socks5_port)


### PR DESCRIPTION
Only attempts with `use_ssl = false` and `socks5 = false` were logged before this change.