### PR TITLE
Removed donation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,10 +122,3 @@ Instructions for developers for testing [here](docs/TESTING.md). If you want to 
 https://twitter3e4tixl4xyajtrzo62zg5vztmjuricljdp2c5kshju4avyoid.onion/joinmarket
 
 + Telegram: https://t.me/joinmarketorg
-
-### Support JoinMarket and bitcoin privacy
-
-Donate to help make JoinMarket even better: [Obtain a bitcoin address here](https://bitcoinprivacy.me/joinmarket-donations)
-
-JoinMarket is an open source project which does not have a funding model, fortunately the project itself has very low running costs as it is almost-fully decentralized and available to everyone for free. Developers contribute only as volunteers and donations are divided amongst them. Many developers have also been important in advocating for privacy and educating the wider bitcoin user base. Be part of the effort to improve bitcoin privacy and fungibility. Every donated coin helps us spend more time on JoinMarket instead of doing other stuff.
-


### PR DESCRIPTION
The site linked to here is not under the control of any of the current active developers and any donation going here will not be support for development (this has been the status for a long while, now).