### PR TITLE
RPC-API: read gaplimit from config

### DIFF
--- a/jmclient/jmclient/configure.py
+++ b/jmclient/jmclient/configure.py
@@ -267,6 +267,11 @@ native = true
 # but don't forget to bump your miner fees!
 merge_algorithm = default
 
+# Used currently by the RPC to modify the gap limit
+# for address searching during wallet sync. Command line
+# scripts can use the command line flag `-g` instead.
+gaplimit = 6
+
 # The fee estimate is based on a projection of how many sats/kilo-vbyte
 # are needed to get in one of the next N blocks. N is set here as
 # the value of 'tx_fees'. This cost estimate is high if you set
@@ -508,8 +513,6 @@ minsize = 100000
 
 # [fraction, 0-1] / variance around all offer sizes. Ex: 500k minsize, 0.1 var = 450k-550k
 size_factor = 0.1
-
-gaplimit = 6
 
 [SNICKER]
 # Any other value than 'true' will be treated as False,

--- a/jmclient/jmclient/wallet_rpc.py
+++ b/jmclient/jmclient/wallet_rpc.py
@@ -987,7 +987,8 @@ class JMWalletDaemon(Service):
                 wallet = open_test_wallet_maybe(
                         wallet_path, walletname, 4,
                         password=password.encode("utf-8"),
-                        ask_for_password=False)
+                        ask_for_password=False,
+                        gap_limit = jm_single().config.getint("POLICY", "gaplimit"))
             except StoragePasswordError:
                 raise NotAuthorized()
             except RetryableStorageError:

--- a/jmclient/jmclient/wallet_utils.py
+++ b/jmclient/jmclient/wallet_utils.py
@@ -1451,7 +1451,8 @@ def create_wallet(path, password, max_mixdepth, wallet_cls, **kwargs):
     wallet_cls.initialize(storage, get_network(), max_mixdepth=max_mixdepth,
                           **kwargs)
     storage.save()
-    return wallet_cls(storage)
+    return wallet_cls(storage,
+                gap_limit=jm_single().config.getint("POLICY", "gaplimit"))
 
 
 def open_test_wallet_maybe(path, seed, max_mixdepth,


### PR DESCRIPTION
Prior to this commit, an attempt to change the gap limit used in wallet syncing, by setting gaplimit in the config via configset, would fail, since gaplimit was only being read from command line options. After this commit, the value of gaplimit in the POLICY section of the config, defaulting to 6, will be read and used in Wallet object creation, either via the createwallet or recoverwallet endpoints, or via the wallet opening operation in the unlockwallet endpoint. This can be used in combination with the rescanblockchain endpoint to allow discovery of funds in addresses beyond the default gap.