### PR TITLE
When looking for a free TCP ports, bind only to localhost

### DIFF
--- a/src/jmbase/support.py
+++ b/src/jmbase/support.py
@@ -350,7 +350,7 @@ def get_free_tcp_ports(num_ports: int) -> List[int]:
     ports = []
     for i in range(num_ports):
         s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        s.bind(("", 0))
+        s.bind(("127.0.0.1", 0))
         s.listen(1)
         ports.append(s.getsockname()[1])
         sockets.append(s)


### PR DESCRIPTION
Not a real security issue, as this is only used in tests, but it's simple to fix and right thing to do. Found by [GitHub CodeQL code scanner](https://docs.github.com/en/code-security/code-scanning/introduction-to-code-scanning/about-code-scanning-with-codeql).