### PR TITLE
Change any dir handshake fail msg from error to warning

### DIFF
--- a/jmdaemon/jmdaemon/onionmc.py
+++ b/jmdaemon/jmdaemon/onionmc.py
@@ -1443,8 +1443,8 @@ class OnionMessageChannel(MessageChannel):
         if len(self.get_connected_directory_peers()) == 0:
             # at least one handshake must have succeeded, for us
             # to continue.
-            log.error("We failed to connect and handshake with "
-                      "ANY directories; onion messaging is not functioning.")
+            log.warning("We failed to connect and handshake with "
+                        "ANY directories; onion messaging is not functioning.")
             self.wait_for_directories_loop.stop()
             return
         # This is what triggers the start of taker/maker workflows.


### PR DESCRIPTION
It's not a fatal error, as JM continues to run, retries and succeeds later.
```
[ERROR]  We failed to connect and handshake with ANY directories; onion messaging is not functioning.
[INFO]  JM daemon setup complete
[WARNING]  We failed to connect to directory 3kxw6lf5vf6y26emzwgibzhrzhmhqiw6ekrek3nqfjjmhwznb2moonad.onion:5222; trying again.
[WARNING]  We failed to connect to directory bqlpq6ak24mwvuixixitift4yu42nxchlilrcqwk2ugn45tdclg42qid.onion:5222; trying again.
[WARNING]  We failed to connect to directory jmdirjmioywe2s5jad7ts6kgcqg66rj6wujj6q77n6wbdrgocqwexzid.onion:5222; trying again.
[INFO]  Updating status to connected for peer bqlpq6ak24mwvuixixitift4yu42nxchlilrcqwk2ugn45tdclg42qid.onion:5222.
```