### PR TITLE
Remove unnecessary imports from future

### DIFF
--- a/jmclient/test/test_taker.py
+++ b/jmclient/test/test_taker.py
@@ -1,4 +1,3 @@
-from future.utils import iteritems
 from commontest import DummyBlockchainInterface
 import jmbitcoin as bitcoin
 import binascii

--- a/scripts/add-utxo.py
+++ b/scripts/add-utxo.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-from future.utils import iteritems
 """A very simple command line tool to import utxos to be used
 as commitments into joinmarket's commitments.json file, allowing
 users to retry transactions more often without getting banned by

--- a/scripts/joinmarket-qt.py
+++ b/scripts/joinmarket-qt.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-from future.utils import iteritems
 
 '''
 Joinmarket GUI using PyQt for doing coinjoins.

--- a/scripts/obwatch/ob-watcher.py
+++ b/scripts/obwatch/ob-watcher.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-from future.utils import iteritems
 from past.builtins import cmp
 from functools import cmp_to_key
 
@@ -12,7 +11,6 @@ import time
 import hashlib
 import os
 import sys
-from future.moves.urllib.parse import parse_qs
 from decimal import Decimal
 from optparse import OptionParser
 from twisted.internet import reactor

--- a/scripts/yg-privacyenhanced.py
+++ b/scripts/yg-privacyenhanced.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-from future.utils import iteritems
 
 import random
 import sys

--- a/setupall.py
+++ b/setupall.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-from __future__ import print_function
 import sys, os, subprocess
 
 """A script to install in one of 3 modes:


### PR DESCRIPTION
They should not be needed, as we have dropped Python 2 support long time ago.