### PR TITLE
Raise absurd tx fee default from 350 sats/vB to 500 sats/vB

### DIFF
--- a/src/jmclient/configure.py
+++ b/src/jmclient/configure.py
@@ -300,9 +300,9 @@ tx_fees_factor = 0.2
 # Core has its own sanity check limit, which is currently
 # 1 million satoshis.
 #
-# Example: N=350000 will use 350 thousand sats/kilo-vbyte (350 sats/vB) as a
+# Example: N=500000 will use 500 thousand sats/kilo-vbyte (500 sats/vB) as a
 # maximum fee.
-absurd_fee_per_kb = 350000
+absurd_fee_per_kb = 500000
 
 # In decimal, the maximum allowable change either lower or
 # higher, that the fee rate used for coinjoin sweeps is


### PR DESCRIPTION
At current fee environment tx fees above 350 sats/vB might soon be not so absurd anymore.

![image](https://github.com/JoinMarket-Org/joinmarket-clientserver/assets/4500994/1171f08a-4aa2-42a9-8de0-255194f11af6)
