### PR TITLE
Use `jm_single().config.getboolean()` instead of string comparisons

### DIFF
--- a/jmclient/jmclient/client_protocol.py
+++ b/jmclient/jmclient/client_protocol.py
@@ -202,7 +202,7 @@ class SNICKERClientProtocol(BaseClientProtocol):
         """
         # always check whether the service is still intended to
         # be active, before starting the polling actions:
-        if jm_single().config.get("SNICKER", "enabled") != "true":
+        if not jm_single().config.getboolean("SNICKER", "enabled"):
             self.shutdown()
             return
         d = self.callRemote(commands.SNICKERReceiverGetProposals)
@@ -821,7 +821,7 @@ def start_reactor(host, port, factory=None, snickerfactory=None,
     serverconn = None
     clientconn = None
 
-    usessl = jm_single().config.get("DAEMON", "use_ssl") != 'false'
+    usessl = jm_single().config.getboolean("DAEMON", "use_ssl")
     jmcport, snickerport, bip78port = [port]*3
     if daemon:
         try:

--- a/jmclient/jmclient/payjoin.py
+++ b/jmclient/jmclient/payjoin.py
@@ -510,10 +510,8 @@ def make_payjoin_request_params(manager):
     disable_output_substitution = "false"
     if manager.disable_output_substitution:
         disable_output_substitution = "true"
-    else:
-        if jm_single().config.getint("PAYJOIN",
-                            "disable_output_substitution") == 1:
-            disable_output_substitution = "true"
+    elif jm_single().config.getboolean("PAYJOIN", "disable_output_substitution"):
+        disable_output_substitution = "true"
     params["disableoutputsubstitution"] = disable_output_substitution
 
     # to determine the additionalfeeoutputindex in cases where we have
@@ -557,7 +555,7 @@ def send_payjoin(manager, accept_callback=None,
         process_payjoin_proposal_from_server, process_error_from_server)
     h = jm_single().config.get("DAEMON", "daemon_host")
     p = jm_single().config.getint("DAEMON", "daemon_port")-2000
-    if jm_single().config.get("DAEMON", "use_ssl") != 'false':
+    if jm_single().config.getboolean("DAEMON", "use_ssl"):
         reactor.connectSSL(h, p, factory, ClientContextFactory())
     else:
         reactor.connectTCP(h, p, factory)
@@ -984,7 +982,7 @@ class JMBIP78ReceiverManager(object):
                 mode="receiver")
         h = jm_single().config.get("DAEMON", "daemon_host")
         p = jm_single().config.getint("DAEMON", "daemon_port")-2000
-        if jm_single().config.get("DAEMON", "use_ssl") != 'false':
+        if jm_single().config.getboolean("DAEMON", "use_ssl"):
             reactor.connectSSL(h, p, factory, ClientContextFactory())
         else:
             reactor.connectTCP(h, p, factory)

--- a/jmclient/jmclient/yieldgenerator.py
+++ b/jmclient/jmclient/yieldgenerator.py
@@ -466,7 +466,7 @@ def ygmain(ygclass, nickserv_password='', gaplimit=6):
          txfee_contribution_factor, cjfee_factor, size_factor])
     jlog.info('starting yield generator')
     clientfactory = JMClientProtocolFactory(maker, proto_type="MAKER")
-    if jm_single().config.get("SNICKER", "enabled") == "true":
+    if jm_single().config.getboolean("SNICKER", "enabled"):
         if jm_single().config.get("BLOCKCHAIN", "network") == "mainnet":
             jlog.error("You have enabled SNICKER on mainnet, this is not "
                        "yet supported for yieldgenerators; either use "
@@ -478,8 +478,7 @@ def ygmain(ygclass, nickserv_password='', gaplimit=6):
         snicker_factory = SNICKERClientProtocolFactory(snicker_r, servers)
     else:
         snicker_factory = None
-    nodaemon = jm_single().config.getint("DAEMON", "no_daemon")
-    daemon = True if nodaemon == 1 else False
+    daemon = not jm_single().config.getboolean("DAEMON", "no_daemon")
     if jm_single().config.get("BLOCKCHAIN", "network") in ["regtest", "testnet", "signet"]:
         startLogging(sys.stdout)
     start_reactor(jm_single().config.get("DAEMON", "daemon_host"),

--- a/scripts/jmwalletd.py
+++ b/scripts/jmwalletd.py
@@ -37,8 +37,7 @@ def jmwalletd_main():
     jlog.info("Starting jmwalletd on port: " + str(options.port))
     jm_wallet_daemon = JMWalletDaemon(options.port, options.wss_port)
     jm_wallet_daemon.startService()
-    nodaemon = jm_single().config.getint("DAEMON", "no_daemon")
-    daemon = True if nodaemon == 1 else False
+    daemon = not jm_single().config.getboolean("DAEMON", "no_daemon")
     start_reactor(jm_single().config.get("DAEMON", "daemon_host"),
                   jm_single().config.getint("DAEMON", "daemon_port"),
                   None, daemon=daemon)

--- a/scripts/joinmarket-qt.py
+++ b/scripts/joinmarket-qt.py
@@ -810,8 +810,7 @@ class SpendTab(QWidget):
                     mainWindow.wallet_service, mixdepth, "joinmarket-qt")
             # start BIP78 AMP protocol if not yet up:
             if not self.bip78_daemon_started:
-                daemon = jm_single().config.getint("DAEMON", "no_daemon")
-                daemon = True if daemon == 1 else False
+                daemon = not jm_single().config.getboolean("DAEMON", "no_daemon")
                 start_reactor(jm_single().config.get("DAEMON", "daemon_host"),
                        jm_single().config.getint("DAEMON", "daemon_port"),
                        bip78=True, jm_coinjoin=False,
@@ -911,8 +910,7 @@ class SpendTab(QWidget):
             #First run means we need to start: create clientfactory
             #and start reactor connections
             self.clientfactory = JMClientProtocolFactory(self.taker)
-            daemon = jm_single().config.getint("DAEMON", "no_daemon")
-            daemon = True if daemon == 1 else False
+            daemon = not jm_single().config.getboolean("DAEMON", "no_daemon")
             start_reactor(jm_single().config.get("DAEMON", "daemon_host"),
                    jm_single().config.getint("DAEMON", "daemon_port"),
                    self.clientfactory,
@@ -1752,8 +1750,8 @@ class JMMainWindow(QMainWindow):
             #First run means we need to start: create daemon;
             # the client and its connection are created in the .initiate()
             # call.
-            daemon = jm_single().config.getint("DAEMON", "no_daemon")
-            if daemon:
+            no_daemon = jm_single().config.getboolean("DAEMON", "no_daemon")
+            if no_daemon:
                 # this call not needed if daemon is external.
                 start_reactor(jm_single().config.get("DAEMON", "daemon_host"),
                        jm_single().config.getint("DAEMON", "daemon_port"),

--- a/scripts/qtsupport.py
+++ b/scripts/qtsupport.py
@@ -47,7 +47,6 @@ using a Bitcoin Core node instead."""}
 
 #configuration types
 config_types = {'rpc_port': int,
-                'network': bool,
                 'checktx': bool,
                 'socks5_port': int,
                 'maker_timeout_sec': int,
@@ -56,7 +55,7 @@ config_types = {'rpc_port': int,
                 'check_high_fee': int,
                 'max_mix_depth': int,
                 'order_wait_time': int,
-                'no_daemon': int,
+                'no_daemon': bool,
                 'daemon_port': int,
                 'absurd_fee_per_kb': 'amount'}
 config_tips = {

--- a/scripts/receive-payjoin.py
+++ b/scripts/receive-payjoin.py
@@ -73,8 +73,7 @@ def receive_payjoin_main():
     receiver_manager = JMBIP78ReceiverManager(wallet_service, options.mixdepth,
                                     bip78_amount, options.hsport)
     reactor.callWhenRunning(receiver_manager.initiate)
-    nodaemon = jm_single().config.getint("DAEMON", "no_daemon")
-    daemon = True if nodaemon == 1 else False
+    daemon = not jm_single().config.getboolean("DAEMON", "no_daemon")
     dhost = jm_single().config.get("DAEMON", "daemon_host")
     dport = jm_single().config.getint("DAEMON", "daemon_port")
     # JM is default, so must be switched off explicitly in this call:

--- a/scripts/sendpayment.py
+++ b/scripts/sendpayment.py
@@ -345,8 +345,7 @@ def main():
                 log.info("All transactions completed correctly")
             reactor.stop()
 
-    nodaemon = jm_single().config.getint("DAEMON", "no_daemon")
-    daemon = True if nodaemon == 1 else False
+    daemon = not jm_single().config.getboolean("DAEMON", "no_daemon")
     dhost = jm_single().config.get("DAEMON", "daemon_host")
     dport = jm_single().config.getint("DAEMON", "daemon_port")
     if bip78url:

--- a/scripts/snicker/create-snicker-proposal.py
+++ b/scripts/snicker/create-snicker-proposal.py
@@ -168,8 +168,7 @@ def main():
         jmprint(encrypted_proposal.decode("utf-8"))
         sys.exit(EXIT_SUCCESS)
 
-    nodaemon = jm_single().config.getint("DAEMON", "no_daemon")
-    daemon = True if nodaemon == 1 else False
+    daemon = not jm_single().config.getboolean("DAEMON", "no_daemon")
     snicker_client = SNICKERPostingClient([encrypted_proposal])
     servers = jm_single().config.get("SNICKER", "servers").split(",")
     snicker_pf = SNICKERClientProtocolFactory(snicker_client, servers)

--- a/scripts/snicker/receive-snicker.py
+++ b/scripts/snicker/receive-snicker.py
@@ -72,8 +72,7 @@ Usage: %prog [options] wallet file [proposal]
         wallet_service.sync_wallet(fast=not options.recoversync)
     wallet_service.startService()
 
-    nodaemon = jm_single().config.getint("DAEMON", "no_daemon")
-    daemon = True if nodaemon == 1 else False
+    daemon = not jm_single().config.getboolean("DAEMON", "no_daemon")
     snicker_r = SNICKERReceiver(wallet_service)
     if options.no_upload:
         proposal = args[1]

--- a/scripts/tumbler.py
+++ b/scripts/tumbler.py
@@ -189,8 +189,7 @@ def main():
                   callbacks=(filter_orders_callback, None, taker_finished),
                   tdestaddrs=destaddrs)
     clientfactory = JMClientProtocolFactory(taker)
-    nodaemon = jm_single().config.getint("DAEMON", "no_daemon")
-    daemon = True if nodaemon == 1 else False
+    daemon = not jm_single().config.getboolean("DAEMON", "no_daemon")
     if jm_single().config.get("BLOCKCHAIN", "network") == "regtest":
         startLogging(sys.stdout)
     start_reactor(jm_single().config.get("DAEMON", "daemon_host"),

--- a/test/ygrunner.py
+++ b/test/ygrunner.py
@@ -190,14 +190,13 @@ def test_start_ygs(setup_ygrunner, num_ygs, wallet_structures, fb_indices,
         if malicious:
             yg.set_maliciousness(malicious, mtype="tx")
         clientfactory = JMClientProtocolFactory(yg, proto_type="MAKER")
-        if jm_single().config.get("SNICKER", "enabled") == "true":
+        if jm_single().config.getboolean("SNICKER", "enabled"):
             snicker_r = SNICKERReceiver(wallet_service_yg)
             servers = jm_single().config.get("SNICKER", "servers").split(",")
             snicker_factory = SNICKERClientProtocolFactory(snicker_r, servers)
         else:
             snicker_factory = None
-        nodaemon = jm_single().config.getint("DAEMON", "no_daemon")
-        daemon = True if nodaemon == 1 else False
+        daemon = not jm_single().config.getboolean("DAEMON", "no_daemon")
         rs = True if i == num_ygs - 1 else False
         start_reactor(jm_single().config.get("DAEMON", "daemon_host"),
                       jm_single().config.getint("DAEMON", "daemon_port"),


### PR DESCRIPTION
Makes parsing of all boolean configs consistent.

From [configparser docs](https://docs.python.org/3/library/configparser.html#configparser.ConfigParser.getboolean):
> accepted values for the option are `'1'`, `'yes'`, `'true'`, and `'on'`, which cause this method to return `True`, and `'0'`, `'no'`, `'false'`, and `'off'`, which cause it to return `False`.