### PR TITLE
Drop Python 3.6 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ Download the latest [release](https://github.com/Joinmarket-Org/joinmarket-clien
 
 Make sure to validate the signature on the tar/zip file provided with the [release](https://github.com/Joinmarket-Org/joinmarket-clientserver/releases) (or check the signature in git if you install that way using `git log --show-signature`).
 
+JoinMarket requires Python 3.7 or newer installed.
+
 (**macOS users**: Make sure that you have Homebrew and Apple's Command Line Tools installed.)
 
     ./install.sh
@@ -46,8 +48,6 @@ Follow instructions on screen; provide sudo password when prompted, then when fi
     cd scripts
 
 You can optionally install a Qt GUI application, you will be prompted to choose this during installation.
-
-Do note, Python 2 is no longer supported as it has reached its end of life.
 
 You should now be able to run the scripts like `python wallet-tool.py` etc., just as you did in the previous Joinmarket version.
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -4,6 +4,8 @@
 * [Installation on Windows](#installation-on-windows)
 * [Alternative/custom installation](#alternativecustom-installation)
 
+JoinMarket requires Python 3.7 or newer.
+
 ### Notes on upgrading, binaries and compatibility
 
 (You can ignore this whole section if starting from scratch).

--- a/jmbase/setup.py
+++ b/jmbase/setup.py
@@ -10,6 +10,6 @@ setup(name='joinmarketbase',
       license='GPL',
       packages=['jmbase'],
       install_requires=['twisted==22.4.0', 'service-identity==21.1.0',
-                        'chromalog==1.0.5', 'pyaes==1.6.1'],
-      python_requires='>=3.6',
+                        'chromalog==1.0.5'],
+      python_requires='>=3.7',
       zip_safe=False)

--- a/jmbitcoin/setup.py
+++ b/jmbitcoin/setup.py
@@ -9,6 +9,6 @@ setup(name='joinmarketbitcoin',
       author_email='',
       license='GPL',
       packages=['jmbitcoin'],
-      python_requires='>=3.6',
-      install_requires=['python-bitcointx==1.1.3'],
+      python_requires='>=3.7',
+      install_requires=['python-bitcointx==1.1.3', 'pyaes==1.6.1'],
       zip_safe=False)

--- a/jmclient/setup.py
+++ b/jmclient/setup.py
@@ -13,5 +13,5 @@ setup(name='joinmarketclient',
                         'argon2_cffi==21.3.0', 'bencoder.pyx==3.0.1',
                         'klein==20.6.0', 'pyjwt==2.4.0',
                         'autobahn==20.12.3', 'werkzeug==2.2.3'],
-      python_requires='>=3.6',
+      python_requires='>=3.7',
       zip_safe=False)

--- a/jmdaemon/setup.py
+++ b/jmdaemon/setup.py
@@ -14,5 +14,5 @@ setup(name='joinmarketdaemon',
                         'cryptography==41.0.2; platform_machine == "aarch64" or platform_machine == "amd64" or platform_machine == "x86_64"',
                         'pyopenssl==23.2.0', 'libnacl==1.8.0',
                         'joinmarketbase==0.9.10dev'],
-      python_requires='>=3.6',
+      python_requires='>=3.7',
       zip_safe=False)

--- a/jmqtui/setup.py
+++ b/jmqtui/setup.py
@@ -9,7 +9,7 @@ setup(name='joinmarketui',
       license='GPL',
       packages=['jmqtui'],
       install_requires=['PyQt5!=5.15.0,!=5.15.1,!=5.15.2,!=6.0'],
-      python_requires='>=3.6',
+      python_requires='>=3.7',
       zip_safe=False)
 
 # The following command should be executed whenever `open_wallet_dialog.ui` is updated.

--- a/setupall.py
+++ b/setupall.py
@@ -17,8 +17,8 @@ to libsodium.
 All modes require and install twisted.
 """
 
-if sys.version_info < (3, 6):
-    raise RuntimeError("This package requres Python 3.6+")
+if sys.version_info < (3, 7):
+    raise RuntimeError("This package requres Python 3.7+")
 
 def help():
     print("Usage: python setupall.py <mode>\n"


### PR DESCRIPTION
It's EOL since end of 2021 and 3.7+ will be minimum for #1484.