### PR TITLE
Add optional `txfee` property for `direct-send` wallet RPC

### DIFF
--- a/docs/api/wallet-rpc.yaml
+++ b/docs/api/wallet-rpc.yaml
@@ -1113,6 +1113,10 @@ components:
         destination:
           type: string
           example: bcrt1qu7k4dppungsqp95nwc7ansqs9m0z95h72j9mze
+        txfee:
+          type: integer
+          example: 6
+          description: Bitcoin miner fee to use for transaction. A number higher than 1000 is used as satoshi per kvB tx fee. The number lower than that uses the dynamic fee estimation of blockchain provider as confirmation target.
     ErrorMessage:
         type: object
         properties:


### PR DESCRIPTION
Resolves #1360. Jam wants it for https://github.com/joinmarket-webui/jam/pull/678.