### PR TITLE
Add space between address and comma for added utxos msg for easier selection by double clicking

### DIFF
--- a/jmclient/jmclient/output.py
+++ b/jmclient/jmclient/output.py
@@ -46,7 +46,7 @@ def fmt_utxo(utxo):
     return utxostr
 
 def fmt_tx_data(tx_data, wallet_service):
-    return 'path: {}, address: {}, value: {}'.format(
+    return 'path: {}, address: {} , value: {}'.format(
         wallet_service.get_path_repr(wallet_service.script_to_path(tx_data['script'])),
         wallet_service.script_to_addr(tx_data['script']), tx_data['value'])
 


### PR DESCRIPTION
So that double clicking in terminal selects "address", not "address," in some terminal apps, for example, xfce4-terminal.

Before:
```
2023-07-17 19:25:38,528 [INFO]  Added utxos=         
 xxx:0 - path: m/84'/0'/2'/0/y, address: bc1qsomething, value: 123456 
```

After:
```
2023-07-17 19:25:38,528 [INFO]  Added utxos=             
xxx:0 - path: m/84'/0'/2'/0/y, address: bc1qsomething , value: 123456 
```