### PR TITLE
Randomize transaction fees only upwards

### DIFF
--- a/jmclient/jmclient/blockchaininterface.py
+++ b/jmclient/jmclient/blockchaininterface.py
@@ -421,8 +421,7 @@ class BitcoinCoreInterface(BlockchainInterface):
             mempoolminfee_in_sat, mempoolminfee_in_sat * float(1 + tx_fees_factor))
 
         if super().fee_per_kb_has_been_manually_set(N):
-            N_res = random.uniform(N * float(1 - tx_fees_factor),
-                N * float(1 + tx_fees_factor))
+            N_res = random.uniform(N, N * float(1 + tx_fees_factor))
             if N_res < mempoolminfee_in_sat:
                 log.info("Using this mempool min fee as tx feerate: " +
                     btc.fee_per_kb_to_str(mempoolminfee_in_sat) + ".")
@@ -451,13 +450,12 @@ class BitcoinCoreInterface(BlockchainInterface):
             # the 'feerate' key is found and contains a positive value:
             if estimate and estimate > 0:
                 estimate_in_sat = btc.btc_to_sat(estimate)
-                retval = random.uniform(
-                    estimate_in_sat * float(1 - tx_fees_factor),
+                retval = random.uniform(estimate_in_sat,
                     estimate_in_sat * float(1 + tx_fees_factor))
                 break
         else:  # cannot get a valid estimate after `tries` tries:
             fallback_fee = 10000
-            retval = random.uniform(fallback_fee * float(1 - tx_fees_factor),
+            retval = random.uniform(fallback_fee,
                 fallback_fee * float(1 + tx_fees_factor))
             log.warn("Could not source a fee estimate from Core, " +
                      "falling back to default: " +

--- a/jmclient/jmclient/configure.py
+++ b/jmclient/jmclient/configure.py
@@ -279,10 +279,10 @@ merge_algorithm = default
 # while N=5 will use the 5 block estimate from your selected blockchain source.
 tx_fees = 3
 
-# Transaction fee rate variance factor, 0.2 means 20% variation around
-# any manually chosen values, so if you set tx_fees=10000 and
-# tx_fees_factor=0.2, it might use any value between 8 thousand and 12 thousand
-# for your transactions.
+# Transaction fee rate variance factor, 0.2 means fee will be random
+# between any manually chosen value and 20% above that value, so if you set
+# tx_fees=10000 and tx_fees_factor=0.2, it might use any value between
+# 10 thousand and 12 thousand for your transactions.
 tx_fees_factor = 0.2
 
 # For users getting transaction fee estimates over an API,


### PR DESCRIPTION
Resolves #1429.

This becomes more important in current high fee environment. For example, `estimatesmartfee 3` currently returns feerate around 164 sat/vB. With 20% default `tx_fee_factor` it means actual feerate used can go as low as 132 sat/vB, which is big difference. With simple non-cj sends people could bump fee with RBF if tx is not confirmed for too long, but not so with coinjoins, including payjoins. We are already randomizing only upwards `mempoolminfee`.

I wanted to do this after #1462, but that may take a lot of time and this seems urgent to me.