### PR TITLE
Do not install python3-venv

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -72,7 +72,6 @@ deps_install ()
         'python3-dev' \
         'python3-pip' \
         'python3-setuptools' \
-        'python3-venv' \
         'libltdl-dev' )
 
     if [ "$with_sudo" == 1 ]; then debian_deps+=("sudo"); fi


### PR DESCRIPTION
`python3-venv` is not longer included in newer versions of Debian.

https://stackoverflow.com/questions/73632344/package-python3-venv-has-no-installation-candidate

The correct thing to do is to detect which version of Debian and install the packages accordingly.