### PR TITLE
Use `coins_to_satoshi()` and `satoshi_to_coins()` from `bitcointx` everywhere

### DIFF
--- a/scripts/bond-calculator.py
+++ b/scripts/bond-calculator.py
@@ -6,7 +6,7 @@ from json import loads
 from optparse import OptionParser
 
 from jmbase import EXIT_ARGERROR, jmprint, get_log, utxostr_to_utxo, EXIT_FAILURE
-from jmbitcoin import amount_to_sat, sat_to_btc
+from jmbitcoin import amount_to_sat, amount_to_str
 from jmclient import add_base_options, load_program_config, jm_single, get_bond_values
 
 DESCRIPTION = """Given either a Bitcoin UTXO in the form TXID:n
@@ -110,7 +110,7 @@ def main() -> None:
                                           options.interest,
                                           options.exponent,
                                           orderbook)
-    jmprint(f"Amount locked: {amount} ({sat_to_btc(amount)} btc)")
+    jmprint(f"Amount locked: {amount_to_str(amount)}")
     jmprint(f"Confirmation time: {datetime.fromtimestamp(parameters['confirm_time'])}")
     jmprint(f"Interest rate: {parameters['interest']} ({parameters['interest'] * 100}%)")
     jmprint(f"Exponent: {parameters['exponent']}")

--- a/scripts/qtsupport.py
+++ b/scripts/qtsupport.py
@@ -24,7 +24,8 @@ from PySide2 import QtCore
 from PySide2.QtGui import *
 from PySide2.QtWidgets import *
 
-from jmbitcoin.amount import amount_to_sat, btc_to_sat, sat_to_btc
+from bitcointx.core import satoshi_to_coins
+from jmbitcoin.amount import amount_to_sat, btc_to_sat, sat_to_str
 from jmbitcoin.bip21 import decode_bip21_uri
 from jmclient import (jm_single, validate_address, get_tumble_schedule)
 
@@ -584,7 +585,7 @@ class BitcoinAmountEdit(QWidget):
         self.setModeBTC()
         layout.addWidget(self.unitChooser)
         if default_value:
-            self.valueInputBox.setText(str(sat_to_btc(amount_to_sat(
+            self.valueInputBox.setText(str(satoshi_to_coins(amount_to_sat(
                 default_value))))
         self.setLayout(layout)
 
@@ -605,7 +606,7 @@ class BitcoinAmountEdit(QWidget):
             sat_amount = self.valueInputBox.text()
             self.setModeBTC()
             if sat_amount:
-                self.valueInputBox.setText('%.8f' % sat_to_btc(sat_amount))
+                self.valueInputBox.setText(sat_to_str(sat_amount))
         else:
             # switch from BTC to sat
             btc_amount = self.valueInputBox.text()
@@ -616,7 +617,7 @@ class BitcoinAmountEdit(QWidget):
     def setText(self, text):
         if text:
             if self.unitChooser.currentIndex() == 0:
-                self.valueInputBox.setText(str(sat_to_btc(text)))
+                self.valueInputBox.setText(str(satoshi_to_coins(text)))
             else:
                 self.valueInputBox.setText(str(text))
         else:

--- a/src/jmbitcoin/amount.py
+++ b/src/jmbitcoin/amount.py
@@ -1,6 +1,7 @@
+import re
+from bitcointx.core import coins_to_satoshi, satoshi_to_coins
 from decimal import Decimal
 from typing import Any, Tuple, Union
-import re
 
 
 def bitcoin_unit_to_power(btc_unit: str) -> int:
@@ -19,7 +20,7 @@ def bitcoin_unit_to_power(btc_unit: str) -> int:
 
 
 def btc_to_sat(btc: Union[int, str, Tuple, float, Decimal]) -> int:
-    return int(Decimal(btc) * Decimal('1e8'))
+    return coins_to_satoshi(Decimal(btc))
 
 
 def sat_to_unit_power(sat: int, power: int) -> Decimal:
@@ -77,11 +78,11 @@ def amount_to_str(amount_str: str) -> str:
 
 
 def sat_to_str(sat: int) -> str:
-    return '%.8f' % sat_to_btc(sat)
+    return '%.8f' % satoshi_to_coins(sat)
 
 
 def sat_to_str_p(sat: int) -> str:
-    return '%+.8f' % sat_to_btc(sat)
+    return '%+.8f' % satoshi_to_coins(sat, check_range=False)
 
 
 def fee_per_kb_to_str(feerate: Any) -> str:


### PR DESCRIPTION
It's bad to have different functions for the same thing, `coins_to_satoshi()` were already used in some tests.