### PR TITLE
CI: Skip duplicate actions

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -3,7 +3,19 @@ name: Python package
 on: [push, pull_request]
 
 jobs:
-  build:
+  pre_job:
+    runs-on: ubuntu-latest
+    outputs:
+      should_skip: ${{ steps.skip_check.outputs.should_skip }}
+    steps:
+      - id: skip_check
+        uses: fkirc/skip-duplicate-actions@v5
+        with:
+          # If the same workflow is running on the exact same content, skip newer runs of it.
+          concurrent_skipping: "same_content_newer"
+
+  main_job:
+    needs: pre_job
     name: python ${{ matrix.python-version }} on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:


### PR DESCRIPTION
See https://github.com/JoinMarket-Org/joinmarket-clientserver/pull/1423#issuecomment-1373604203.

Because of `on: [push, pull_request]`, if PR was created from a different branch of the same repo, not from a forked repo, all tests were run twice. This adds [skip duplicate actions](https://github.com/marketplace/actions/skip-duplicate-actions) pre-job, which should ensure tests are run only once in such cases.