### PR TITLE
Pin werkzeug dependency to 2.2.0

### DIFF
--- a/jmclient/setup.py
+++ b/jmclient/setup.py
@@ -12,6 +12,6 @@ setup(name='joinmarketclient',
       install_requires=['joinmarketbase==0.9.10dev', 'mnemonic==0.20',
                         'argon2_cffi==21.3.0', 'bencoder.pyx==3.0.1',
                         'pyaes==1.6.1', 'klein==20.6.0', 'pyjwt==2.4.0',
-                        'autobahn==20.12.3'],
+                        'autobahn==20.12.3', 'werkzeug==2.2.0'],
       python_requires='>=3.6',
       zip_safe=False)


### PR DESCRIPTION
Fixes #1483.
Prior to this commit, running the RPC API server using Klein failed due to a recent change in Werkzeug 2.3+, preventing any endpoint from returning anything but a 405 error. See
https://github.com/twisted/klein/pull/575.
After this commit we pin to 2.2.0 until such time as updated versions of werkzeug/Klein are reviewed by us.