### PR TITLE
Testing on minimum-required and latest Python version only

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, ubuntu-latest]
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.7", "3.11"]
         bitcoind-version: ["0.18.0", "25.1"]
 
     steps:


### PR DESCRIPTION
Taking the same approach as `bitcoind` version testing, setting only minimum required and latest Python version in CI. Testing so many versions does not bring much added value IMHO. 