### PR TITLE
Fix / remove `sys.version` checks

### DIFF
--- a/jmdaemon/jmdaemon/orderbookwatch.py
+++ b/jmdaemon/jmdaemon/orderbookwatch.py
@@ -69,11 +69,7 @@ class OrderbookWatch(object):
                       txfee, cjfee):
         try:
             self.dblock.acquire(True)
-            if sys.version_info >= (3,0):
-                maxint = sys.maxsize
-            else:
-                maxint = sys.maxint
-            if int(oid) < 0 or int(oid) > maxint:
+            if int(oid) < 0 or int(oid) > sys.maxsize:
                 log.debug("Got invalid order ID: " + oid + " from " +
                           counterparty)
                 return

--- a/setupall.py
+++ b/setupall.py
@@ -17,8 +17,8 @@ to libsodium.
 All modes require and install twisted.
 """
 
-if sys.version_info < (3, 3):
-    raise RuntimeError("This package requres Python 3.3+")
+if sys.version_info < (3, 6):
+    raise RuntimeError("This package requres Python 3.6+")
 
 def help():
     print("Usage: python setupall.py <mode>\n"


### PR DESCRIPTION
Python 2 is not supported anymore, so no need to check for Python 3+ and JM currently requires 3.6+ not 3.3+.