### PR TITLE
Remove unnecessary check for Python 3.7+

### DIFF
--- a/scripts/obwatch/ob-watcher.py
+++ b/scripts/obwatch/ob-watcher.py
@@ -16,10 +16,6 @@ from optparse import OptionParser
 from twisted.internet import reactor
 from datetime import datetime, timedelta
 
-if sys.version_info < (3, 7):
-    print("ERROR: this script requires at least python 3.7")
-    exit(1)
-
 from jmbase.support import EXIT_FAILURE
 from jmbase import bintohex
 from jmclient import FidelityBondMixin, get_interest_rate, check_and_start_tor


### PR DESCRIPTION
Python 3.6 support in JoinMarket is dropped for some time.