### PR TITLE
Improve performance with better algorithms and caching of expensive computed values

### DIFF
--- a/src/jmclient/wallet.py
+++ b/src/jmclient/wallet.py
@@ -921,7 +921,8 @@ class BaseWallet(object):
         returns:
             script
         """
-        raise NotImplementedError()
+        priv, engine = self._get_key_from_path(path)
+        return engine.key_to_script(priv)
 
     def get_script(self, mixdepth, address_type, index):
         path = self.get_path(mixdepth, address_type, index)
@@ -1932,13 +1933,6 @@ class ImportWalletMixin(object):
             return super().get_details(path)
         return path[1], 'imported', path[2]
 
-    def get_script_from_path(self, path):
-        if not self._is_imported_path(path):
-            return super().get_script_from_path(path)
-
-        priv, engine = self._get_key_from_path(path)
-        return engine.key_to_script(priv)
-
 
 class BIP39WalletMixin(object):
     """
@@ -2116,7 +2110,7 @@ class BIP32Wallet(BaseWallet):
 
     def get_script_from_path(self, path):
         if not self._is_my_bip32_path(path):
-            raise WalletError("unable to get script for unknown key path")
+            return super().get_script_from_path(path)
 
         md, address_type, index = self.get_details(path)
 
@@ -2132,10 +2126,7 @@ class BIP32Wallet(BaseWallet):
             #concept of a "next address" cant be used
             return self.get_new_script_override_disable(md, address_type)
 
-        priv, engine = self._get_key_from_path(path)
-        script = engine.key_to_script(priv)
-
-        return script
+        return super().get_script_from_path(path)
 
     def get_path(self, mixdepth=None, address_type=None, index=None):
         if mixdepth is not None:

--- a/src/jmclient/wallet.py
+++ b/src/jmclient/wallet.py
@@ -543,29 +543,20 @@ class BaseWallet(object):
         privkey = self._get_key_from_path(path)[0]
         return privkey
 
-    def _get_addr_int_ext(self, address_type, mixdepth):
-        if address_type == self.ADDRESS_TYPE_EXTERNAL:
-            script = self.get_external_script(mixdepth)
-        elif address_type == self.ADDRESS_TYPE_INTERNAL:
-            script = self.get_internal_script(mixdepth)
-        else:
-            assert 0
-        return self.script_to_addr(script)
-
     def get_external_addr(self, mixdepth):
         """
         Return an address suitable for external distribution, including funding
         the wallet from other sources, or receiving payments or donations.
         JoinMarket will never generate these addresses for internal use.
         """
-        return self._get_addr_int_ext(self.ADDRESS_TYPE_EXTERNAL, mixdepth)
+        return self.get_new_addr(mixdepth, self.ADDRESS_TYPE_EXTERNAL)
 
     def get_internal_addr(self, mixdepth):
         """
         Return an address for internal usage, as change addresses and when
         participating in transactions initiated by other parties.
         """
-        return self._get_addr_int_ext(self.ADDRESS_TYPE_INTERNAL, mixdepth)
+        return self.get_new_addr(mixdepth, self.ADDRESS_TYPE_INTERNAL)
 
     def get_external_script(self, mixdepth):
         return self.get_new_script(mixdepth, self.ADDRESS_TYPE_EXTERNAL)

--- a/src/jmclient/wallet.py
+++ b/src/jmclient/wallet.py
@@ -2233,7 +2233,6 @@ class BIP32Wallet(BaseWallet):
         self._index_cache[mixdepth][address_type] = index
 
     def get_index_cache_and_increment(self, mixdepth, address_type):
-        index = self._index_cache[mixdepth][address_type]
         cur_index = self._index_cache[mixdepth][address_type]
         self._set_index_cache(mixdepth, address_type, cur_index + 1)
         return cur_index

--- a/src/jmclient/wallet.py
+++ b/src/jmclient/wallet.py
@@ -2208,7 +2208,7 @@ class BIP32Wallet(BaseWallet):
             self._ENGINE
 
     def _is_my_bip32_path(self, path):
-        return path[0] == self._key_ident
+        return len(path) > 0 and path[0] == self._key_ident
 
     def is_standard_wallet_script(self, path):
         return self._is_my_bip32_path(path)

--- a/src/jmclient/wallet.py
+++ b/src/jmclient/wallet.py
@@ -2234,10 +2234,6 @@ class BIP32Wallet(BaseWallet):
         self._script_map[script] = path
         return script
 
