### PR TITLE
Tx size estimation allows varied in, out types

### DIFF
--- a/jmbitcoin/jmbitcoin/secp256k1_transaction.py
+++ b/jmbitcoin/jmbitcoin/secp256k1_transaction.py
@@ -1,6 +1,7 @@
 # note, only used for non-cryptographic randomness:
 import random
 import json
+from typing import List, Union, Tuple
 # needed for single sha256 evaluation, which is used
 # in bitcoin (p2wsh) but not exposed in python-bitcointx:
 import hashlib
@@ -106,7 +107,7 @@ def human_readable_output(txoutput):
         pass # non standard script
     return outdict
 
-def there_is_one_segwit_input(input_types):
+def there_is_one_segwit_input(input_types: List[str]) -> bool:
     # note that we need separate input types for
     # any distinct types of scripthash inputs supported,
     # since each may have a different size of witness; in
@@ -114,7 +115,7 @@ def there_is_one_segwit_input(input_types):
     # will need updating.
     return any(y in ["p2sh-p2wpkh", "p2wpkh", "p2wsh"] for y in input_types)
 
-def estimate_tx_size(ins, outs):
+def estimate_tx_size(ins: List[str], outs: List[str]) -> Union[int, Tuple[int]]:
     '''Estimate transaction size.
     Both arguments `ins` and `outs` must be lists of script types,
     and they must be present in the keys of the dicts `inmults`,

--- a/jmbitcoin/jmbitcoin/secp256k1_transaction.py
+++ b/jmbitcoin/jmbitcoin/secp256k1_transaction.py
@@ -106,13 +106,13 @@ def human_readable_output(txoutput):
         pass # non standard script
     return outdict
 
-def there_is_one_segwit_input(x):
+def there_is_one_segwit_input(input_types):
     # note that we need separate input types for
     # any distinct types of scripthash inputs supported,
     # since each may have a different size of witness; in
     # that case, the internal list in this list comprehension
     # will need updating.
-    return any([y in ["p2sh-p2wpkh", "p2wpkh", "p2wsh"] for y in x])
+    return any(y in ["p2sh-p2wpkh", "p2wpkh", "p2wsh"] for y in input_types)
 
 def estimate_tx_size(ins, outs):
     '''Estimate transaction size.
@@ -174,16 +174,14 @@ def estimate_tx_size(ins, outs):
     for i in ins:
         if i not in inmults:
             raise NotImplementedError(
-                "Script type not supported for transaction size "
-                "estimation: {}".format(i))
+            f"Script type not supported for transaction size estimation: {i}")
         inmult = inmults[i]
         nwsize += inmult["nw"]
         wsize += inmult["w"]
     for o in outs:
         if o not in outmults:
             raise NotImplementedError(
-                "Script type not supported for transaction size "
-                "estimation: {}".format(o))
+            f"Script type not supported for transaction size estimation: {o}")
         nwsize += outmults[o]
 
     if not tx_is_segwit:

--- a/jmbitcoin/jmbitcoin/secp256k1_transaction.py
+++ b/jmbitcoin/jmbitcoin/secp256k1_transaction.py
@@ -168,8 +168,8 @@ def estimate_tx_size(ins, outs):
     wsize = 0
     tx_is_segwit = there_is_one_segwit_input(ins)
     if tx_is_segwit:
-        # flag and marker bytes
-        nwsize += 2
+        # flag and marker bytes are included in witness
+        wsize += 2
 
     for i in ins:
         if i not in inmults:

--- a/jmbitcoin/jmbitcoin/secp256k1_transaction.py
+++ b/jmbitcoin/jmbitcoin/secp256k1_transaction.py
@@ -19,31 +19,6 @@ from bitcointx.core.scripteval import (VerifyScript, SCRIPT_VERIFY_WITNESS,
                                        SCRIPT_VERIFY_STRICTENC,
                                        SIGVERSION_WITNESS_V0)
 
