### PR TITLE
Refactor: Add `get_wallet_rescan_status()` instead of `getwalletinfo()` for `bci`

### DIFF
--- a/jmclient/jmclient/wallet_rpc.py
+++ b/jmclient/jmclient/wallet_rpc.py
@@ -641,11 +641,7 @@ class JMWalletDaemon(Service):
 
             if self.services["wallet"]:
                 if self.services["wallet"].isRunning():
-                    winfo = self.services["wallet"].get_backend_walletinfo()
-                    if "scanning" in winfo and winfo["scanning"]:
-                        # Note that if not 'false', it contains info
-                        # that looks like: {'duration': 1, 'progress': Decimal('0.04665404082350701')}
-                        rescanning = True
+                    rescanning, _ = self.services["wallet"].get_backend_wallet_rescan_status()
                     wallet_name = self.wallet_name
                     # At this point if an `auth_header` is present, it has been checked
                     # by the call to `check_cookie_if_present` above.

--- a/jmclient/jmclient/wallet_service.py
+++ b/jmclient/jmclient/wallet_service.py
@@ -4,7 +4,7 @@ import collections
 import itertools
 import time
 import sys
-from typing import Optional
+from typing import Optional, Tuple
 from decimal import Decimal
 from copy import deepcopy
 from twisted.internet import reactor
@@ -733,11 +733,8 @@ class WalletService(Service):
     def rescanblockchain(self, start_height: int, end_height: Optional[int] = None) -> None:
         self.bci.rescanblockchain(start_height, end_height)
 
-    def get_backend_walletinfo(self) -> dict:
-        """ 'Backend' wallet means the Bitcoin Core wallet,
-        which will always be loaded if self.bci is init-ed.
-        """
-        return self.bci.getwalletinfo()
+    def get_backend_wallet_rescan_status(self) -> Tuple[bool, Optional[Decimal]]:
+        return self.bci.get_wallet_rescan_status()
 
     def get_transaction_block_height(self, tx):
         """ Given a CTransaction object tx, return


### PR DESCRIPTION
Noticed this when tried to rebase #1462 after merging of #1477. #1461 added public `getwalletinfo()` method to `BitcoinCoreInterface`, which was used by code outside of `jmclient/jmclient/blockchaininterface.py`. This is bad approach, as it relies on Bitcoin Core RPC `getwalletinfo` returned `dict`, which contains a lots of different stuff too, could lead to more problems in future introducing other blockchain interface classes. Let's instead have generic method returning just wallet rescan status. Also it now returns `Tuple[bool, Optional[Decimal]]` with rescan status percentage, if rescan is in progress, although that's not used by any other code for now.