### PR TITLE
Qt: Fix no amount entered message (can be sats too, not only BTC)

### DIFF
--- a/scripts/joinmarket-qt.py
+++ b/scripts/joinmarket-qt.py
@@ -1205,7 +1205,7 @@ class SpendTab(QWidget):
         if len(self.amountInput.text()) == 0:
             JMQtMessageBox(
                 self,
-                "Amount, in bitcoins, must be provided.",
+                "Amount must be provided.",
                 mbtype='warn', title="Error")
             return False
         if len(self.changeInput.text().strip()) != 0:


### PR DESCRIPTION
Message was wrong since dropdown to switch between BTC and sat amounts was added.