### PR TITLE
Bump libsecp256k1 from v0.4.1 to v0.5.0

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -324,9 +324,9 @@ libsecp256k1_build()
 
 libsecp256k1_install()
 {
-    secp256k1_version="0.4.1"
+    secp256k1_version="0.5.0"
     secp256k1_lib_tar="v$secp256k1_version.tar.gz"
-    secp256k1_lib_sha="31b1a03c7365dbce7aff4be9526243da966c58a8b88b6255556d51b3016492c5"
+    secp256k1_lib_sha="07934fde88c677abbc4d42c36ef7ef8d3850cd0c065e4f976f66f4f97502c95a"
     secp256k1_lib_url='https://github.com/bitcoin-core/secp256k1/archive/refs/tags'
     if ! dep_get "${secp256k1_lib_tar}" "${secp256k1_lib_sha}" "${secp256k1_lib_url}"; then
         return 1


### PR DESCRIPTION
This release includes algorithmic improvements which increase the speed of key generation and signing. At the same time, the binary size has been reduced significantly.

Full changelog: https://github.com/bitcoin-core/secp256k1/blob/master/CHANGELOG.md#050---2024-05-06

The ABI is backward compatible with versions 0.4.x and 0.3.x, so no python-bitcointx update is needed.