### PR TITLE
Remove `--disable-jni` from `libsecp256k1_build`

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -307,7 +307,6 @@ libsecp256k1_build()
     ./autogen.sh
     ./configure \
         --enable-module-recovery \
-        --disable-jni \
         --prefix "${jm_root}" \
         --enable-experimental \
         --enable-module-ecdh \


### PR DESCRIPTION
JNI was removed with libsecp256k1 v0.2.0, see https://github.com/bitcoin-core/secp256k1/pull/682.