### PR TITLE
CI: Use x64 not arm64 macOS

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-latest, ubuntu-latest]
+        os: [macos-13, ubuntu-latest]
         python-version: ["3.8", "3.11"]
         bitcoind-version: ["0.18.0", "26.0"]
 


### PR DESCRIPTION
ARM (M1) GitHub runner doesn't have Python 3.8 available. EOL of 3.8 is 31 Oct 2024, would be good to continue support, unless there are some bigger reasons to drop it sooner.

And macos-latest was recently changed to M1, see
<https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories>.

This fixes current non-random always happening CI failures.