### PR TITLE
Log in case JM loads RPC wallet at startup

### DIFF
--- a/src/jmclient/blockchaininterface.py
+++ b/src/jmclient/blockchaininterface.py
@@ -338,7 +338,9 @@ class BitcoinCoreInterface(BlockchainInterface):
             # Check that RPC wallet is loaded. If not, try to load it.
             loaded_wallets = self._rpc("listwallets", [])
             if not wallet_name in loaded_wallets:
+                log.info("Loading Bitcoin RPC wallet " + wallet_name + "...")
                 self._rpc("loadwallet", [wallet_name])
+                log.info("Done.")
             # We only support legacy wallets currently
             wallet_info = self._getwalletinfo()
             if "descriptors" in wallet_info and wallet_info["descriptors"]:


### PR DESCRIPTION
There are some cases when this operation can be slow, better log. Otherwise user might think JM just hanged up.

In my case I was doing some testing on ARM machine where I don't run JM everyday, so that wallet haven't been used for a long time and Core needed to do rescan for almost 8000 blocks.