### PR TITLE
feat(rpc): add block height to session response

### DIFF
--- a/docs/api/wallet-rpc.yaml
+++ b/docs/api/wallet-rpc.yaml
@@ -849,6 +849,8 @@ components:
           type: string
         rescanning:
           type: boolean
+        block_height:
+          type: integer
     ListUtxosResponse:
       type: object
       properties:

--- a/src/jmclient/wallet_rpc.py
+++ b/src/jmclient/wallet_rpc.py
@@ -717,6 +717,8 @@ class JMWalletDaemon(Service):
             # rescanning, but that would be a strange scenario:
             rescanning = False
 
+            block_height = None
+
             if self.services["wallet"]:
                 if self.services["wallet"].isRunning():
                     rescanning, _ = self.services["wallet"].get_backend_wallet_rescan_status()
@@ -725,6 +727,8 @@ class JMWalletDaemon(Service):
                     # by the call to `check_cookie_if_present` above.
                     auth_header = request.getHeader('Authorization')
                     if auth_header is not None:
+                        block_height = self.services["wallet"].current_blockheight
+
                         if self.coinjoin_state == CJ_TAKER_RUNNING and \
                            self.tumbler_options is not None:
                                 if self.taker is not None and not self.taker.aborted:
@@ -751,6 +755,7 @@ class JMWalletDaemon(Service):
                 offer_list=offer_list,
                 nickname=nickname,
                 rescanning=rescanning,
+                block_height=block_height,
             )
 
         @app.route('/wallet/<string:walletname>/taker/direct-send', methods=['POST'])


### PR DESCRIPTION
Adds the current block height to the `/session` response.

This can be useful for api clients to display a more sophisticated message on how long to wait for a given UTXO when it has less than 5 confirmations (for [sourcing commitments](https://github.com/JoinMarket-Org/joinmarket-clientserver/blob/master/docs/SOURCING-COMMITMENTS.md#wait-for-at-least-5-confirmations)). `/session` is usually polled, so when the block height changes, additional information can be reloaded (instead of polling the `/wallet/{walletname}/utxos` endpoint).

The value is only included for authenticated requests when a wallet is loaded.
Additionally, block height changes could be pushed via websocket. However, this is not included in this PR.