### PR TITLE
Cache `None` in `tx_cache` for non-wallet transactions

### DIFF
--- a/src/jmclient/wallet_utils.py
+++ b/src/jmclient/wallet_utils.py
@@ -909,6 +909,8 @@ def wallet_fetch_history(wallet, options):
                         ).get_deser_from_gettransaction(wallet_tx)
                     tx_cache[ins.prevout.hash[::-1]] = (wallet_tx,
                                                         wallet_tx_deser)
+                else:
+                    tx_cache[ins.prevout.hash[::-1]] = (None, None)
             if wallet_tx is None:
                 continue
             inp = wallet_tx_deser.vout[ins.prevout.n]


### PR DESCRIPTION
`wallet_fetch_history()` calls `BlockchainInterface.get_transaction()` for each input of wallet transactions to figure out which of the inputs are ours and which aren't. It will return `None` for non-wallet transactions and that weren't cached, so, if the same non-wallet transaction appears in inputs of wallet transactions multiple times, unnecessary `gettransaction` RPCs to Bitcoin Core were made.