### PR TITLE
build(deps): update tor from v0.4.7.13 to v0.4.8.7

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -408,9 +408,9 @@ tor_build ()
 
 tor_install ()
 {
-    tor_version='tor-0.4.7.13'
+    tor_version='tor-0.4.8.7'
     tor_tar="${tor_version}.tar.gz"
-    tor_sha='2079172cce034556f110048e26083ce9bea751f3154b0ad2809751815b11ea9d'
+    tor_sha='b20d2b9c74db28a00c07f090ee5b0241b2b684f3afdecccc6b8008931c557491'
     tor_url='https://dist.torproject.org'
     tor_pubkeys='Tor.asc'
 


### PR DESCRIPTION
Updates local tor from  v0.4.7.13 to v0.4.8.7.

~~Release notes: https://gitlab.torproject.org/tpo/core/tor/-/commit/51cefce3e689461492d22275b0bcac36db61ac8e~~