### PR TITLE
docs: add restart config to directory node service

### DIFF
--- a/docs/onion-message-channels.md
+++ b/docs/onion-message-channels.md
@@ -190,6 +190,8 @@ After=network-online.target
 Type=simple
 ExecStart=/bin/bash -c 'cd /path/to/joinmarket-clientserver && source jmvenv/bin/activate && cd scripts && python start-dn.py 'Greetings from Directory Node' --datadir=/path/to/chosen/datadir'
 User=user
+Restart=always
+RestartSec=10
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Found it while testing that if Tor fails the start-dn.py exits and by default systemd does not restart it.

This small recommended change ensures that the process is restarted both in case of graceful and ungraceful exit and leaves 10 seconds between.