### PR TITLE
Support Bitcoin Core v26 for tests

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -10,7 +10,7 @@ jobs:
       matrix:
         os: [macos-latest, ubuntu-latest]
         python-version: ["3.7", "3.11"]
-        bitcoind-version: ["0.18.0", "25.1"]
+        bitcoind-version: ["0.18.0", "26.0"]
 
     steps:
       - uses: actions/checkout@v3

--- a/conftest.py
+++ b/conftest.py
@@ -138,12 +138,16 @@ def setup_regtest_bitcoind(pytestconfig):
     bitcoincli_path = os.path.join(bitcoin_path, "bitcoin-cli")
     start_cmd = f'{bitcoind_path} -regtest -daemon -conf={conf}'
     stop_cmd = f'{bitcoincli_path} -regtest -rpcuser={rpcuser} -rpcpassword={rpcpassword} stop'
-    local_command(start_cmd, bg=True)
+
     # determine bitcoind version
     try:
         bitcoind_version = get_bitcoind_version(bitcoind_path)
     except RuntimeError as exc:
         pytest.exit(f"Cannot setup tests, bitcoind failing.\n{exc}")
+
+    if bitcoind_version[0] >= 26:
+        start_cmd += ' -allowignoredconf=1'
+    local_command(start_cmd, bg=True)
     root_cmd = f'{bitcoincli_path} -regtest -rpcuser={rpcuser} -rpcpassword={rpcpassword}'
     wallet_name = 'jm-test-wallet'
     # Bitcoin Core v0.21+ does not create default wallet

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -204,6 +204,16 @@ run_jm_tests ()
     if [[ -z "$btcconf" ]]; then
         btcconf="${jm_test_datadir}/bitcoin.conf"
         cp -f ./test/bitcoin.conf "${jm_test_datadir}/bitcoin.conf"
+        # Temporary hack until we support descriptor wallets.
+        # https://github.com/JoinMarket-Org/joinmarket-clientserver/issues/1571
+        if [[ -n $btcroot ]]; then
+            bitcoind="$btcroot/bitcoind"
+        else
+            bitcoind="bitcoind"
+        fi
+        if [[ "$($bitcoind -version | grep -Eo 'v[0-9]+')" == "v26" ]]; then
+            echo "deprecatedrpc=create_bdb" >> "${jm_test_datadir}/bitcoin.conf"
+        fi
     fi
     ${orig_umask}
     echo "datadir=${jm_test_datadir}" >> "${jm_test_datadir}/bitcoin.conf"


### PR DESCRIPTION
Bitcoin Core config needs to be hacked with `deprecatedrpc=create_bdb` for v26 until #1571 is solved.