### PR TITLE
Drop Python 3.7 support

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, ubuntu-latest]
-        python-version: ["3.7", "3.11"]
+        python-version: ["3.8", "3.11"]
         bitcoind-version: ["0.18.0", "26.0"]
 
     steps:

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Download the latest [release](https://github.com/Joinmarket-Org/joinmarket-clien
 
 Make sure to validate the signature on the tar/zip file provided with the [release](https://github.com/Joinmarket-Org/joinmarket-clientserver/releases) (or check the signature in git if you install that way using `git log --show-signature`).
 
-JoinMarket requires Python 3.7 or newer installed.
+JoinMarket requires Python 3.8, 3.9, 3.10 or 3.11 installed.
 
 (**macOS users**: Make sure that you have Homebrew and Apple's Command Line Tools installed.)
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -4,7 +4,7 @@
 * [Installation on Windows](#installation-on-windows)
 * [Alternative/custom installation](#alternativecustom-installation)
 
-JoinMarket requires Python 3.7 or newer.
+JoinMarket requires Python 3.8, 3.9, 3.10 or 3.11.
 
 ### Notes on upgrading, binaries and compatibility
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "joinmarket"
 version = "0.9.11dev"
 description = "Joinmarket client library for Bitcoin coinjoins"
 readme = "README.md"
-requires-python = ">=3.7,<3.12"
+requires-python = ">=3.8,<3.12"
 license = {file = "LICENSE"}
 dependencies = [
     "chromalog==1.0.5",


### PR DESCRIPTION
It's EOL since 27 Jun 2023 and 3.8+ is required for #1637.

Also mentioned in docs that JoinMarket is currently not compatible with 3.12 (#1589).