### PR TITLE
Bump txtorcon from 23.0.0 to 23.11.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
     "cryptography==41.0.6",
     "service-identity==21.1.0",
     "twisted==23.8.0",
-    "txtorcon==23.0.0",
+    "txtorcon==23.11.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
In #1567 we updated to 23.0.0, not 23.5.0, because that was the last version supporting Python 3.7. Now that Python 3.7 support is dropped with #1639, can upgrade to latest.

Changes in [23.5.0](https://github.com/meejah/txtorcon/releases/tag/v23.5.0):

* twisted.web.client.Agent instances now use the same HTTPS policy by default as twisted.web.client.Agent. It is possible to override this policy with the tls_context_factory= argument, the equivalent to Agent's contextFactory= (Thanks to Itamar Turner-Trauring)
* Added support + testing for Python 3.11.
* No more ipaddress dependency

Changes in [23.11.0](https://github.com/meejah/txtorcon/releases/tag/v23.11.0):

 * Fix test-failures on Python 3.12
 * Particular GETINFO hanging (https://github.com/meejah/txtorcon/issues/389) (ultra-long lines over 16KiB caused problems in the protocol)
 * Use built-in `mock` only (https://github.com/jelly)
 * Remove `incremental` (https://github.com/gdrosos)

Basically, not much changes, but fixed bug, dropped dependencies and better support for Python 3.11 and 3.12 is good enough reason to merge for me.