-# for each transaction type, different output script pubkeys may result in
-# a difference in the number of bytes accounted for while estimating the
-# transaction size, this variable stores the difference and is factored in
-# when calculating the correct transaction size. For example, for a p2pkh
-# transaction, if one of the outputs is a p2wsh pubkey, then the transaction
-# would need 9 extra bytes to account for the difference in script pubkey
-# sizes
-OUTPUT_EXTRA_BYTES = {
-    'p2pkh': {
-        'p2wpkh': -3,
-        'p2sh-p2wpkh': -2,
-        'p2wsh': 9
-    },
-    'p2wpkh': {
-        'p2pkh': 3,
-        'p2sh-p2wpkh': 1,
-        'p2wsh': 12
-    },
-    'p2sh-p2wpkh': {
-        'p2pkh': 2,
-        'p2wpkh': -1,
-        'p2wsh': 11
-    }
-}
-
 def human_readable_transaction(tx, jsonified=True):
     """ Given a CTransaction object, output a human
     readable json-formatted string (suitable for terminal

--- a/jmbitcoin/jmbitcoin/secp256k1_transaction.py
+++ b/jmbitcoin/jmbitcoin/secp256k1_transaction.py
@@ -160,7 +160,7 @@ def estimate_tx_size(ins, outs):
     # here, outputs are always entirely nonwitness.
     outmults = {"p2wsh": 43,
                "p2wpkh": 31,
-               "p2sh-p2wpkh": 64,
+               "p2sh-p2wpkh": 32,
                "p2pkh": 34}
 
     # nVersion, nLockTime, nins, nouts:

--- a/jmbitcoin/test/test_tx_signing.py
+++ b/jmbitcoin/test/test_tx_signing.py
@@ -4,6 +4,28 @@ import hashlib
 from jmbase import bintohex
 import jmbitcoin as btc
 
+
+# Cases copied from:
+# https://github.com/kristapsk/bitcoin-scripts/blob/0b847bec016638e60313ecec2b81f2e8accd311b/tests/tx-vsize.bats
+@pytest.mark.parametrize(
+    "inaddrtypes, outaddrtypes, size_expected",
+    [(["p2pkh"], ["p2pkh"], 192),
+     (["p2pkh"], ["p2pkh", "p2pkh"], 226),
+     (["p2pkh"], ["p2sh-p2wpkh", "p2sh-p2wpkh"], 222),
+     (["p2pkh"], ["p2pkh", "p2sh-p2wpkh"], 224),
+     (["p2sh-p2wpkh"], ["p2sh-p2wpkh"], 135),
+     (["p2wpkh"], ["p2wpkh"], 111),
+     ])
+def test_tx_size_estimate(inaddrtypes, outaddrtypes, size_expected):
+    # non-sw only inputs result in a single integer return,
+    # segwit inputs return (witness size, non-witness size)
+    x = btc.estimate_tx_size(inaddrtypes, outaddrtypes)
+    if btc.there_is_one_segwit_input(inaddrtypes):
+        s = int(x[0]/4 + x[1])
+    else:
+        s = x
+    assert s == size_expected
+
 @pytest.mark.parametrize(
     "addrtype",
     [("p2wpkh"),

--- a/jmbitcoin/test/test_tx_signing.py
+++ b/jmbitcoin/test/test_tx_signing.py
@@ -3,25 +3,46 @@ import pytest
 import hashlib
 from jmbase import bintohex
 import jmbitcoin as btc
+from math import ceil
 
 
-# Cases copied from:
+# Case of spending into a FB, one p2wpkh input, one FB output, one p2wpkh output:
+#
+# "020000000001019b3a5c6ec9712bd6b1aa1e07ed12a677eb21215430fb84a689664fb0d4fa175a0000000000feffffff0290099c0a000000001600144d32ca4673822334531a2941bb85bff075c384d180b14f0100000000220020dae515a98f31542dd6b21bb0b0e31fccc4ebcdc9ba3e225798bc981ccbb8a21d024830450221009bc5fb8d077b32304c02a886926a68110bc7c5195a92b55977bd4affd23ab2d50220774e88828cf80cba4bb2e277a69a7c693c3566b5b72a0c0cf25cba89df0646d30121036d1baed4008f0d7f03ac41bbdbe46e02eeef6f040f7bdbc41adac30c2cf8831886020000"
+#
+# case of spending from a FB, single input, to 2 p2wpkh outputs
+# "020000000001013499e10a8035a3cb928f5a894b2a3feed7d46ab579f0a2211a17ed1df0e2d9660100000000feffffff02405dc6000000000016001486551870825ef64d7fda89cc2a6fda497ab71a02954d8900000000001600147c24b9a3ddf5eb26142fb3f05a3746a0a582f81a0247304402206ca2049154939b083a5eb22713d3cb78f6673f43828fa4a7ef0f03275584da6c0220770fe7d50ba5e0a5f8039f28c5deaaf1e8b2030008bf51cc8721cf088eab5586012a0480c22e61b175210376e5964ee2c328e85b88a50f02953b1cddb1490825140331a3948023cc19946bac81c22e61"
+#
+# case of spending from an FB plus one more p2wpkh input, spending to a p2sh output and a p2wpkh output
+# "02000000000102117efb788cee9644d5493fc9d1a120598f4f5200bb6909c0ebdac66cf88da80a0100000000feffffffb0f3ce583987d08080684e2c75d2d6871cb2d30f610327671440d7121c14b7ab0000000000feffffff0240a5ae020000000017a914c579342c2c4c9220205e2cdc285617040c924a0a8797027a00000000001600146fad63e6420ec3eb423a105b05c6df6cc8dab92902473044022040f1db3289d8c6e0dd94c0f55254f10512486094e36fd92f4423abc95320418902206718670b3f332d84cf8294ad389155594ebe125988f2f535c58ff3b077471ce9012102f9306fdc84a366f21fed44fbdd9149a046829f26fb52e7a316b19b536c18d2df0247304402207d0fde11ce32f48107ac246a01efad1c22b9466cd9ff4d5683030790bcb34ce5022020014fcf1b1b0606db5ef363568f10476524f7102644691a8a435faa17cbbe88012a04804f5661b17521037a9502304b2810706adef15b884ac7ca0c48c2e5d03cf93934487b44feb7c276ac814f5661"
+#
+# case of spending from one FB input to one FB output
+#
+# "0200000000010150c8e3786d357cbe61d8e27de7439e1b32d75d0a0ad596c5ff2863134cbd3ead0100000000feffffff01db84f701000000002200208b8ed0bc565e419dd956c3841b7bb25f7c197e2699002bac58a68f47206e1f340247304402202a639209aa9a2883ad75210edce2165260167435f56cede83e8c74095944f355022050fde591f1fefb615a072a797ace3c332c678e0f9161e58d79efa1705f9ab17c012a04002e7f61b1752103d4d747d0dca80c129c017ec1cdc658945013e04ff3d6946f15ccc9df52c323f0ac012e7f61"
+#
+# Virtual sizes can be calculated from bitcointx.core.CTransaction.deserialize(unhexlify(txhex)).get_virtual_size()
+#
+# More cases copied from:
 # https://github.com/kristapsk/bitcoin-scripts/blob/0b847bec016638e60313ecec2b81f2e8accd311b/tests/tx-vsize.bats
 @pytest.mark.parametrize(
     "inaddrtypes, outaddrtypes, size_expected",
-    [(["p2pkh"], ["p2pkh"], 192),
+    [(["p2wpkh"], ["p2wsh", "p2wpkh"], 153),
+     (["p2wsh"], ["p2wpkh", "p2wpkh"], 143),
+     (["p2wsh", "p2wpkh"], ["p2sh-p2wpkh", "p2wpkh"], 212),
+     (["p2wsh"], ["p2wsh"], 124),
+     (["p2pkh"], ["p2pkh"], 192),
      (["p2pkh"], ["p2pkh", "p2pkh"], 226),
      (["p2pkh"], ["p2sh-p2wpkh", "p2sh-p2wpkh"], 222),
      (["p2pkh"], ["p2pkh", "p2sh-p2wpkh"], 224),
-     (["p2sh-p2wpkh"], ["p2sh-p2wpkh"], 135),
-     (["p2wpkh"], ["p2wpkh"], 111),
+     (["p2sh-p2wpkh"], ["p2sh-p2wpkh"], 134),
+     (["p2wpkh"], ["p2wpkh"], 110),
      ])
 def test_tx_size_estimate(inaddrtypes, outaddrtypes, size_expected):
     # non-sw only inputs result in a single integer return,
     # segwit inputs return (witness size, non-witness size)
     x = btc.estimate_tx_size(inaddrtypes, outaddrtypes)
     if btc.there_is_one_segwit_input(inaddrtypes):
-        s = int(x[0]/4 + x[1])
+        s = ceil((x[0] + x[1] * 4)/4.0)
     else:
         s = x
     assert s == size_expected

--- a/jmbitcoin/test/test_tx_signing.py
+++ b/jmbitcoin/test/test_tx_signing.py
@@ -36,13 +36,14 @@ from math import ceil
      (["p2pkh"], ["p2pkh", "p2sh-p2wpkh"], 224),
      (["p2sh-p2wpkh"], ["p2sh-p2wpkh"], 134),
      (["p2wpkh"], ["p2wpkh"], 110),
+     (["p2wpkh"], ["p2wpkh", "p2tr"], 153),
      ])
 def test_tx_size_estimate(inaddrtypes, outaddrtypes, size_expected):
     # non-sw only inputs result in a single integer return,
     # segwit inputs return (witness size, non-witness size)
     x = btc.estimate_tx_size(inaddrtypes, outaddrtypes)
     if btc.there_is_one_segwit_input(inaddrtypes):
-        s = ceil((x[0] + x[1] * 4)/4.0)
+        s = ceil((x[0] + x[1] * 4) / 4.0)
     else:
         s = x
     assert s == size_expected

--- a/jmclient/jmclient/taker_utils.py
+++ b/jmclient/jmclient/taker_utils.py
@@ -26,8 +26,8 @@ def get_utxo_scripts(wallet: BaseWallet, utxos):
     # as passed from `get_utxos_by_mixdepth` at one mixdepth,
     # return the list of script types for each utxo
     script_types = []
-    for k, v in utxos.items():
-        script_types.append(wallet.get_outtype(v["address"]))
+    for utxo in utxos.values():
+        script_types.append(wallet.get_outtype(utxo["address"]))
     return script_types
 
 def direct_send(wallet_service, amount, mixdepth, destination, answeryes=False,
@@ -110,13 +110,13 @@ def direct_send(wallet_service, amount, mixdepth, destination, answeryes=False,
         fee_est = estimate_tx_fee(len(utxos), 1, txtype=script_types, outtype=outtype)
         outs = [{"address": destination, "value": total_inputs_val - fee_est}]
     else:
-        change_type = wallet_service.get_txtype()
+        change_type = txtype
         if custom_change_addr:
             change_type = wallet_service.get_outtype(custom_change_addr)
             if change_type is None:
                 # we don't recognize this type; best we can do is revert to default,
                 # even though it may be inaccurate:
-                change_type = wallet_service.get_txtype()
+                change_type = txtype
         outtypes = [change_type, outtype]
         # not doing a sweep; we will have change.
         # 8 inputs to be conservative; note we cannot account for the possibility

--- a/jmclient/jmclient/taker_utils.py
+++ b/jmclient/jmclient/taker_utils.py
@@ -21,7 +21,7 @@ Utility functions for tumbler-style takers;
 Currently re-used by CLI script tumbler.py and joinmarket-qt
 """
 