-    def get_script(self, mixdepth, address_type, index):
-        path = self.get_path(mixdepth, address_type, index)
-        return self.get_script_from_path(path)
-
     @deprecated
     def get_key(self, mixdepth, address_type, index):
         path = self.get_path(mixdepth, address_type, index)
@@ -2526,14 +2522,6 @@ class FidelityBondMixin(object):
 
     def _get_default_used_indices(self):
         return {x: [0, 0, 0, 0] for x in range(self.max_mixdepth + 1)}
-
-    def get_script(self, mixdepth, address_type, index):
-        path = self.get_path(mixdepth, address_type, index)
-        return self.get_script_from_path(path)
-
-    def get_addr(self, mixdepth, address_type, index):
-        script = self.get_script(mixdepth, address_type, index)
-        return self.script_to_addr(script)
 
     def add_burner_output(self, path, txhex, block_height, merkle_branch,
             block_index, write=True):

--- a/src/jmclient/wallet_utils.py
+++ b/src/jmclient/wallet_utils.py
@@ -431,9 +431,6 @@ def wallet_showutxos(wallet_service, showprivkey):
         includeconfs=True)
     for md in utxos:
         (enabled, disabled) = get_utxos_enabled_disabled(wallet_service, md)
-        utxo_d = []
-        for k, v in disabled.items():
-            utxo_d.append(k)
         for u, av in utxos[md].items():
             success, us = utxo_to_utxostr(u)
             assert success
@@ -453,7 +450,7 @@ def wallet_showutxos(wallet_service, showprivkey):
                        'external': False,
                        'mixdepth': mixdepth,
                        'confirmations': av['confs'],
-                       'frozen': True if u in utxo_d else False}
+                       'frozen': u in disabled}
             if showprivkey:
                 unsp[us]['privkey'] = wallet_service.get_wif_path(av['path'])
             if locktime:

--- a/src/jmclient/wallet_utils.py
+++ b/src/jmclient/wallet_utils.py
@@ -407,8 +407,8 @@ def get_imported_privkey_branch(wallet_service, m, showprivkey):
         addr = wallet_service.get_address_from_path(path)
         script = wallet_service.get_script_from_path(path)
         balance = 0.0
-        for data in wallet_service.get_utxos_by_mixdepth(
-            include_disabled=True)[m].values():
+        for data in wallet_service.get_utxos_at_mixdepth(m,
+            include_disabled=True).values():
             if script == data['script']:
                 balance += data['value']
         status = ('used' if balance > 0.0 else 'empty')
