### PR TITLE
Signal BIP125 opt-in RBF for non-cj sends by default

### DIFF
--- a/jmclient/jmclient/cli_options.py
+++ b/jmclient/jmclient/cli_options.py
@@ -489,11 +489,11 @@ def get_sendpayment_parser():
                       'broadcasting the transaction. '
                       'Currently only works with direct '
                       'send (-N 0).')
-    parser.add_option('--rbf',
+    parser.add_option('--no-rbf',
                       action='store_true',
-                      dest='rbf',
+                      dest='no_rbf',
                       default=False,
-                      help='enable opt-in rbf')
+                      help='disable signaling BIP125 opt-in RBF')
     parser.add_option('-u',
                       '--custom-change',
                       type="str",

--- a/jmclient/jmclient/payjoin.py
+++ b/jmclient/jmclient/payjoin.py
@@ -488,7 +488,7 @@ def make_payment_psbt(manager, accept_callback=None, info_callback=None):
                                manager.mixdepth, str(manager.destination),
                                accept_callback=accept_callback,
                                info_callback=info_callback,
-                               with_final_psbt=True, optin_rbf=True)
+                               with_final_psbt=True)
     if not payment_psbt:
         return (False, "could not create non-payjoin payment")
 

--- a/jmclient/jmclient/taker_utils.py
+++ b/jmclient/jmclient/taker_utils.py
@@ -33,7 +33,7 @@ def get_utxo_scripts(wallet: BaseWallet, utxos: dict) -> list:
 def direct_send(wallet_service, amount, mixdepth, destination, answeryes=False,
                 accept_callback=None, info_callback=None, error_callback=None,
                 return_transaction=False, with_final_psbt=False,
-                optin_rbf=False, custom_change_addr=None):
+                optin_rbf=True, custom_change_addr=None):
     """Send coins directly from one mixdepth to one destination address;
     does not need IRC. Sweep as for normal sendpayment (set amount=0).
     If answeryes is True, callback/command line query is not performed.

--- a/jmclient/test/test_tx_creation.py
+++ b/jmclient/test/test_tx_creation.py
@@ -165,8 +165,7 @@ def test_spend_then_rbf(setup_tx_creation):
     # we return the transaction object, not directly broadcast.
     tx1 = direct_send(wallet_service, amount, 0,
                       destn, answeryes=True,
-                      return_transaction=True,
-                      optin_rbf=True)
+                      return_transaction=True)
     assert tx1
     # record the utxos for reuse:
     assert isinstance(tx1, bitcoin.CTransaction)

--- a/scripts/sendpayment.py
+++ b/scripts/sendpayment.py
@@ -251,7 +251,8 @@ def main():
     if options.makercount == 0 and not bip78url:
         tx = direct_send(wallet_service, amount, mixdepth, destaddr,
                          options.answeryes, with_final_psbt=options.with_psbt,
-                         optin_rbf=options.rbf, custom_change_addr=custom_change)
+                         optin_rbf=not options.no_rbf,
+                         custom_change_addr=custom_change)
         if options.with_psbt:
             log.info("This PSBT is fully signed and can be sent externally for "
                      "broadcasting:")


### PR DESCRIPTION
This seems to be direction where everybody is going. Wasabi Wallet 2.0 does this, Electrum does this. I see no downsides here.

Before this you could signal opt-in RBF only from `sendpayment.py`, but not Qt GUI.

Will be more useful after #1019 is merged, but power users already can use other tools to construct replacement transactions.