-def get_utxo_scripts(wallet: BaseWallet, utxos):
+def get_utxo_scripts(wallet: BaseWallet, utxos: dict) -> list:
     # given a Joinmarket wallet and a set of utxos
     # as passed from `get_utxos_by_mixdepth` at one mixdepth,
     # return the list of script types for each utxo

--- a/jmclient/jmclient/taker_utils.py
+++ b/jmclient/jmclient/taker_utils.py
@@ -121,12 +121,14 @@ def direct_send(wallet_service, amount, mixdepth, destination, answeryes=False,
             # we don't recognize the destination script type,
             # so set it as the same as the change (which will usually
             # be the same as the spending wallet, but see above for custom)
+            # Notice that this is handled differently to the sweep case above,
+            # because we must use a list - there is more than one output
             outtype = change_type
         outtypes = [change_type, outtype]
         # not doing a sweep; we will have change.
         # 8 inputs to be conservative; note we cannot account for the possibility
         # of non-standard input types at this point.
-        initial_fee_est = estimate_tx_fee(8,2, txtype=txtype, outtype=outtypes)
+        initial_fee_est = estimate_tx_fee(8, 2, txtype=txtype, outtype=outtypes)
         utxos = wallet_service.select_utxos(mixdepth, amount + initial_fee_est,
                                             includeaddr=True)
         script_types = get_utxo_scripts(wallet_service.wallet, utxos)

--- a/jmclient/jmclient/taker_utils.py
+++ b/jmclient/jmclient/taker_utils.py
@@ -117,6 +117,11 @@ def direct_send(wallet_service, amount, mixdepth, destination, answeryes=False,
                 # we don't recognize this type; best we can do is revert to default,
                 # even though it may be inaccurate:
                 change_type = txtype
+        if outtype is None:
+            # we don't recognize the destination script type,
+            # so set it as the same as the change (which will usually
+            # be the same as the spending wallet, but see above for custom)
+            outtype = change_type
         outtypes = [change_type, outtype]
         # not doing a sweep; we will have change.
         # 8 inputs to be conservative; note we cannot account for the possibility

--- a/jmclient/jmclient/wallet.py
+++ b/jmclient/jmclient/wallet.py
@@ -27,8 +27,8 @@ from .support import select_gradual, select_greedy, select_greediest, \
     select, NotEnoughFundsException
 from .cryptoengine import TYPE_P2PKH, TYPE_P2SH_P2WPKH, TYPE_P2WSH,\
     TYPE_P2WPKH, TYPE_TIMELOCK_P2WSH, TYPE_SEGWIT_WALLET_FIDELITY_BONDS,\
-    TYPE_WATCHONLY_FIDELITY_BONDS, TYPE_WATCHONLY_TIMELOCK_P2WSH, TYPE_WATCHONLY_P2WPKH,\
-    ENGINES, detect_script_type, EngineError
+    TYPE_WATCHONLY_FIDELITY_BONDS, TYPE_WATCHONLY_TIMELOCK_P2WSH, \
+    TYPE_WATCHONLY_P2WPKH, TYPE_P2TR, ENGINES, detect_script_type, EngineError
 from .support import get_random_bytes
 from . import mn_encode, mn_decode
 import jmbitcoin as btc
@@ -92,7 +92,7 @@ def estimate_tx_fee(ins, outs, txtype='p2pkh', outtype=None, extra_bytes=0):
 
     # See docstring for explanation:
     if isinstance(txtype, str):
-        ins = [txtype]* ins
+        ins = [txtype] * ins
     else:
         assert isinstance(txtype, list)
         ins = txtype
@@ -505,6 +505,8 @@ class BaseWallet(object):
             return 'p2sh-p2wpkh'
         elif script_type == TYPE_P2WSH:
             return 'p2wsh'
+        elif script_type == TYPE_P2TR:
+            return 'p2tr'
         # should be unreachable; all possible returns
         # from detect_script_type are covered.
         assert False

--- a/jmclient/jmclient/wallet.py
+++ b/jmclient/jmclient/wallet.py
@@ -8,6 +8,7 @@ import random
 import copy
 import base64
 import json
+from math import ceil
 from binascii import hexlify, unhexlify
 from datetime import datetime, timedelta
 from calendar import timegm
@@ -113,8 +114,7 @@ def estimate_tx_fee(ins, outs, txtype='p2pkh', outtype=None, extra_bytes=0):
         witness_estimate, non_witness_estimate = btc.estimate_tx_size(
             ins, outs)
         non_witness_estimate += extra_bytes
-        return int(int((
-            non_witness_estimate + 0.25*witness_estimate)*fee_per_kb)/Decimal(1000.0))
+        return int(int(ceil(non_witness_estimate + 0.25*witness_estimate)*fee_per_kb)/Decimal(1000.0))
 
 def compute_tx_locktime():
     # set locktime for best anonset (Core, Electrum)

--- a/jmclient/test/test_taker.py
+++ b/jmclient/test/test_taker.py
@@ -513,15 +513,15 @@ def test_custom_change(setup_taker):
         for out in taker.latest_tx.vout:
             # input utxo is 200M; amount is 20M; as per logs:
             # totalin=200000000
-            # my_txfee=13050
+            # my_txfee=13680 <- this estimate ignores address type
             # makers_txfee=3000
-            # cjfee_total=12000 => changevalue=179974950
+            # cjfee_total=12000 => changevalue=179974320
             # note that there is a small variation in the size of
             # the transaction (a few bytes) for the different scriptPubKey
-            # type, but this is currently ignored by the Taker, who makes
-            # fee estimate purely based on the number of ins and outs;
-            # this will never be too far off anyway.
-            if out.scriptPubKey == script and out.nValue == 179974950:
+            # type, but this is currently ignored in coinjoins by the
+            # Taker (not true for direct send operations), hence we get
+            # the same value for each different output type.
+            if out.scriptPubKey == script and out.nValue == 179974320:
                 # must be only one
                 assert not custom_change_found
                 custom_change_found = True

--- a/jmclient/test/test_taker.py
+++ b/jmclient/test/test_taker.py
@@ -513,15 +513,15 @@ def test_custom_change(setup_taker):
         for out in taker.latest_tx.vout:
             # input utxo is 200M; amount is 20M; as per logs:
             # totalin=200000000
-            # my_txfee=13680 <- this estimate ignores address type
+            # my_txfee=13650 <- this estimate ignores address type
             # makers_txfee=3000
-            # cjfee_total=12000 => changevalue=179974320
+            # cjfee_total=12000 => changevalue=179974350
             # note that there is a small variation in the size of
             # the transaction (a few bytes) for the different scriptPubKey
             # type, but this is currently ignored in coinjoins by the
             # Taker (not true for direct send operations), hence we get
             # the same value for each different output type.
-            if out.scriptPubKey == script and out.nValue == 179974320:
+            if out.scriptPubKey == script and out.nValue == 179974350:
                 # must be only one
                 assert not custom_change_found
                 custom_change_found = True


### PR DESCRIPTION
Prior to this commit, p2wsh inputs from fidelity bonds resulted in miscalculation of transaction fees, even in cases where the exact set of inputs were known (such as a direct send).
In this commit we change the estimation to a model in which the caller of jmbitcoin.secp256k1_transaction.estimate_tx_size must specify a list of types, one for each input to the transaction, and the same for outputs. In some cases, the caller of the function uses the default script type of the wallet, but in other cases where the caller can know the exact types of each utxo used as input, and each destination used as output, they are specified explicitly. In particular, the use of fidelity bond outputs as input to transactions can be accounted for. Currently this is only done in direct send payments; coinjoins still fall back to assuming all inputs the same type (note that it is not possible to use fidelity bond utxos as inputs to coinjoins). Note also that the burn destination calculation in direct send is removed, since it is not used, so the maintenance burden is best avoided.