### PR TITLE
Don't alter `LD_LIBRARY_PATH`, `PKG_CONFIG_PATH` and `C_INCLUDE_PATH` in tests

### DIFF
--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -172,9 +172,6 @@ run_jm_tests ()
     fi
     jm_requirements="requirements/testing.txt"
     jm_source="${VIRTUAL_ENV}/.."
-    export PKG_CONFIG_PATH="${PKG_CONFIG_PATH}:${VIRTUAL_ENV}/lib/pkgconfig"
-    export LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:${VIRTUAL_ENV}/lib"
-    export C_INCLUDE_PATH="${C_INCLUDE_PATH}:${VIRTUAL_ENV}/include"
 
     pushd "${jm_source}" || return 1
     if [ ! -f 'miniircd.tar.gz' ] || ! sha256_verify 'ce3a4ddc777343645ccd06ca36233b5777e218ee89d887ef529ece86a917fc33' 'miniircd.tar.gz'; then


### PR DESCRIPTION
Fixes #1430.

Problem was that, with altered `LD_LIBRARY_PATH`, for system wide installed `bitcoind`, `libsecp256k1.so.0` from jmvenv was loaded, not the one from `/usr/lib64`.

<del>I assume changes for `C_INCLUDE_PATH` may be needed to build miniircd, but don't see why `LD_LIBRARY_PATH` should be changed at all.</del>