### PR TITLE
Decode JWT token for validation

### DIFF
--- a/docs/JSON-RPC-API-using-jmwalletd.md
+++ b/docs/JSON-RPC-API-using-jmwalletd.md
@@ -16,11 +16,23 @@ Documentation of the websocket functionality [below](#websocket).
 
 This HTTP server does *NOT* currently support multiple sessions; it is intended as a manager/daemon for all the Joinmarket services for a single user. Note that in particular it allows only control of *one wallet at a time*.
 
-#### Rules about making requests
+### Rules about making requests
+
+Note that for some methods, it's particularly important to deal with the HTTP response asynchronously, since it can take some time for wallet synchronization, service startup etc. to occur; in these cases a HTTP return code of 202 is sent.
+
+#### Authentication
 
 Authentication is with the [JSON Web Token](https://jwt.io/) scheme, provided using the Python package [PyJWT](https://pypi.org/project/PyJWT/).
 
-Note that for some methods, it's particularly important to deal with the HTTP response asynchronously, since it can take some time for wallet synchronization, service startup etc. to occur; in these cases a HTTP return code of 202 is sent.
+On initially creating, unlocking or recovering a wallet, a new access and refresh token will be sent in response, the former is valid for only 30 minutes and must be used for any authenticated call, the former is valid for 4 hours and can be used to request a new access token, ideally before access token expiration to avoid unauthorized response from authenticated endpoint and in any case, before refresh token expiration.
+
+Tokens are signed with HS256 (HMAC with SHA-256), a symmetric keyed hashing algorithm that uses one secret key. Signature keys (differentiated between access and refresh tokens) are generated from random bytes upon the following events, implying that any previously issued token is invalidated.
+
+- starting Joinmarket wallet deamon
+- creating, unlocking or recovering a wallet if RPC API is already serving another wallet
+- locking wallet
+
+On top of these events, refresh token signing key is also re-generated when refreshing an access token.
 
 ### API documentation
 

--- a/docs/api/wallet-rpc.yaml
+++ b/docs/api/wallet-rpc.yaml
@@ -10,6 +10,30 @@ servers:
 - url: https://none
   description: This API is called locally to a jmwalletd instance, acting as server, for each wallet owner, it is not public.
 paths:
+  /token:
+    post:
+      security:
+        - bearerAuth: []
+      summary: The token endpoint is used by the client to obtain an access token using a grant such as refresh token
+      operationId: token
+      description: >
+        Give a refresh token and get back both an access and refresh token.
+        On initially creating, unlocking or recovering a wallet, store both the refresh and access tokens, the latter is valid for only 30 minutes (must be used for any authenticated call) while the former is for 4 hours (can only be used in the refresh request parameters). Use /token endpoint on a regular basis to get new access and refresh tokens, ideally before access token expiration to avoid AuthenticationError response from authenticated endpoint and in any case, before refresh token expiration. The newly issued tokens must be used in subsequent calls since operation invalidates previously issued tokens.
+      responses:
+        '200':
+          $ref: '#/components/responses/RefreshToken-200-OK'
+        '400':
+          $ref: '#/components/responses/400-BadRequest'
+        '401':
+          $ref: '#/components/responses/401-AuthenticationError'
+        '403':
+          $ref: '#/components/responses/403-Forbidden'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TokenRequest'
+        description: token refresh parameters
   /wallet/create:
     post:
       summary: create a new wallet
@@ -99,7 +123,9 @@ paths:
         '400':
           $ref: '#/components/responses/400-BadRequest'
         '401':
-          $ref: '#/components/responses/401-Unauthorized'
+          $ref: '#/components/responses/401-AuthenticationError'
+        '403':
+          $ref: '#/components/responses/403-Forbidden'
   /wallet/{walletname}/display:
     get:
       security:
@@ -120,7 +146,9 @@ paths:
         '400':
           $ref: '#/components/responses/400-BadRequest'
         '401':
-          $ref: '#/components/responses/401-Unauthorized'
+          $ref: '#/components/responses/401-AuthenticationError'
+        '403':
+          $ref: '#/components/responses/403-Forbidden'
         '404':
           $ref: '#/components/responses/404-NotFound'
   /session:
@@ -135,7 +163,9 @@ paths:
         '200':
           $ref: "#/components/responses/Session-200-OK"
         '401':
-          $ref: '#/components/responses/401-Unauthorized'
+          $ref: '#/components/responses/401-AuthenticationError'
+        '403':
+          $ref: '#/components/responses/403-Forbidden'
         '404':
           $ref: '#/components/responses/404-NotFound'
   /getinfo:
@@ -162,11 +192,11 @@ paths:
     get:
       summary: get latest report on yield generating activity
       operationId: yieldgenreport
-      description: "Get list of coinjoins taken part in as maker (across all wallets).
-      Data returned as list of strings, each one in the same comma separated format as found in yigen-statement.csv.
-      Note that this returns all lines in the file, including the lines that are only present to represent the starting
-      of a bot. Those lines contain the word Connected and can be thus discarded.
-      The header line is also delivered and so can be ignored as per the client requirements."
+      description: >
+        Get list of coinjoins taken part in as maker (across all wallets).
+        Data returned as list of strings, each one in the same comma separated format as found in yigen-statement.csv.
+        Note that this returns all lines in the file, including the lines that are only present to represent the starting of a bot. Those lines contain the word Connected and can be thus discarded.
+        The header line is also delivered and so can be ignored as per the client requirements.
       responses:
         '200':
           $ref: "#/components/responses/YieldGenReport-200-OK"
@@ -198,11 +228,15 @@ paths:
         '400':
           $ref: '#/components/responses/400-BadRequest'
         '401':
-          $ref: '#/components/responses/401-Unauthorized'
+          $ref: '#/components/responses/401-AuthenticationError'
+        '403':
+          $ref: '#/components/responses/403-Forbidden'
         '404':
           $ref: '#/components/responses/404-NotFound'
   /wallet/{walletname}/rescanblockchain/{blockheight}:
     get:
+      security:
+        - bearerAuth: []
       summary: Rescan the blockchain from a given blockheight
       operationId: rescanblockchain
       description: Use this operation on recovered wallets to re-sync the wallet
@@ -225,7 +259,9 @@ paths:
         '400':
           $ref: '#/components/responses/400-BadRequest'
         '401':
-          $ref: '#/components/responses/401-Unauthorized'
+          $ref: '#/components/responses/401-AuthenticationError'
+        '403':
+          $ref: '#/components/responses/403-Forbidden'
         '404':
           $ref: '#/components/responses/404-NotFound'
   /wallet/{walletname}/address/timelock/new/{lockdate}:
@@ -256,7 +292,9 @@ paths:
         '400':
           $ref: '#/components/responses/400-BadRequest'
         '401':
-          $ref: '#/components/responses/401-Unauthorized'
+          $ref: '#/components/responses/401-AuthenticationError'
+        '403':
+          $ref: '#/components/responses/403-Forbidden'
         '404':
           $ref: '#/components/responses/404-NotFound'
   /wallet/{walletname}/utxos:
@@ -280,7 +318,9 @@ paths:
         '400':
           $ref: '#/components/responses/400-BadRequest'
         '401':
-          $ref: '#/components/responses/401-Unauthorized'
+          $ref: '#/components/responses/401-AuthenticationError'
+        '403':
+          $ref: '#/components/responses/403-Forbidden'
         '404':
           $ref: '#/components/responses/404-NotFound'
   /wallet/{walletname}/taker/direct-send:
@@ -309,7 +349,9 @@ paths:
         '400':
           $ref: '#/components/responses/400-BadRequest'
         '401':
-          $ref: '#/components/responses/401-Unauthorized'
+          $ref: '#/components/responses/401-AuthenticationError'
+        '403':
+          $ref: '#/components/responses/403-Forbidden'
         '404':
           $ref: '#/components/responses/404-NotFound'
         '409':
@@ -343,6 +385,10 @@ paths:
           $ref: '#/components/responses/400-BadRequest'
         '401':
           $ref: '#/components/responses/401-Unauthorized'
+        '401':
+          $ref: '#/components/responses/401-AuthenticationError'
+        '403':
+          $ref: '#/components/responses/403-Forbidden'
         '404':
           $ref: '#/components/responses/404-NotFound'
         '409':
@@ -370,6 +416,10 @@ paths:
           $ref: '#/components/responses/400-BadRequest'
         '401':
           $ref: "#/components/responses/401-Unauthorized"
+        '401':
+          $ref: '#/components/responses/401-AuthenticationError'
+        '403':
+          $ref: '#/components/responses/403-Forbidden'
         '404':
           $ref: '#/components/responses/404-NotFound'
   /wallet/{walletname}/taker/coinjoin:
@@ -399,6 +449,10 @@ paths:
           $ref: '#/components/responses/400-BadRequest'
         '401':
           $ref: '#/components/responses/401-Unauthorized'
+        '401':
+          $ref: '#/components/responses/401-AuthenticationError'
+        '403':
+          $ref: '#/components/responses/403-Forbidden'
         '404':
           $ref: '#/components/responses/404-NotFound'
         '409':
@@ -432,6 +486,10 @@ paths:
           $ref: '#/components/responses/400-BadRequest'
         '401':
           $ref: '#/components/responses/401-Unauthorized'
+        '401':
+          $ref: '#/components/responses/401-AuthenticationError'
+        '403':
+          $ref: '#/components/responses/403-Forbidden'
         '404':
           $ref: '#/components/responses/404-NotFound'
         '409':
@@ -457,7 +515,9 @@ paths:
         '400':
           $ref: '#/components/responses/400-BadRequest'
         '401':
-          $ref: "#/components/responses/401-Unauthorized"
+          $ref: "#/components/responses/401-AuthenticationError"
+        '403':
+          $ref: '#/components/responses/403-Forbidden'
         '404':
           $ref: '#/components/responses/404-NotFound'
   /wallet/{walletname}/taker/stop:
@@ -481,6 +541,10 @@ paths:
           $ref: '#/components/responses/400-BadRequest'
         '401':
           $ref: "#/components/responses/401-Unauthorized"
+        '401':
+          $ref: '#/components/responses/401-AuthenticationError'
+        '403':
+          $ref: '#/components/responses/403-Forbidden'
         '404':
           $ref: '#/components/responses/404-NotFound'
   /wallet/{walletname}/configset:
@@ -509,7 +573,9 @@ paths:
         '400':
           $ref: '#/components/responses/400-BadRequest'
         '401':
-          $ref: '#/components/responses/401-Unauthorized'
+          $ref: '#/components/responses/401-AuthenticationError'
+        '403':
+          $ref: '#/components/responses/403-Forbidden'
         '409':
           $ref: '#/components/responses/409-NoConfig'
   /wallet/{walletname}/configget:
@@ -537,7 +603,9 @@ paths:
         '400':
           $ref: '#/components/responses/400-BadRequest'
         '401':
-          $ref: "#/components/responses/401-Unauthorized"
+          $ref: "#/components/responses/401-AuthenticationError"
+        '403':
+          $ref: '#/components/responses/403-Forbidden'
         '409':
           $ref: '#/components/responses/409-NoConfig'
   /wallet/{walletname}/freeze:
@@ -565,6 +633,10 @@ paths:
           $ref: "#/components/responses/Freeze-200-OK"
         '400':
           $ref: '#/components/responses/400-BadRequest'
+        '401':
+          $ref: "#/components/responses/401-AuthenticationError"
+        '403':
+          $ref: '#/components/responses/403-Forbidden'
   /wallet/{walletname}/getseed:
     get:
       security:
@@ -590,7 +662,9 @@ paths:
         '400':
           $ref: '#/components/responses/400-BadRequest'
         '401':
-          $ref: "#/components/responses/401-Unauthorized"
+          $ref: "#/components/responses/401-AuthenticationError"
+        '403':
+          $ref: '#/components/responses/403-Forbidden'
 components:
   securitySchemes:
     bearerAuth:
@@ -662,6 +736,35 @@ components:
         destination:
           type: string
           example: "bcrt1qujp2x2fv437493sm25gfjycns7d39exjnpptzw"
+    TokenRequest:
+      type: object
+      required:
+        - grant_type
+        - refresh_token
+      properties:
+        grant_type:
+          type: string
+        refresh_token:
+          type: string
+    TokenResponse:
+      type: object
+      required:
+        - token
+        - token_type
+        - expires_in
+        - scope
+        - refresh_token
+      properties:
+        token:
+          type: string
+        token_type:
+          type: string
+        expires_in:
+          type: int
+        scope:
+          type: string
+        refresh_token:
+          type: string
     RunScheduleRequest:
       type: object
       required:
@@ -919,13 +1022,31 @@ components:
                                 type: string
                               extradata:
                                 type: string
-
     CreateWalletResponse:
       type: object
       required:
         - walletname
-        - token
         - seedphrase
+        - token
+        - refresh_token
+      properties:
+        walletname:
+          type: string
+          example: wallet.jmdat
+        seedphrase:
+          type: string
+        token:
+          type: string
+          format: byte
+        refresh_token:
+          type: string
+          format: byte
+    UnlockWalletResponse:
+      type: object
+      required:
+        - walletname
+        - token
+        - refresh_token
       properties:
         walletname:
           type: string
@@ -933,18 +1054,7 @@ components:
         token:
           type: string
           format: byte
-        seedphrase:
-          type: string
-    UnlockWalletResponse:
-      type: object
-      required:
-        - walletname
-        - token
-      properties:
-        walletname:
-          type: string
-          example: wallet.jmdat
-        token:
+        refresh_token:
           type: string
           format: byte
     DirectSendResponse:
@@ -1087,6 +1197,8 @@ components:
         properties:
           message:
             type: string
+          error_description:
+            type: string
 
   responses:
     # Success responses
@@ -1126,6 +1238,12 @@ components:
         application/json:
           schema:
             $ref: "#/components/schemas/ListWalletsResponse"
+    Token-200-OK:
+      description: "Access token obtained successfully"
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/TokenResponse"
     Session-200-OK:
       description: "successful heartbeat response"
       content:
@@ -1219,6 +1337,20 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/ErrorMessage'
+    401-AuthenticationError:
+      description: Bearer token authentication error.
+      headers:
+        WWW-Authenticate:
+          description: Defines the HTTP authentication methods.
+          schema:
+            type: string
+    403-Forbidden:
+      description: Bearer token authorization error.
+      headers:
+        WWW-Authenticate:
+          description: Defines the HTTP authentication methods.
+          schema:
+            type: string
     409-AlreadyExists:
       description: Unable to complete request because object already exists.
       content:

--- a/jmclient/jmclient/auth.py
+++ b/jmclient/jmclient/auth.py
@@ -1,0 +1,100 @@
+import datetime
+import os
+
+import jwt
+
+from jmbase.support import bintohex
+
+
+class InvalidScopeError(Exception):
+    pass
+
+
+class ExpiredSignatureError(jwt.exceptions.ExpiredSignatureError):
+    pass
+
+
+def get_random_key(size: int = 16) -> str:
+    """Create a random key has an hexadecimal string."""
+    return bintohex(os.urandom(size))
+
+
+class JMTokenAuthority:
+    """Manage authorization tokens."""
+
+    SESSION_VALIDITY = {
+        "access": datetime.timedelta(minutes=30),
+        "refresh": datetime.timedelta(hours=4),
+    }
+    SIGNATURE_ALGORITHM = "HS256"
+
+    def __init__(self, *wallet_names: str):
+        self.signature_key = {
+            "access": get_random_key(),
+            "refresh": get_random_key(),
+        }
+        self._scope = {"walletrpc"}
+        for wallet_name in wallet_names:
+            self.add_to_scope(wallet_name)
+
+    def verify(self, token: str, *, token_type: str = "access"):
+        """Verify JWT token.
+
+        Token must have a valid signature and its scope must contain both scopes in
+        arguments and wallet_name property.
+        """
+        try:
+            claims = jwt.decode(
+                token,
+                self.signature_key[token_type],
+                algorithms=self.SIGNATURE_ALGORITHM,
+                leeway=10,
+            )
+        except jwt.exceptions.ExpiredSignatureError:
+            raise ExpiredSignatureError
+
+        token_claims = set(claims.get("scope", []).split())
+        if not self._scope <= token_claims:
+            raise InvalidScopeError
+
+    def add_to_scope(self, *args: str):
+        for arg in args:
+            self._scope.add(arg)
+
+    def discard_from_scope(self, *args: str):
+        for arg in args:
+            self._scope.discard(arg)
+
+    @property
+    def scope(self):
+        return " ".join(self._scope)
+
+    def _issue(self, token_type: str) -> str:
+        return jwt.encode(
+            {
+                "exp": datetime.datetime.utcnow() + self.SESSION_VALIDITY[token_type],
+                "scope": self.scope,
+            },
+            self.signature_key[token_type],
+            algorithm=self.SIGNATURE_ALGORITHM,
+        )
+
+    def issue(self) -> dict:
+        """Issue a new access and refresh token.
+        Previously issued refresh token is invalidated.
+        """
+        self.signature_key["refresh"] = get_random_key()
+        return {
+            "token": self._issue("access"),
+            "token_type": "bearer",
+            "expires_in": int(self.SESSION_VALIDITY["access"].total_seconds()),
+            "scope": self.scope,
+            "refresh_token": self._issue("refresh"),
+        }
+
+    def reset(self):
+        """Invalidate all previously issued tokens by creating new signature keys."""
+        self.signature_key = {
+            "access": get_random_key(),
+            "refresh": get_random_key(),
+        }

--- a/jmclient/test/test_auth.py
+++ b/jmclient/test/test_auth.py
@@ -1,0 +1,97 @@
+"""test auth module."""
+
+import copy
+import datetime
+
+import jwt
+import pytest
+
+from jmclient.auth import ExpiredSignatureError, InvalidScopeError, JMTokenAuthority
+
+
+class TestJMTokenAuthority:
+    wallet_name = "dummywallet"
+    token_auth = JMTokenAuthority(wallet_name)
+
+    access_sig = copy.copy(token_auth.signature_key["access"])
+    refresh_sig = copy.copy(token_auth.signature_key["refresh"])
+
+    validity = datetime.timedelta(hours=1)
+    scope = f"walletrpc {wallet_name}"
+
+    @pytest.mark.parametrize(
+        "sig, token_type", [(access_sig, "access"), (refresh_sig, "refresh")]
+    )
+    def test_verify_valid(self, sig, token_type):
+        token = jwt.encode(
+            {"exp": datetime.datetime.utcnow() + self.validity, "scope": self.scope},
+            sig,
+            algorithm=self.token_auth.SIGNATURE_ALGORITHM,
+        )
+
+        try:
+            self.token_auth.verify(token, token_type=token_type)
+        except Exception as e:
+            print(e)
+            pytest.fail("Token verification failed, token is valid.")
+
+    def test_verify_expired(self):
+        token = jwt.encode(
+            {"exp": datetime.datetime.utcnow() - self.validity, "scope": self.scope},
+            self.access_sig,
+            algorithm=self.token_auth.SIGNATURE_ALGORITHM,
+        )
+
+        with pytest.raises(ExpiredSignatureError):
+            self.token_auth.verify(token)
+
+    def test_verify_non_scoped(self):
+        token = jwt.encode(
+            {"exp": datetime.datetime.utcnow() + self.validity, "scope": "wrong"},
+            self.access_sig,
+            algorithm=self.token_auth.SIGNATURE_ALGORITHM,
+        )
+
+        with pytest.raises(InvalidScopeError):
+            self.token_auth.verify(token)
+
+    def test_issue(self):
+        def scope_equals(scope):
+            return set(scope.split(" ")) == set(self.scope.split(" "))
+
+        token_response = self.token_auth.issue()
+
+        assert token_response.pop("expires_in") == int(
+            self.token_auth.SESSION_VALIDITY["access"].total_seconds()
+        )
+        assert token_response.pop("token_type") == "bearer"
+        assert scope_equals(token_response.pop("scope"))
+
+        try:
+            for k, v in token_response.items():
+                claims = jwt.decode(
+                    v,
+                    self.token_auth.signature_key["refresh"]
+                    if k == "refresh_token"
+                    else self.token_auth.signature_key["access"],
+                    algorithms=self.token_auth.SIGNATURE_ALGORITHM,
+                )
+                assert scope_equals(claims.get("scope"))
+            assert self.token_auth.signature_key["refresh"] != self.refresh_sig
+        except jwt.exceptions.InvalidTokenError:
+            pytest.fail("An invalid token was issued.")
+
+    def test_scope_operation(self):
+        assert "walletrpc" in self.token_auth._scope
+        assert self.wallet_name in self.token_auth._scope
+
+        scope = copy.copy(self.token_auth._scope)
+        s = "new_wallet"
+
+        self.token_auth.add_to_scope(s)
+        assert scope < self.token_auth._scope
+        assert s in self.token_auth._scope
+
+        self.token_auth.discard_from_scope(s, "walletrpc")
+        assert scope > self.token_auth._scope
+        assert s not in self.token_auth._scope


### PR DESCRIPTION
Implement `jmclient.auth` module to manage JWT.

Upon successful authentication (e.g. unlock wallet), response includes both a `token` and a `refresh_token`. The former can be used for call authentication, valid for 30 min. After expiration, user can call `/token/refresh` endpoint with his expired access token in header and refresh token in POST call payload to get both a new access and refresh token. Refresh token is valid for 4 hours.

Anytime a new access token is issued, refresh token signature key is re-initialized, invalidating any previously issued token.
Tokens are scoped to a specific `wallet_name` and a generic `walletrpc` category, and should allow future upgrades such as authorization granularity. 

Fixes https://github.com/JoinMarket-Org/joinmarket-clientserver/issues/1297