### PR TITLE
Fix tests for Core v26 when user has no access to `~/.bitcoin/settings.json`

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -8,12 +8,12 @@ from typing import Any, Tuple
 import pytest
 
 
-def get_bitcoind_version(bitcoind_path: str) -> Tuple[int, int]:
+def get_bitcoind_version(bitcoind_path: str, conf: str) -> Tuple[int, int]:
     """
     This utility function returns the bitcoind version number
     as a tuple in the form (major, minor)
     """
-    version = local_command(f'{bitcoind_path} -version')
+    version = local_command(f'{bitcoind_path} -version -conf={conf}')
     if version.returncode != 0:
         raise RuntimeError(version.stdout.decode('utf-8'))
     version_string = version.stdout.split(b'\n')[0]
@@ -141,7 +141,7 @@ def setup_regtest_bitcoind(pytestconfig):
 
     # determine bitcoind version
     try:
-        bitcoind_version = get_bitcoind_version(bitcoind_path)
+        bitcoind_version = get_bitcoind_version(bitcoind_path, conf)
     except RuntimeError as exc:
         pytest.exit(f"Cannot setup tests, bitcoind failing.\n{exc}")
 

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -211,7 +211,7 @@ run_jm_tests ()
         else
             bitcoind="bitcoind"
         fi
-        if [[ "$($bitcoind -version | grep -Eo 'v[0-9]+')" == "v26" ]]; then
+        if [[ "$($bitcoind -version -datadir="${jm_test_datadir}" | grep -Eo 'v[0-9]+')" == "v26" ]]; then
             echo "deprecatedrpc=create_bdb" >> "${jm_test_datadir}/bitcoin.conf"
         fi
     fi


### PR DESCRIPTION
From v26 Bitcoin Core always checks it's datadir `settings.json` file, even if you do stuff like `-help` or `-version`. It's stupid, but it is what it is. This makes problems with multi-user setups, where `bitcoind` runs under one user (`bitcoin`) and JoinMarket under another (`joinmarket`), and `/home/joinmarket/.bitcoin` is just symlink to original Bitcoin datadir, with sole purpose that RPC auth cookie is accessible, but `settings.json`, created by `bitcoind` itself, is not group readable. That is setup used for RaspiBolt, but not only, it's setup that makes sense.

Without this, tests fail on such setups:
```
(jmvenv) joinmarket@odroid:~/git/joinmarket-clientserver$ ./test/run_tests.sh 
~/git/joinmarket-clientserver ~/git/joinmarket-clientserver
miniircd.tar.gz: OK
Error: Settings file could not be read:
- /home/joinmarket/.bitcoin/settings.json. Please check permissions.
==================================================================================== test session starts =====================================================================================
platform linux -- Python 3.8.10, pytest-6.2.5, py-1.11.0, pluggy-1.3.0
rootdir: /home/joinmarket/git/joinmarket-clientserver, configfile: pyproject.toml, testpaths: test
plugins: cov-2.5.1
collected 421 items                                                                                                                                                                          

test/jmbase/test_base_support.py 

!!!!!!!!! _pytest.outcomes.Exit: Cannot setup tests, bitcoind failing.
Error: Settings file could not be read:
- /home/joinmarket/.bitcoin/settings.json. Please check permissions. !!!!!!!!!!


(jmvenv) joinmarket@odroid:~/git/joinmarket-clientserver$ ls -al /home/joinmarket/.bitcoin
lrwxrwxrwx 1 joinmarket joinmarket 13 Nov 22  2022 /home/joinmarket/.bitcoin -> /data/bitcoin
(jmvenv) joinmarket@odroid:~/git/joinmarket-clientserver$ ls -al /data/bitcoin
total 115448
drwxrwxr-x 15 bitcoin bitcoin     4096 Dec 30 11:11 .
drwxr-xr-x 18 root    root        4096 Oct 21 11:21 ..
-rw-r-----  1 bitcoin bitcoin       75 Dec  7 06:20 .cookie
-rw-------  1 bitcoin bitcoin        0 Sep 27  2021 .lock
drwx------  3 bitcoin bitcoin     4096 Dec  7 06:20 SatSale
-rw-------  1 bitcoin bitcoin       34 Sep 27  2021 banlist.json
-rw-r-----  1 bitcoin bitcoin     1238 Dec  7 06:20 bitcoin.conf
drwx------  3 bitcoin bitcoin   237568 Dec 30 06:00 blocks
drwx------  2 bitcoin bitcoin   167936 Dec 30 11:19 chainstate
-rw-------  1 bitcoin bitcoin 17409758 Dec 30 11:23 debug.log
drwx------  2 bitcoin bitcoin     4096 Sep 12  2022 descriptors_test
-rw-------  1 bitcoin bitcoin   247985 Dec 30 11:22 fee_estimates.dat
-rw-------  1 bitcoin bitcoin      679 Sep 27  2021 i2p_private_key
drwx------  4 bitcoin bitcoin     4096 Sep 12  2022 indexes
drwx------  3 bitcoin bitcoin     4096 Dec  7 06:21 jm_v26_test
drwx------  3 bitcoin bitcoin     4096 Dec  7 08:30 jm_wallet
drwx------  3 bitcoin bitcoin     4096 Feb 17  2022 joinmarket
drwx------  2 bitcoin bitcoin     4096 Nov 27  2021 joinmarket-old
-rw-------  1 bitcoin bitcoin 94860907 Dec  7 06:02 mempool.dat
-rw-------  1 bitcoin bitcoin       99 Dec  7 06:21 onion_v3_private_key
-rw-------  1 bitcoin bitcoin  5189788 Dec 30 11:11 peers.dat
-rw-rw-r--  1 bitcoin bitcoin     1534 Nov 27  2021 rpcauth.py
-rw-------  1 bitcoin bitcoin       60 Dec 19 13:19 settings.json
drwx------  3 bitcoin bitcoin     4096 Sep 16  2022 specterd452d801d8c61692
drwx------  3 bitcoin bitcoin     4096 Sep 16  2022 specterd452d801d8c61692_hotstorage
drwx------  3 bitcoin bitcoin     4096 Sep 16  2022 specterf42828a49e7c6fd0
drwx------  3 bitcoin bitcoin     4096 Dec  7 06:20 test
```

Fix is to provide `-conf`/`-datadir` argument to `bitcoind -version` calls.

See also discussion in https://github.com/raspibolt/raspibolt/pull/1387.