### PR TITLE
Fix ShellCheck warnings and add ShellCheck to CI

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -14,6 +14,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+      - name: Run ShellCheck
+        uses: ludeeus/action-shellcheck@master
+        with:
+          version: v0.9.0
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -181,7 +181,7 @@ run_jm_tests ()
         mkdir -p miniircd
         tar -xzf miniircd.tar.gz -C ./miniircd --strip-components=1
     fi
-    if ! pip install -e .[test]; then
+    if ! pip install -e '.[test]'; then
         echo "Joinmarket could not be installed. Exiting."
         return 1
     fi

--- a/test/testrunner/install_bitcoind.sh
+++ b/test/testrunner/install_bitcoind.sh
@@ -10,7 +10,7 @@ fi
 if [[ "$(uname)" == "Linux" ]]; then
     platform="x86_64-linux-gnu"
 elif [[ "$(uname)" == "Darwin" ]]; then
-    if [[ $BITCOIND_VERSION > 23.0 || $BITCOIND_VERSION == 23.0 ]]; then
+    if [[ $(echo "$BITCOIND_VERSION > 23.0" | bc) == 1 || $(echo "$BITCOIND_VERSION == 23.0" | bc) == 1 ]]; then
         platform="x86_64-apple-darwin"
     else
         platform="osx64"
@@ -20,16 +20,16 @@ else
     exit 1
 fi
 
-if sudo cp ~/bitcoin/bitcoin-$BITCOIND_VERSION/bin/bitcoind /usr/local/bin/bitcoind
+if sudo cp "$HOME/bitcoin/bitcoin-$BITCOIND_VERSION/bin/bitcoind" /usr/local/bin/bitcoind
 then
     echo "found cached bitcoind"
-    sudo cp ~/bitcoin/bitcoin-$BITCOIND_VERSION/bin/bitcoin-cli /usr/local/bin/bitcoin-cli
+    sudo cp "$HOME/bitcoin/bitcoin-$BITCOIND_VERSION/bin/bitcoin-cli" /usr/local/bin/bitcoin-cli
 else
     mkdir -p ~/bitcoin && \
     pushd ~/bitcoin && \
-    wget https://bitcoincore.org/bin/bitcoin-core-$BITCOIND_VERSION/bitcoin-$BITCOIND_VERSION-$platform.tar.gz && \
-    tar xvfz bitcoin-$BITCOIND_VERSION-$platform.tar.gz && \
-    sudo cp ./bitcoin-$BITCOIND_VERSION/bin/bitcoind /usr/local/bin/bitcoind && \
-    sudo cp ./bitcoin-$BITCOIND_VERSION/bin/bitcoin-cli /usr/local/bin/bitcoin-cli && \
+    wget "https://bitcoincore.org/bin/bitcoin-core-$BITCOIND_VERSION/bitcoin-$BITCOIND_VERSION-$platform.tar.gz" && \
+    tar xvfz "bitcoin-$BITCOIND_VERSION-$platform.tar.gz" && \
+    sudo cp "./bitcoin-$BITCOIND_VERSION/bin/bitcoind" /usr/local/bin/bitcoind && \
+    sudo cp "./bitcoin-$BITCOIND_VERSION/bin/bitcoin-cli" /usr/local/bin/bitcoin-cli && \
     popd
 fi


### PR DESCRIPTION
Could use `./test/lint/lint-shell.sh` instead, but this way was simpler.

https://github.com/marketplace/actions/shellcheck