### PR TITLE
Bump pyopenssl from 23.2.0 to 24.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ jmclient = [
 ]
 jmdaemon = [
     "libnacl==1.8.0",
-    "pyopenssl==23.2.0",
+    "pyopenssl==24.0.0",
 ]
 jmqtui = [
     "PyQt5!=5.15.0,!=5.15.1,!=5.15.2,!=6.0",


### PR DESCRIPTION
Needed for #1669, allows upgrading `cryptography` to 42.x, see https://github.com/pyca/pyopenssl/issues/1285 and https://github.com/pyca/pyopenssl/pull/1284.