### PR TITLE
fix debian install

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -67,6 +67,7 @@ deps_install ()
         'curl' \
         'build-essential' \
         'automake' \
+        'autoconf' \
         'pkg-config' \
         'libtool' \
         'python3-dev' \


### PR DESCRIPTION
this fix an error on debian install:
```
~/joinmarket-clientserver/deps ~/joinmarket-clientserver                                                                                                                                       
~/joinmarket-clientserver/deps/libffi-3.2.1 ~/joinmarket-clientserver/deps ~/joinmarket-clientserver                                                                                           
patching file Makefile.am                                                                                                                                                                      
patching file configure.ac                                                                                                                                                                     
patching file configure.ac                                                                                                                                                                     
./autogen.sh: 2: exec: autoreconf: not found                                                                                                                                                   
./install.sh: line 271: ./configure: No such file or directory                                                                                                                                 
gmake: *** No rule to make target 'uninstall'.  Stop.                                                                                                                                          
gmake: *** No targets specified and no makefile found.  Stop.  
```
`autoreconf: not found` 

the `autoreconf` command is part of `autoconf` pkg that was not included

fix some issues like this: https://github.com/JoinMarket-Org/joinmarket-clientserver/issues/541