### PR TITLE
CI: Disable venv cache and remove editable installs

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -17,16 +17,16 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Cache venv
-        id: cache-venv
-        uses: actions/cache@v3
-        env:
-          cache-name: venv
-        with:
-          path: jmvenv
-          key: ${{ runner.os }}-${{ matrix.python-version }}-${{ env.cache-name }}-${{ hashFiles('requirements/*.txt', 'install.sh', '*/setup.py') }}
+#      - name: Cache venv
+#        id: cache-venv
+#        uses: actions/cache@v3
+#        env:
+#          cache-name: venv
+#        with:
+#          path: jmvenv
+#          key: ${{ runner.os }}-${{ matrix.python-version }}-${{ env.cache-name }}-${{ hashFiles('requirements/*.txt', 'install.sh', '*/setup.py') }}
       - name: Setup joinmarket + virtualenv
-        if: steps.cache-venv.outputs.cache-hit != 'true'
+#        if: steps.cache-venv.outputs.cache-hit != 'true'
         run: |
           ./install.sh --develop --with-qt
           ./jmvenv/bin/python -m pip install --upgrade pip

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -28,6 +28,8 @@ jobs:
       - name: Setup joinmarket + virtualenv
 #        if: steps.cache-venv.outputs.cache-hit != 'true'
         run: |
+          sed -i.bak 's/-e //g' requirements/base.txt
+          sed -i.bak 's/-e //g' requirements/gui.txt
           ./install.sh --develop --with-qt
           ./jmvenv/bin/python -m pip install --upgrade pip
           ./jmvenv/bin/pip install -r requirements/base.txt


### PR DESCRIPTION
See https://github.com/JoinMarket-Org/joinmarket-clientserver/pull/1479#issuecomment-1536741199. This seems to be at least increasing chances of CI to succeed. I commented out not removed venv cache part as a reminder that this is not what we want in a long term.

`sed -i.bak` not just `sed -i` is to be compatible with both GNU (Linux) and macOS sed.