### PR TITLE
Bump `cryptography` to 41.0.4 for all platforms

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,11 +11,10 @@ requires-python = ">=3.7"
 license = {file = "LICENSE"}
 dependencies = [
     "chromalog==1.0.5",
+    "cryptography==41.0.4",
     "service-identity==21.1.0",
     "twisted==22.4.0",
     "txtorcon==23.0.0",
-    'cryptography==3.3.2; platform_machine != "aarch64" and platform_machine != "amd64" and platform_machine != "x86_64"',
-    'cryptography==41.0.2; platform_machine == "aarch64" or platform_machine == "amd64" or platform_machine == "x86_64"',
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Remove conditions for old `cryptography` for 32-bit platforms. Back in a day it was pinned to v3.3.2, because newer versions introduced Rust as a dependency and 32-bit platforms don't have pre-built wheels. I think we should get rid of this hack - 1) not much people are running 32-bit OSes anymore (years ago default Raspberry Pi OS was 32-bit even for 64-bit boards, that's not true anymore), 2) none of developers actually tests stuff on these platforms and against such old `cryptography` versions, 3) it should be still possible to use JM with 32-bit archs, just local installation of Rust will be needed to build.

Also bump to v41.0.4, as v41.0.2 and v41.0.3 is statically linked with vulnerable versions of OpenSSL (although these vulnerabilities should not affect JM).

