### PR TITLE
Allow fee bump tx not signalling BIP125 if `mempoolfullrbf` is enabled

### DIFF
--- a/scripts/bumpfee.py
+++ b/scripts/bumpfee.py
@@ -74,8 +74,10 @@ def check_valid_candidate(orig_tx, wallet, output_index=-1):
     if own_inputs_n != tx_inputs_n:
         raise ValueError('Transaction inputs should belong to the wallet.')
 
-    # at least one input should signal opt-in rbf
-    if not any([vin.nSequence <= 0xffffffff - 2 for vin in orig_tx.vin]):
+    # either mempoolfullrbf must be enabled or at least one input must signal
+    # opt-in rbf
+    if not jm_single().bc_interface.mempoolfullrbf() and \
+       not any([vin.nSequence <= 0xffffffff - 2 for vin in orig_tx.vin]):
         raise ValueError('Transaction not replaceable.')
 
     # 1. If output_index is specified, check that the output exist

--- a/test/jmclient/commontest.py
+++ b/test/jmclient/commontest.py
@@ -90,6 +90,8 @@ class DummyBlockchainInterface(BlockchainInterface):
         pass
     def rescanblockchain(self, start_height: int, end_height: Optional[int] = None) -> None:
         pass
+    def mempoolfullrbf(self) -> bool:
+        pass
 
     def get_current_block_height(self) -> int:
         return 10**6


### PR DESCRIPTION
We should allow this if full-RBF is enabled in Bitcoin node.