### PR TITLE
fix(docs): remove duplicate keys in wallet-rpc.md

### DIFF
--- a/docs/api/wallet-rpc.yaml
+++ b/docs/api/wallet-rpc.yaml
@@ -88,7 +88,7 @@ paths:
             type: string
       responses:
         '200':
-          $ref: "#/components/responses/Unlock-200-OK"
+          $ref: '#/components/responses/Unlock-200-OK'
         '400':
           $ref: '#/components/responses/400-BadRequest'
         '401':
@@ -119,7 +119,7 @@ paths:
             type: string
       responses:
         '200':
-          $ref: "#/components/responses/Lock-200-OK"
+          $ref: '#/components/responses/Lock-200-OK'
         '400':
           $ref: '#/components/responses/400-BadRequest'
         '401':
@@ -142,7 +142,7 @@ paths:
             type: string
       responses:
         '200':
-          $ref: "#/components/responses/Display-200-OK"
+          $ref: '#/components/responses/Display-200-OK'
         '400':
           $ref: '#/components/responses/400-BadRequest'
         '401':
@@ -161,7 +161,7 @@ paths:
       description: get whether a wallet is loaded and whether coinjoin/maker are happening. if an auth token is provided, which is optional, it will be validated.
       responses:
         '200':
-          $ref: "#/components/responses/Session-200-OK"
+          $ref: '#/components/responses/Session-200-OK'
         '401':
           $ref: '#/components/responses/401-AuthenticationError'
         '403':
@@ -177,7 +177,7 @@ paths:
       description: get information about backend, including the version of Joinmarket running.
       responses:
         '200':
-          $ref: "#/components/responses/Getinfo-200-OK"
+          $ref: '#/components/responses/Getinfo-200-OK'
   /wallet/all:
     get:
       summary: get current available wallets
@@ -185,7 +185,7 @@ paths:
       description: get all wallet filenames in standard location as a list
       responses:
         '200':
-          $ref: "#/components/responses/ListWallets-200-OK"
+          $ref: '#/components/responses/ListWallets-200-OK'
         '404':
           $ref: '#/components/responses/404-NotFound'
   /wallet/yieldgen/report:
@@ -199,7 +199,7 @@ paths:
         The header line is also delivered and so can be ignored as per the client requirements.
       responses:
         '200':
-          $ref: "#/components/responses/YieldGenReport-200-OK"
+          $ref: '#/components/responses/YieldGenReport-200-OK'
         '404':
           $ref: '#/components/responses/404-NotFound'
   /wallet/{walletname}/address/new/{mixdepth}:
@@ -224,7 +224,7 @@ paths:
             type: string
       responses:
         '200':
-          $ref: "#/components/responses/GetAddress-200-OK"
+          $ref: '#/components/responses/GetAddress-200-OK'
         '400':
           $ref: '#/components/responses/400-BadRequest'
         '401':
@@ -255,7 +255,7 @@ paths:
             type: integer
       responses:
         '200':
-          $ref: "#/components/responses/RescanBlockchain-200-OK"
+          $ref: '#/components/responses/RescanBlockchain-200-OK'
         '400':
           $ref: '#/components/responses/400-BadRequest'
         '401':
@@ -288,7 +288,7 @@ paths:
             example: "2021-09"
       responses:
         '200':
-          $ref: "#/components/responses/GetAddress-200-OK"
+          $ref: '#/components/responses/GetAddress-200-OK'
         '400':
           $ref: '#/components/responses/400-BadRequest'
         '401':
@@ -314,7 +314,7 @@ paths:
             example: "2021-09"
       responses:
         '200':
-          $ref: "#/components/responses/ListUtxos-200-OK"
+          $ref: '#/components/responses/ListUtxos-200-OK'
         '400':
           $ref: '#/components/responses/400-BadRequest'
         '401':
@@ -345,7 +345,7 @@ paths:
         description: transaction creation parameters
       responses:
         '200':
-          $ref: "#/components/responses/DirectSend-200-Accepted"
+          $ref: '#/components/responses/DirectSend-200-Accepted'
         '400':
           $ref: '#/components/responses/400-BadRequest'
         '401':
@@ -380,11 +380,9 @@ paths:
       responses:
         # note we use a default response, no data returned:
         '202':
-          $ref: "#/components/responses/202-Accepted"
+          $ref: '#/components/responses/202-Accepted'
         '400':
           $ref: '#/components/responses/400-BadRequest'
-        '401':
-          $ref: '#/components/responses/401-Unauthorized'
         '401':
           $ref: '#/components/responses/401-AuthenticationError'
         '403':
@@ -411,11 +409,9 @@ paths:
             type: string
       responses:
         '202':
