### PR TITLE
Replace readfp

### DIFF
--- a/src/jmclient/configure.py
+++ b/src/jmclient/configure.py
@@ -702,7 +702,7 @@ def _remove_unwanted_default_settings(config: ConfigParser) -> None:
 
 def load_program_config(config_path: str = "", bs: Optional[str] = None,
                         plugin_services: List[JMPluginService] = []) -> None:
-    global_singleton.config.readfp(io.StringIO(defaultconfig))
+    global_singleton.config.read_file(io.StringIO(defaultconfig))
     if not config_path:
         config_path = lookup_appdata_folder(global_singleton.APPNAME)
     # we set the global home directory, but keep the config_path variable


### PR DESCRIPTION
Replace `ConfigParser.readfp()` with `ConfigParser.read_file()`  as per Python [docs](https://docs.python.org/3/library/configparser.html?highlight=configparser#configparser.ConfigParser.read_file)

The latter is available as from Python v3.2 while the former breaks as from v3.12