### PR TITLE
JWT follow-up

### DIFF
--- a/docs/api/wallet-rpc.yaml
+++ b/docs/api/wallet-rpc.yaml
@@ -21,7 +21,7 @@ paths:
         On initially creating, unlocking or recovering a wallet, store both the refresh and access tokens, the latter is valid for only 30 minutes (must be used for any authenticated call) while the former is for 4 hours (can only be used in the refresh request parameters). Use /token endpoint on a regular basis to get new access and refresh tokens, ideally before access token expiration to avoid authentication errors and in any case, before refresh token expiration. The newly issued tokens must be used in subsequent calls since operation invalidates previously issued tokens.
       responses:
         '200':
-          $ref: '#/components/responses/RefreshToken-200-OK'
+          $ref: '#/components/responses/Token-200-OK'
         '400':
           $ref: '#/components/responses/400-BadRequest'
       requestBody:
@@ -579,11 +579,6 @@ paths:
           required: true
           schema:
             type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/GetSeedResponse'
       responses:
         '200':
           $ref: '#/components/responses/GetSeed-200-OK'
@@ -684,7 +679,7 @@ components:
         token_type:
           type: string
         expires_in:
-          type: int
+          type: integer
         scope:
           type: string
         refresh_token:

--- a/src/jmclient/auth.py
+++ b/src/jmclient/auth.py
@@ -1,5 +1,6 @@
 import datetime
 import os
+from base64 import b64encode
 
 import jwt
 
@@ -18,6 +19,9 @@ def get_random_key(size: int = 16) -> str:
     """Create a random key has an hexadecimal string."""
     return bintohex(os.urandom(size))
 
+
+def b64str(s: str) -> str:
+    return b64encode(s.encode()).decode()
 
 class JMTokenAuthority:
     """Manage authorization tokens."""
@@ -57,13 +61,13 @@ class JMTokenAuthority:
         if not self._scope <= token_claims:
             raise InvalidScopeError
 
-    def add_to_scope(self, *args: str):
+    def add_to_scope(self, *args: str, encoded: bool = True):
         for arg in args:
-            self._scope.add(arg)
+            self._scope.add(b64str(arg) if encoded else arg)
 
-    def discard_from_scope(self, *args: str):
+    def discard_from_scope(self, *args: str, encoded: bool = True):
         for arg in args:
-            self._scope.discard(arg)
+            self._scope.discard(b64str(arg) if encoded else arg)
 
     @property
     def scope(self):

--- a/test/jmclient/test_websocket.py
+++ b/test/jmclient/test_websocket.py
@@ -21,7 +21,8 @@ test_tx_hex_1 = "02000000000102578770b2732aed421ffe62d54fd695cf281ca336e4f686d2a
 test_tx_hex_txid = "ca606efc5ba8f6669ba15e9262e5d38e745345ea96106d5a919688d1ff0da0cc"
 
 # Shared JWT token authority for test:
-test_token_authority = JMTokenAuthority("dummywallet")
+token_authority = JMTokenAuthority()
+
 
 class ClientTProtocol(WebSocketClientProtocol):
     """
@@ -29,11 +30,11 @@ class ClientTProtocol(WebSocketClientProtocol):
     message every 2 seconds and print everything it receives.
     """
 
+    ACCESS_TOKEN = token_authority.issue()["token"].encode("utf8")
+
     def sendAuth(self):
-        """ Our server will not broadcast
-        to us unless we authenticate.
-        """
-        self.sendMessage(test_token_authority.issue()["token"].encode('utf8'))
+        """Our server will not broadcast to us unless we authenticate."""
+        self.sendMessage(self.ACCESS_TOKEN)
 
     def onOpen(self):
         # auth on startup
@@ -65,7 +66,7 @@ class WebsocketTestBase(object):
             free_ports = get_free_tcp_ports(1)
             self.wss_port = free_ports[0]
         self.wss_url = "ws://127.0.0.1:" + str(self.wss_port)
-        self.wss_factory = JmwalletdWebSocketServerFactory(self.wss_url, test_token_authority)
+        self.wss_factory = JmwalletdWebSocketServerFactory(self.wss_url, token_authority)
         self.wss_factory.protocol = JmwalletdWebSocketServerProtocol
         self.listeningport = listenWS(self.wss_factory, contextFactory=None)
         self.test_tx = CTransaction.deserialize(hextobin(test_tx_hex_1))


### PR DESCRIPTION
- Fix JWT unit tests (`async` was somehow making tests always successful therefore hiding some issues)
- Fix `WWW-Authenticate` header construction (https://github.com/JoinMarket-Org/joinmarket-clientserver/pull/1480#issuecomment-1731692496)
- Encode wallet names with base64 in scopes to allow for space delimited names (https://github.com/JoinMarket-Org/joinmarket-clientserver/pull/1480#issuecomment-1729669816, https://github.com/joinmarket-webui/jam/issues/663#issuecomment-1735191541)
- Fix syntax errors in OpenAPI RPC documentation (https://github.com/JoinMarket-Org/joinmarket-clientserver/issues/1559)