### PR TITLE
Apply all current ShellCheck suggestions and add `lint-shell.sh`

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -457,7 +457,7 @@ parse_flags ()
     while :; do
         case $1 in
             --develop)
-                #develop_build='1'
+                # no-op for backwards compatibility
                 ;;
             --disable-os-deps-check)
                 use_os_deps_check='0'
@@ -574,7 +574,6 @@ install_get_os ()
 main ()
 {
     # flags
-    #develop_build=''
     python='python3'
     build_local_tor=''
     no_gpg_validation=''

--- a/scripts/joinmarket-qt.sh
+++ b/scripts/joinmarket-qt.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-cd $(dirname "$0")/.. && \
+# shellcheck source=/dev/null
+cd "$(dirname "$0")/.." && \
 source jmvenv/bin/activate && \
 cd scripts && \
 python3 joinmarket-qt.py

--- a/test/Dockerfiles/build_docker.sh
+++ b/test/Dockerfiles/build_docker.sh
@@ -20,7 +20,6 @@ build_docker ()
     core_url="https://bitcoincore.org/bin/bitcoin-core-${core_version}/${core_dist}"
     declare -A deps=( [${core_dist}]="${core_url}" )
     jm_root="${TRAVIS_BUILD_DIR}"
-    #owner_name="${TRAVIS_REPO_SLUG%\/*}"
     repo_name="${TRAVIS_REPO_SLUG#*\/}"
 
     for dep in "${!deps[@]}"; do

--- a/test/Dockerfiles/build_docker.sh
+++ b/test/Dockerfiles/build_docker.sh
@@ -20,10 +20,10 @@ build_docker ()
     core_url="https://bitcoincore.org/bin/bitcoin-core-${core_version}/${core_dist}"
     declare -A deps=( [${core_dist}]="${core_url}" )
     jm_root="${TRAVIS_BUILD_DIR}"
-    owner_name="${TRAVIS_REPO_SLUG%\/*}"
+    #owner_name="${TRAVIS_REPO_SLUG%\/*}"
     repo_name="${TRAVIS_REPO_SLUG#*\/}"
 
-    for dep in ${!deps[@]}; do
+    for dep in "${!deps[@]}"; do
         if [[ ! -r "${HOME}/downloads/${dep}" ]]; then
             curl --retry 5 -L "${deps[${dep}]}" -o "$HOME/downloads/${dep}"
         fi
@@ -31,7 +31,7 @@ build_docker ()
 
     mkdir -p "${jm_root}/deps/cache"
     find "$HOME/downloads" -type f -exec cp -v {} "${jm_root}/deps/cache/" \;
-    cd "${jm_root}/../"
+    cd "${jm_root}/../" || return 1
 
     docker build \
         --shm-size=1G \

--- a/test/lint/lint-all.sh
+++ b/test/lint/lint-all.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2017-2019 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+#
+# This script runs all contrib/devtools/lint-* files, and fails if any exit
+# with a non-zero status code.
+
+# This script is intentionally locale dependent by not setting "export LC_ALL=C"
+# in order to allow for the executed lint scripts to opt in or opt out of locale
+# dependence themselves.
+
+set -u
+
+SCRIPTDIR=$(dirname "${BASH_SOURCE[0]}")
+LINTALL=$(basename "${BASH_SOURCE[0]}")
+
+EXIT_CODE=0
+
+for f in "${SCRIPTDIR}"/lint-*; do
+  if [ "$(basename "$f")" != "$LINTALL" ]; then
+    if ! "$f"; then
+      echo "^---- failure generated from $f"
+      EXIT_CODE=1
+    fi
+  fi
+done
+
+exit ${EXIT_CODE}

--- a/test/lint/lint-python.sh
+++ b/test/lint/lint-python.sh
@@ -13,7 +13,7 @@ elif flake8 --version | grep -q "Python 2"; then
 fi
 
 if [[ $# == 0 ]]; then
-    flake8 $(git ls-files "*.py") --extend-exclude "${EXCLUDE_PATTERNS}"
+    flake8 "$(git ls-files "*.py")" --extend-exclude "${EXCLUDE_PATTERNS}"
 else
     flake8 "$@"
 fi

--- a/test/lint/lint-python.sh
+++ b/test/lint/lint-python.sh
@@ -13,7 +13,8 @@ elif flake8 --version | grep -q "Python 2"; then
 fi
 
 if [[ $# == 0 ]]; then
-    flake8 "$(git ls-files "*.py")" --extend-exclude "${EXCLUDE_PATTERNS}"
+    # shellcheck disable=SC2046
+    flake8 $(git ls-files "*.py") --extend-exclude "${EXCLUDE_PATTERNS}"
 else
     flake8 "$@"
 fi

--- a/test/lint/lint-shell.sh
+++ b/test/lint/lint-shell.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2018-2021 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+#
+# Check for shellcheck warnings in shell scripts.
+
+export LC_ALL=C
+
+# Disabled warnings:
+disabled=(
+)
+
+EXIT_CODE=0
+
+if ! command -v shellcheck > /dev/null; then
+    echo "Skipping shell linting since shellcheck is not installed."
+    exit $EXIT_CODE
+fi
+
+SHELLCHECK_CMD=(shellcheck --external-sources --check-sourced --source-path=SCRIPTDIR)
+EXCLUDE="--exclude=$(IFS=','; echo "${disabled[*]}")"
+# Check shellcheck directive used for sourced files
+mapfile -t SOURCED_FILES < <(git ls-files | xargs gawk '/^# shellcheck shell=/ {print FILENAME} {nextfile}')
+mapfile -t GUIX_FILES < <(git ls-files contrib/guix contrib/shell | xargs gawk '/^#!\/usr\/bin\/env bash/ {print FILENAME} {nextfile}')
+mapfile -t FILES < <(git ls-files -- '*.sh' | grep -vE 'src/(leveldb|secp256k1|minisketch|univalue)/')
+if ! "${SHELLCHECK_CMD[@]}" "$EXCLUDE" "${SOURCED_FILES[@]}" "${GUIX_FILES[@]}" "${FILES[@]}"; then
+    EXIT_CODE=1
+fi
+
+exit $EXIT_CODE


### PR DESCRIPTION
Based on #1175, but also covers `install.sh` changes since then, all other shell scripts and adds ShellCheck linter script. Not adding this to CI for now. I'm thinking we could split off all the linting to separate job, don't see a point in running them under all OS / Python version combinations.