### PR TITLE
Tests: Use different jm_test_datadir for each local user

### DIFF
--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -195,7 +195,7 @@ run_jm_tests ()
     fi
     for dir in '/dev/shm' '/Volumes/ramdisk' '/tmp' "${jm_source}/test"; do
         if [[ -d "${dir}" && -r "${dir}" && -w "${dir}" && -x "${dir}" ]]; then
-            jm_test_datadir="${dir}/jm_test_home/.bitcoin"
+            jm_test_datadir="${dir}/jm_test_home-$(whoami)/.bitcoin"
             break
         fi
     done


### PR DESCRIPTION
Otherwise will have permission denied errors when trying to run tests from a different local users on the same system.