### PR TITLE
Add link to my public orderbook mirror

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,8 +70,9 @@ If you are running Joinmarket-Qt, you can instead use the [walkthrough](docs/JOI
 
 If you used the old version of Joinmarket, the notes in the [scripts readme](scripts/README.md) help to understand what has and hasn't changed about the scripts (warning: this refers to changes from several years ago, so may be slightly outdated).
 
-If you are looking for the available makers, run the [orderbook](docs/orderbook.md). 
-Public mainnet mirror: [JoinMarket Browser Interface Orderbook](https://nixbitcoin.org/orderbook) [(🧅 tor)](http://qvzlxbjvyrhvsuyzz5t63xx7x336dowdvt7wfj53sisuun4i4rdtbzid.onion/orderbook)
+If you are looking for the available makers, run the [orderbook](docs/orderbook.md). It's recommended to run your own orderbook locally, but there are also public mirrors:
+* https://nixbitcoin.org/orderbook (clearnet) / http://qvzlxbjvyrhvsuyzz5t63xx7x336dowdvt7wfj53sisuun4i4rdtbzid.onion/orderbook (Tor)
+* http://nnuifroxn5aolsqa2svedcskojlqfp2ygt4u42ac7njehsbemagpwiqd.onion (Tor)
 
 ### Useful third-party projects
 


### PR DESCRIPTION
I've started hosting a permanently running JM orderbook on a VPS. Alternative to the one provided by @nixbitcoin, mine is .onion-only.

At least now there will be two public orderbook sites now, so that people can compare results. There are known issues with long running OB. Have scheduled mine to restart once per hour as a workaround.