### PR TITLE
Fix `pyaes` dependency, should be in `jmbase`, not `jmbitcoin`

### DIFF
--- a/jmbase/setup.py
+++ b/jmbase/setup.py
@@ -10,6 +10,6 @@ setup(name='joinmarketbase',
       license='GPL',
       packages=['jmbase'],
       install_requires=['twisted==22.4.0', 'service-identity==21.1.0',
-                        'chromalog==1.0.5'],
+                        'chromalog==1.0.5', 'pyaes==1.6.1'],
       python_requires='>=3.7',
       zip_safe=False)

--- a/jmbitcoin/setup.py
+++ b/jmbitcoin/setup.py
@@ -10,5 +10,5 @@ setup(name='joinmarketbitcoin',
       license='GPL',
       packages=['jmbitcoin'],
       python_requires='>=3.7',
-      install_requires=['python-bitcointx==1.1.3', 'pyaes==1.6.1'],
+      install_requires=['python-bitcointx==1.1.3'],
       zip_safe=False)


### PR DESCRIPTION
Mistake was made while merging #1512.