### PR TITLE
Fix `num_cores()` when no Python available before install

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -6,16 +6,8 @@ check_exists() {
     command -v "$1" > /dev/null
 }
 
-num_cores() {
-    if check_exists python; then
-        python -c 'import multiprocessing as mp; print(mp.cpu_count())'
-    elif check_exists nproc; then
-        nproc
-    else
-        # fallback to no parallel processes
-        echo "1"
-    fi
-}
+# This may be overriden by --python/-p option.
+python="python3"
 
 # This is needed for systems where GNU is not the default make, like FreeBSD.
 if check_exists gmake; then
@@ -23,6 +15,17 @@ if check_exists gmake; then
 else
     make="make"
 fi
+
+num_cores() {
+    if check_exists ${python}; then
+        ${python} -c 'import multiprocessing as mp; print(mp.cpu_count())'
+    elif check_exists nproc; then
+        nproc
+    else
+        # fallback to no parallel processes
+        echo "1"
+    fi
+}
 
 sha256_verify ()
 {
@@ -581,7 +584,6 @@ install_get_os ()
 main ()
 {
     # flags
-    python='python3'
     build_local_tor=''
     no_gpg_validation=''
     use_os_deps_check='1'

--- a/install.sh
+++ b/install.sh
@@ -7,7 +7,14 @@ check_exists() {
 }
 
 num_cores() {
-    python -c 'import multiprocessing as mp; print(mp.cpu_count())'
+    if check_exists python; then
+        python -c 'import multiprocessing as mp; print(mp.cpu_count())'
+    elif check_exists nproc; then
+        nproc
+    else
+        # fallback to no parallel processes
+        echo "1"
+    fi
 }
 
 # This is needed for systems where GNU is not the default make, like FreeBSD.


### PR DESCRIPTION
It is possible to run `install.sh` on Debian based systems without Python being available before, `deb_deps_install()` installs it, as it is in dependency list, but that happens later in the script.

Silences `./install.sh: line 10: python: command not found` error (https://github.com/JoinMarket-Org/joinmarket-clientserver/pull/1396#issuecomment-1369962024) and properly does parallel builds under multicore environments in such cases.