### PR TITLE
fix Dockerfile gpg err

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /jm/clientserver
 
 COPY . .
 
-RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates=* curl=* \
+RUN apt-get update && apt-get install -y --no-install-recommends gnupg ca-certificates=* curl=* \
   python3-pip=* python3=* \
   && pip3 install 'wheel>=0.35.1' \
   && ./install.sh --docker-install \


### PR DESCRIPTION
solve this at build:
```
GPG not installed, cannot verify release signatures; install gpg or use --no-gpg-validation.                                                  
Terminated
```