### PR TITLE
CI: Build local Tor by default and remove `--develop`

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -30,7 +30,7 @@ jobs:
         run: |
           sed -i.bak 's/-e //g' requirements/base.txt
           sed -i.bak 's/-e //g' requirements/gui.txt
-          ./install.sh --develop --with-qt
+          ./install.sh --with-local-tor --with-qt
           ./jmvenv/bin/pip install -r requirements/testing.txt
       - name: Lint with flake8
         run: ./jmvenv/bin/flake8 -v jmclient jmbase jmbitcoin jmdaemon scripts


### PR DESCRIPTION
We already build Qt GUI for tests and don't actually do anything with it, makes sense to also test building Tor. Also, remove `--develop`, as, since #1490 editable installs is removed, so adding legacy `--develop` flag makes no sense.

Somewhat related - #1496.