### PR TITLE
Handle `JsonRpcError` in `_estimate_fee_basic`

### DIFF
--- a/src/jmclient/blockchaininterface.py
+++ b/src/jmclient/blockchaininterface.py
@@ -593,8 +593,12 @@ class BitcoinCoreInterface(BlockchainInterface):
         # cannot be estimated in that case the 2nd highest priority
         # should be used instead of falling back to hardcoded values
         tries = 2 if conf_target == 1 else 1
+        rpc_result = None
         for i in range(tries):
-            rpc_result = self._rpc('estimatesmartfee', [conf_target + i])
+            try:
+                rpc_result = self._rpc('estimatesmartfee', [conf_target + i])
+            except JsonRpcError:
+                continue
             if not rpc_result:
                 # in case of connection error:
                 return None


### PR DESCRIPTION
`_estimate_fee_basic` is supposed to return `None` if fee rate can't be estimated and then `estimate_fee_per_kb` handles that with hardcoded fallback fee. But `JsonRpcError` wasn't handled and it could fail when fee estimation is not working in Core.

Fixes #1653.

Previously it outputed unhandled error and hanged, now it's:

```
2024-02-10 02:05:11,803 [DEBUG]  rpc: estimatesmartfee [3]
2024-02-10 02:05:11,812 [WARNING]  Could not source a fee estimate from Core
2024-02-10 02:05:11,813 [WARNING]  Fee estimation for 3 block confirmation target failed. Falling back to default (randomized for privacy): 11976 sat/kvB (11.9 sat/vB).
2024-02-10 02:05:11,815 [DEBUG]  rpc: getmempoolinfo []
2024-02-10 02:05:11,818 [DEBUG]  rpc: estimatesmartfee [3]
2024-02-10 02:05:11,820 [WARNING]  Could not source a fee estimate from Core
2024-02-10 02:05:11,821 [WARNING]  Fee estimation for 3 block confirmation target failed. Falling back to default (randomized for privacy): 10279 sat/kvB (10.2 sat/vB).
2024-02-10 02:05:11,849 [INFO]  Using a fee of: 0.00001449 BTC (1449 sat).
```