### PR TITLE
CI: Run tests on both Linux and macOS

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -4,10 +4,11 @@ on: [push, pull_request]
 
 jobs:
   build:
-
-    runs-on: ubuntu-latest
+    name: python ${{ matrix.python-version }} on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
+        os: [macos-latest, ubuntu-latest]
         python-version: ["3.7", "3.8", "3.9", "3.10"]
 
     steps:
@@ -27,7 +28,6 @@ jobs:
       - name: Setup joinmarket + virtualenv
         if: steps.cache-venv.outputs.cache-hit != 'true'
         run: |
-          sudo apt update
           ./install.sh --develop --with-qt
           ./jmvenv/bin/python -m pip install --upgrade pip
           ./jmvenv/bin/pip install -r requirements/base.txt

--- a/test/testrunner/install_bitcoind.sh
+++ b/test/testrunner/install_bitcoind.sh
@@ -4,18 +4,25 @@ set -ev
 
 export BITCOIND_VERSION=0.19.1
 
-if sudo cp ~/bitcoin/bitcoin-$BITCOIND_VERSION/bin/bitcoind /usr/local/bin/bitcoind
-then
-        echo "found cached bitcoind"
-	sudo cp ~/bitcoin/bitcoin-$BITCOIND_VERSION/bin/bitcoin-cli /usr/local/bin/bitcoin-cli
+if [[ "$(uname)" == "Linux" ]]; then
+    platform="x86_64-linux-gnu"
+elif [[ "$(uname)" == "Darwin" ]]; then
+    platform="osx64"
 else
-        mkdir -p ~/bitcoin && \
-        pushd ~/bitcoin && \
-        wget https://bitcoin.org/bin/bitcoin-core-$BITCOIND_VERSION/bitcoin-$BITCOIND_VERSION-x86_64-linux-gnu.tar.gz && \
-        tar xvfz bitcoin-$BITCOIND_VERSION-x86_64-linux-gnu.tar.gz && \
-        sudo cp ./bitcoin-$BITCOIND_VERSION/bin/bitcoind /usr/local/bin/bitcoind && \
-        sudo cp ./bitcoin-$BITCOIND_VERSION/bin/bitcoin-cli /usr/local/bin/bitcoin-cli && \
-        popd
+    echo "Unsupported platform: $(uname)"
+    exit 1
 fi
 
-
+if sudo cp ~/bitcoin/bitcoin-$BITCOIND_VERSION/bin/bitcoind /usr/local/bin/bitcoind
+then
+    echo "found cached bitcoind"
+    sudo cp ~/bitcoin/bitcoin-$BITCOIND_VERSION/bin/bitcoin-cli /usr/local/bin/bitcoin-cli
+else
+    mkdir -p ~/bitcoin && \
+    pushd ~/bitcoin && \
+    wget https://bitcoincore.org/bin/bitcoin-core-$BITCOIND_VERSION/bitcoin-$BITCOIND_VERSION-$platform.tar.gz && \
+    tar xvfz bitcoin-$BITCOIND_VERSION-$platform.tar.gz && \
+    sudo cp ./bitcoin-$BITCOIND_VERSION/bin/bitcoind /usr/local/bin/bitcoind && \
+    sudo cp ./bitcoin-$BITCOIND_VERSION/bin/bitcoin-cli /usr/local/bin/bitcoin-cli && \
+    popd
+fi


### PR DESCRIPTION
If devs have problems with accessing Mac's for tests, let GitHub Actions CI do the basic tesing for us.