@@ -1276,8 +1276,8 @@ def display_utxos_for_disable_choice_default(wallet_service, utxos_enabled,
 def get_utxos_enabled_disabled(wallet_service, md):
     """ Returns dicts for enabled and disabled separately
     """
-    utxos_enabled = wallet_service.get_utxos_by_mixdepth()[md]
-    utxos_all = wallet_service.get_utxos_by_mixdepth(include_disabled=True)[md]
+    utxos_enabled = wallet_service.get_utxos_at_mixdepth(md)
+    utxos_all = wallet_service.get_utxos_at_mixdepth(md, include_disabled=True)
     utxos_disabled_keyset = set(utxos_all).difference(set(utxos_enabled))
     utxos_disabled = {}
     for u in utxos_disabled_keyset:

--- a/test/jmclient/test_taker.py
+++ b/test/jmclient/test_taker.py
@@ -121,6 +121,11 @@ class DummyWallet(LegacyWallet):
         """
         return 'p2wpkh'
 
+    def _get_key_from_path(self, path):
+        if path[0] == b'dummy':
+            return struct.pack(b'B', path[2] + 1)*32 + b'\x01', self._ENGINE
+        raise NotImplementedError()
+
     def get_key_from_addr(self, addr):
         """usable addresses: privkey all 1s, 2s, 3s, ... :"""
         privs = [x*32 + b"\x01" for x in [struct.pack(b'B', y) for y in range(1,6)]]
@@ -139,8 +144,8 @@ class DummyWallet(LegacyWallet):
                 return p
         raise ValueError("No such keypair")
 
-    def _is_my_bip32_path(self, path):
-        return True
+    def get_path_repr(self, path):
+        return '/'.join(map(str, path))
 
     def is_standard_wallet_script(self, path):
         if path[0] == "nonstandard_path":

--- a/test/jmclient/test_taker.py
+++ b/test/jmclient/test_taker.py
@@ -121,7 +121,8 @@ class DummyWallet(LegacyWallet):
         """
         return 'p2wpkh'
 
-    def _get_key_from_path(self, path):
+    def _get_key_from_path(self, path,
+            validate_cache: bool = False):
         if path[0] == b'dummy':
             return struct.pack(b'B', path[2] + 1)*32 + b'\x01', self._ENGINE
         raise NotImplementedError()
@@ -152,10 +153,12 @@ class DummyWallet(LegacyWallet):
             return False
         return True
 
-    def script_to_addr(self, script):
+    def script_to_addr(self, script,
+            validate_cache: bool = False):
         if self.script_to_path(script)[0] == "nonstandard_path":
             return "dummyaddr"
-        return super().script_to_addr(script)
+        return super().script_to_addr(script,
+            validate_cache=validate_cache)
 
 
 def dummy_order_chooser():

--- a/test/jmclient/test_utxomanager.py
+++ b/test/jmclient/test_utxomanager.py
@@ -56,14 +56,12 @@ def test_utxomanager_persist(setup_env_nodeps):
     assert not um.is_disabled(txid, index+2)
     um.disable_utxo(txid, index+2)
 
-    utxos = um.get_utxos_by_mixdepth()
-    assert len(utxos[mixdepth]) == 1
-    assert len(utxos[mixdepth+1]) == 2
-    assert len(utxos[mixdepth+2]) == 0
+    assert len(um.get_utxos_at_mixdepth(mixdepth)) == 1
+    assert len(um.get_utxos_at_mixdepth(mixdepth+1)) == 2
+    assert len(um.get_utxos_at_mixdepth(mixdepth+2)) == 0
 
-    balances = um.get_balance_by_mixdepth()
-    assert balances[mixdepth] == value
-    assert balances[mixdepth+1] == value * 2
+    assert um.get_balance_at_mixdepth(mixdepth) == value
+    assert um.get_balance_at_mixdepth(mixdepth+1) == value * 2
 
     um.remove_utxo(txid, index, mixdepth)
     assert um.have_utxo(txid, index) == False
@@ -79,14 +77,12 @@ def test_utxomanager_persist(setup_env_nodeps):
     assert um.have_utxo(txid, index) == False
     assert um.have_utxo(txid, index+1) == mixdepth + 1
 
-    utxos = um.get_utxos_by_mixdepth()
-    assert len(utxos[mixdepth]) == 0
-    assert len(utxos[mixdepth+1]) == 1
+    assert len(um.get_utxos_at_mixdepth(mixdepth)) == 0
+    assert len(um.get_utxos_at_mixdepth(mixdepth+1)) == 1
 
-    balances = um.get_balance_by_mixdepth()
-    assert balances[mixdepth] == 0
-    assert balances[mixdepth+1] == value
-    assert balances[mixdepth+2] == 0
+    assert um.get_balance_at_mixdepth(mixdepth) == 0
+    assert um.get_balance_at_mixdepth(mixdepth+1) == value
+    assert um.get_balance_at_mixdepth(mixdepth+2) == 0
 
 
 def test_utxomanager_select(setup_env_nodeps):

--- a/test/jmclient/test_wallet.py
+++ b/test/jmclient/test_wallet.py
@@ -477,7 +477,7 @@ def test_get_bbm(setup_wallet):
     wallet = get_populated_wallet(amount, num_tx)
     # disable a utxo and check we can correctly report
     # balance with the disabled flag off:
-    utxo_1 = list(wallet._utxos.get_utxos_by_mixdepth()[0].keys())[0]
+    utxo_1 = list(wallet._utxos.get_utxos_at_mixdepth(0).keys())[0]
     wallet.disable_utxo(*utxo_1)
     balances = wallet.get_balance_by_mixdepth(include_disabled=True)
     assert balances[0] == num_tx * amount

--- a/test/jmclient/test_wallet.py
+++ b/test/jmclient/test_wallet.py
@@ -17,7 +17,6 @@ from jmclient import load_test_config, jm_single, BaseWallet, \
     wallet_gettimelockaddress, UnknownAddressForLabel
 from test_blockchaininterface import sync_test_wallet
 from freezegun import freeze_time
-from bitcointx.wallet import CCoinAddressError
 
 pytestmark = pytest.mark.usefixtures("setup_regtest_bitcoind")
 
@@ -264,9 +263,6 @@ def test_bip32_timelocked_addresses(setup_wallet, timenumber, address, wif):
     mixdepth = FidelityBondMixin.FIDELITY_BOND_MIXDEPTH
     address_type = FidelityBondMixin.BIP32_TIMELOCK_ID
 
-    #wallet needs to know about the script beforehand
-    wallet.get_script_and_update_map(mixdepth, address_type, timenumber)
-
     assert address == wallet.get_addr(mixdepth, address_type, timenumber)
     assert wif == wallet.get_wif_path(wallet.get_path(mixdepth, address_type, timenumber))
 
@@ -287,7 +283,7 @@ def test_gettimelockaddress_method(setup_wallet, timenumber, locktime_string):
 
     m = FidelityBondMixin.FIDELITY_BOND_MIXDEPTH
     address_type = FidelityBondMixin.BIP32_TIMELOCK_ID
-    script = wallet.get_script_and_update_map(m, address_type, timenumber)
+    script = wallet.get_script(m, address_type, timenumber)
     addr = wallet.script_to_addr(script)
 
     addr_from_method = wallet_gettimelockaddress(wallet, locktime_string)
@@ -456,7 +452,7 @@ def test_timelocked_output_signing(setup_wallet):
     wallet = SegwitWalletFidelityBonds(storage)
 
     timenumber = 0
-    script = wallet.get_script_and_update_map(
+    script = wallet.get_script(
         FidelityBondMixin.FIDELITY_BOND_MIXDEPTH,
         FidelityBondMixin.BIP32_TIMELOCK_ID, timenumber)
     utxo = fund_wallet_addr(wallet, wallet.script_to_addr(script))
@@ -610,7 +606,9 @@ def test_address_labels(setup_wallet):
         wallet.get_address_label("2MzY5yyonUY7zpHspg7jB7WQs1uJxKafQe4")
         wallet.set_address_label("2MzY5yyonUY7zpHspg7jB7WQs1uJxKafQe4",
             "test")
-    with pytest.raises(CCoinAddressError):
+        # we no longer decode addresses just to see if we know about them,
+        # so we won't get a CCoinAddressError for invalid addresses
+        #with pytest.raises(CCoinAddressError):
         wallet.get_address_label("badaddress")
         wallet.set_address_label("badaddress", "test")
 


### PR DESCRIPTION
**Note:** Reviewing each commit individually will make more sense than trying to review the combined diff.

This PR implements several performance enhancements that take the CPU time to run `wallet-tool.py display` on my wallet down from ~44 minutes to ~11 seconds.

The most significant gains come from replacing an **O**(_m_*_n_) algorithm in `get_imported_privkey_branch` with a semantically equivalent **O**(_m_+_n_) algorithm and from adding a persistent cache for computed private keys, public keys, scripts, and addresses.

Below are some actual benchmarks on my wallet, which has 5 mixdepths, each having path indices reaching into the 4000s, and almost 700 imported private keys.

* 673fbfb9a5dd6820bd72a88b52d0c7d38689550c `origin/master` (baseline)
    ```
    user    44m3.618s
    sys     0m6.375s
    ```
* 48aec83d76cf3472e13558bf87e3c8cfc570228c `wallet`: remove a dead store in `get_index_cache_and_increment`
* fbb681a207be465fb53b43ac18a2b52c8a4a6323 `wallet`: add `get_{balance,utxos}_at_mixdepth` methods
* 75a970378579bb04f189e8d9eca22e5e2aadb0b4 `wallet_utils`: use new `get_utxos_at_mixdepth` method
    ```
    user    42m14.464s
    sys     0m3.355s
    ```
* 84966e628d510ddf0cadba170346ea926dc06000 `wallet_showutxos`: use **O**(1) check for frozen instead of **O**(_n_)
* 75c5a75468a6de88e64c4af7a8226c633d358fd5 `get_imported_privkey_branch`: use **O**(_m_+_n_) algorithm instead of **O**(_m_*_n_)
    ```
    user    5m0.045s
    sys     0m0.453s
    ```
* da8daf048369081d882fb591d50583559a2284f0 `wallet`: add `_addr_map`, paralleling `_script_map`
    ```
    user    4m56.175s
    sys     0m0.423s
    ```
* d8aa1afe6f0ec596bb133f594ae88cc2fffb6ad2 `wallet`: add persistent cache, mapping path->(priv, pub, script, addr)
    ```
    user    1m42.272s
    sys     0m0.471s
    ```
* After running another command to modify the wallet file so as to persist the cache, `wallet-tool.py display` now runs in:
    ```
    user    0m11.141s
    sys     0m0.225s
    ```