### PR TITLE
Update local Tor to 0.4.7.12

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -417,9 +417,9 @@ tor_build ()
 
 tor_install ()
 {
-    tor_version='tor-0.4.7.8'
+    tor_version='tor-0.4.7.12'
     tor_tar="${tor_version}.tar.gz"
-    tor_sha='9e9a5c67ad2acdd5f0f8be14ed591fed076b1708abf8344066990a0fa66fe195'
+    tor_sha='3b5d969712c467851bd028f314343ef15a97ea457191e93ffa97310b05b9e395'
     tor_url='https://dist.torproject.org'
     tor_pubkeys='Tor.asc'
 


### PR DESCRIPTION
There have been multiple bugfixes between 0.4.7.8 and 0.4.7.12, including major fixes aimed at helping defend against network denial of service. https://gitlab.torproject.org/tpo/core/tor/-/raw/release-0.4.7/ReleaseNotes