### PR TITLE
CI: Remove unnecessary commands from setup joinmarket + virtualenv step

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -31,8 +31,6 @@ jobs:
           sed -i.bak 's/-e //g' requirements/base.txt
           sed -i.bak 's/-e //g' requirements/gui.txt
           ./install.sh --develop --with-qt
-          ./jmvenv/bin/python -m pip install --upgrade pip
-          ./jmvenv/bin/pip install -r requirements/base.txt
           ./jmvenv/bin/pip install -r requirements/testing.txt
       - name: Lint with flake8
         run: ./jmvenv/bin/flake8 -v jmclient jmbase jmbitcoin jmdaemon scripts


### PR DESCRIPTION
They are run by `install.sh`, no need to run them additionally afterwards.

If #1475 gets merged, `./jmvenv/bin/pip install -r requirements/testing.txt` can also be removed.