### PR TITLE
Tell libsodium not to download code from savannah.gnu.org in `autogen.sh`

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -345,7 +345,7 @@ libsodium_build ()
 {
     $make uninstall
     $make distclean
-    ./autogen.sh
+    ./autogen.sh DO_NOT_UPDATE_CONFIG_SCRIPTS=1
     ./configure \
         --enable-minimal \
         --enable-shared \


### PR DESCRIPTION
Fixes #1655.