### PR TITLE
Account for missing nick fields in OnionPeer

### DIFF
--- a/jmdaemon/jmdaemon/onionmc.py
+++ b/jmdaemon/jmdaemon/onionmc.py
@@ -1505,7 +1505,11 @@ class OnionMessageChannel(MessageChannel):
             # since the peer may already be removed from self.peers,
             # we don't limit except by filter:
             for p in peer_filter:
-                peerlist.add(p.get_nick_peerlocation_ser() + NICK_PEERLOCATOR_SEPARATOR + "D")
+                try:
+                    peerlist.add(p.get_nick_peerlocation_ser(
+                        ) + NICK_PEERLOCATOR_SEPARATOR + "D")
+                except OnionPeerError:
+                    pass
         # For testing: dns won't usually participate:
         peerlist.add(self.self_as_peer.get_nick_peerlocation_ser())
         # don't send an empty set (will not be possible unless


### PR DESCRIPTION
Prior to this commit, if a message (like a disconnection control message), was to be sent to live peers, regarding another peer that did not have a nick field set, a crash would occur in directory nodes sending this message, because the function
OnionPeer.get_nick_peerlocation_ser() assumed the existence of the nick field, and raised the OnionPeerError exception if it did not exist.

After this commit, the raising of this Exception is caught when calling OnionPeer.get_nick_peerlocation_ser, so that a peer in this state is just not added to the list of peers to be sent to live peers. This condition is caused specifically by the fact that said peer has not completed a handshake (which must always pass the value of the nick), and so the other live peers will not yet be aware of it.