### PR TITLE
Update `txtorcon` to 23.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
     "chromalog==1.0.5",
     "pyaes==1.6.1",
     "service-identity==21.1.0",
-    "txtorcon==22.0.0",
+    "txtorcon==23.0.0",
     "twisted==22.4.0",
 ]
 


### PR DESCRIPTION
Replaces #1558.

Changes:

* Drop Python2 support
* Fix a bug with stream updates (and CONTROLLER_WAIT)

https://github.com/meejah/txtorcon/releases/tag/v23.0.0