-          $ref: "#/components/responses/202-Accepted"
+          $ref: '#/components/responses/202-Accepted'
         '400':
           $ref: '#/components/responses/400-BadRequest'
-        '401':
-          $ref: "#/components/responses/401-Unauthorized"
         '401':
           $ref: '#/components/responses/401-AuthenticationError'
         '403':
@@ -444,11 +440,9 @@ paths:
         description: taker side coinjoin parameters
       responses:
         '202':
-          $ref: "#/components/responses/202-Accepted"
+          $ref: '#/components/responses/202-Accepted'
         '400':
           $ref: '#/components/responses/400-BadRequest'
-        '401':
-          $ref: '#/components/responses/401-Unauthorized'
         '401':
           $ref: '#/components/responses/401-AuthenticationError'
         '403':
@@ -481,11 +475,9 @@ paths:
         description: taker side schedule parameters
       responses:
         '202':
-          $ref: "#/components/responses/RunSchedule-202-OK"
+          $ref: '#/components/responses/RunSchedule-202-OK'
         '400':
           $ref: '#/components/responses/400-BadRequest'
-        '401':
-          $ref: '#/components/responses/401-Unauthorized'
         '401':
           $ref: '#/components/responses/401-AuthenticationError'
         '403':
@@ -511,11 +503,11 @@ paths:
             type: string
       responses:
         '200':
-          $ref: "#/components/responses/GetSchedule-200-OK"
+          $ref: '#/components/responses/GetSchedule-200-OK'
         '400':
           $ref: '#/components/responses/400-BadRequest'
         '401':
-          $ref: "#/components/responses/401-AuthenticationError"
+          $ref: '#/components/responses/401-AuthenticationError'
         '403':
           $ref: '#/components/responses/403-Forbidden'
         '404':
@@ -536,11 +528,9 @@ paths:
             type: string
       responses:
         '202':
-          $ref: "#/components/responses/202-Accepted"
+          $ref: '#/components/responses/202-Accepted'
         '400':
           $ref: '#/components/responses/400-BadRequest'
-        '401':
-          $ref: "#/components/responses/401-Unauthorized"
         '401':
           $ref: '#/components/responses/401-AuthenticationError'
         '403':
@@ -569,7 +559,7 @@ paths:
         description: config editing parameters
       responses:
         '200':
-          $ref: "#/components/responses/ConfigSet-200-OK"
+          $ref: '#/components/responses/ConfigSet-200-OK'
         '400':
           $ref: '#/components/responses/400-BadRequest'
         '401':
@@ -599,11 +589,11 @@ paths:
               $ref: '#/components/schemas/ConfigGetRequest'
       responses:
         '200':
-          $ref: "#/components/responses/ConfigGet-200-OK"
+          $ref: '#/components/responses/ConfigGet-200-OK'
         '400':
           $ref: '#/components/responses/400-BadRequest'
         '401':
-          $ref: "#/components/responses/401-AuthenticationError"
+          $ref: '#/components/responses/401-AuthenticationError'
         '403':
           $ref: '#/components/responses/403-Forbidden'
         '409':
@@ -630,11 +620,11 @@ paths:
         description: utxo string and freeze toggle as boolean
       responses:
         '200':
-          $ref: "#/components/responses/Freeze-200-OK"
+          $ref: '#/components/responses/Freeze-200-OK'
         '400':
           $ref: '#/components/responses/400-BadRequest'
         '401':
-          $ref: "#/components/responses/401-AuthenticationError"
+          $ref: '#/components/responses/401-AuthenticationError'
         '403':
           $ref: '#/components/responses/403-Forbidden'
   /wallet/{walletname}/getseed:
@@ -658,11 +648,11 @@ paths:
               $ref: '#/components/schemas/GetSeedResponse'
       responses:
         '200':
-          $ref: "#/components/responses/GetSeed-200-OK"
+          $ref: '#/components/responses/GetSeed-200-OK'
         '400':
           $ref: '#/components/responses/400-BadRequest'
         '401':
-          $ref: "#/components/responses/401-AuthenticationError"
+          $ref: '#/components/responses/401-AuthenticationError'
         '403':
           $ref: '#/components/responses/403-Forbidden'
 components:


### PR DESCRIPTION
Resolves #1552.

This is a hot fix to make the api docs served at https://joinmarket-org.github.io/joinmarket-clientserver/api/ work again. 

Removes
```
'401':
  $ref: "#/components/responses/401-Unauthorized"
```
in favor of 
```
'401':
  $ref: '#/components/responses/401-AuthenticationError'
```
when both are present.

This PR does not remove response `401-Unauthorized` completely, as it is still used and I am not totally sure which one of them is actually returned.

## How to test
```
cd docs/api
python3 -m http.server 9999
```
Then visit `http://localhost:9999` and verify that the page loads as expected.