### PR TITLE
Raise fallback fee rate from 10 sat/vB to 20 sat/vB

### DIFF
--- a/src/jmclient/blockchaininterface.py
+++ b/src/jmclient/blockchaininterface.py
@@ -253,7 +253,7 @@ class BlockchainInterface(ABC):
         """
 
         # default to use if fees cannot be estimated
-        fallback_fee = 10000
+        fallback_fee = 20000
 
         tx_fees_factor = abs(jm_single().config.getfloat('POLICY', 'tx_fees_factor'))
 


### PR DESCRIPTION
It's just current reality on mainnet, that's around what `bitcoin-cli estimatesmartfee 1008` (1 week confirmation target) returns.