### PR TITLE
Add `**/build/` to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ scripts/snicker/snicker-proposals.txt
 scripts/snicker/candidates.txt
 .qt_for_python/
 cmtdata/
+**/build/


### PR DESCRIPTION
These are created when editable installs are manually removed (`-e` in `requirements/base.txt`).