### PR TITLE
CI: Bump Bitcoin Core from 26.0 to 26.1

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -10,7 +10,7 @@ jobs:
       matrix:
         os: [macos-13, ubuntu-latest]
         python-version: ["3.8", "3.11"]
-        bitcoind-version: ["0.18.0", "26.0"]
+        bitcoind-version: ["0.18.0", "26.1"]
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
https://github.com/JoinMarket-Org/joinmarket-clientserver/pull/1694#issuecomment-2076979574