### PR TITLE
CI: Remove Python 3.6 (EOL), add 3.10

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Subset of #1218. Python 3.6 is not only EOL for a long time, also no more available on ubuntu-latest for GitHub workflows, see https://github.com/JoinMarket-Org/joinmarket-clientserver/actions/runs/3705429480/jobs/6279325863. So this is kinda urgent, our CI is broken otherwise.