### PR TITLE
Fixed direct-send RPC-API to accept list of UTXOs

### DIFF
--- a/docs/api/wallet-rpc.yaml
+++ b/docs/api/wallet-rpc.yaml
@@ -1120,12 +1120,12 @@ components:
           type: integer
           example: 6
           description: Bitcoin miner fee to use for transaction. A number higher than 1000 is used as satoshi per kvB tx fee. The number lower than that uses the dynamic fee estimation of blockchain provider as confirmation target.
-        utxos:
+        selected_utxos:
           type: array
           items:
             type: string
-            example: "85cf4c880876eead0a6674cbc341b21b86058530c2eacf18a16007f8f9cb1b1a:0"
-          description: Optional parameter. If specified, these UTXOs will be used in the transaction.If not specified, the default UTXO selection logic will be used.
+            example: 85cf4c880876eead0a6674cbc341b21b86058530c2eacf18a16007f8f9cb1b1a:0
+          nullable: true
     ErrorMessage:
         type: object
         properties:

--- a/docs/api/wallet-rpc.yaml
+++ b/docs/api/wallet-rpc.yaml
@@ -1124,9 +1124,9 @@ components:
           type: array
           items:
             type: string
-        example: 
-          - "96a1195792bfc851fbbd8ff51d07294cf9daa81af720bd020e6397311fc3b220:0"
-        description: "Optional parameter. If specified, these UTXOs will be used in the transaction. If not specified, the default UTXO selection logic will be used."
+          example: 
+            - "96a1195792bfc851fbbd8ff51d07294cf9daa81af720bd020e6397311fc3b220:0"
+          description: "Optional parameter. If specified, these UTXOs will be used in the transaction. If not specified, the default UTXO selection logic will be used."
     ErrorMessage:
         type: object
         properties:

--- a/docs/api/wallet-rpc.yaml
+++ b/docs/api/wallet-rpc.yaml
@@ -297,7 +297,7 @@ paths:
         - bearerAuth: []
       summary: create and broadcast a transaction (without coinjoin)
       operationId: directsend
-      description: create and broadcast a transaction (without coinjoin) You can specify the UTXOs to be used in the transaction by providing them in the `utxos` parameter. If `utxos` is not specified, the default UTXO selection logic will be used.
+      description: create and broadcast a transaction (without coinjoin)
       parameters:
         - name: walletname
           in: path
@@ -1124,9 +1124,8 @@ components:
           type: array
           items:
             type: string
-          example: 
-            - "96a1195792bfc851fbbd8ff51d07294cf9daa81af720bd020e6397311fc3b220:0"
-          description: "Optional parameter. If specified, these UTXOs will be used in the transaction. If not specified, the default UTXO selection logic will be used."
+            example: "96a1195792bfc851fbbd8ff51d07294cf9daa81af720bd020e6397311fc3b220:0"
+          description: Optional parameter. If specified, these UTXOs will be used in the transaction. If not specified, the default UTXO selection logic will be used.
     ErrorMessage:
         type: object
         properties:

--- a/docs/api/wallet-rpc.yaml
+++ b/docs/api/wallet-rpc.yaml
@@ -297,7 +297,7 @@ paths:
         - bearerAuth: []
       summary: create and broadcast a transaction (without coinjoin)
       operationId: directsend
-      description: create and broadcast a transaction (without coinjoin)
+      description: create and broadcast a transaction (without coinjoin) You can specify the UTXOs to be used in the transaction by providing them in the `utxos` parameter. If `utxos` is not specified, the default UTXO selection logic will be used.
       parameters:
         - name: walletname
           in: path
@@ -1120,6 +1120,12 @@ components:
           type: integer
           example: 6
           description: Bitcoin miner fee to use for transaction. A number higher than 1000 is used as satoshi per kvB tx fee. The number lower than that uses the dynamic fee estimation of blockchain provider as confirmation target.
+        utxos:
+          type: array
+          items:
+            type: string
+          example: 96a1195792bfc851fbbd8ff51d07294cf9daa81af720bd020e6397311fc3b220:0
+          description: Optional parameter. If specified, these UTXOs will be used in the transaction. If not specified, the default UTXO selection logic will be used.
     ErrorMessage:
         type: object
         properties:

--- a/docs/api/wallet-rpc.yaml
+++ b/docs/api/wallet-rpc.yaml
@@ -1120,6 +1120,12 @@ components:
           type: integer
           example: 6
           description: Bitcoin miner fee to use for transaction. A number higher than 1000 is used as satoshi per kvB tx fee. The number lower than that uses the dynamic fee estimation of blockchain provider as confirmation target.
+        utxos:
+          type: array
+          items:
+            type: string
+            example: "85cf4c880876eead0a6674cbc341b21b86058530c2eacf18a16007f8f9cb1b1a:0"
+          description: Optional parameter. If specified, these UTXOs will be used in the transaction.If not specified, the default UTXO selection logic will be used.
     ErrorMessage:
         type: object
         properties:

--- a/docs/api/wallet-rpc.yaml
+++ b/docs/api/wallet-rpc.yaml
@@ -1124,8 +1124,9 @@ components:
           type: array
           items:
             type: string
-          example: 96a1195792bfc851fbbd8ff51d07294cf9daa81af720bd020e6397311fc3b220:0
-          description: Optional parameter. If specified, these UTXOs will be used in the transaction. If not specified, the default UTXO selection logic will be used.
+        example: 
+          - "96a1195792bfc851fbbd8ff51d07294cf9daa81af720bd020e6397311fc3b220:0"
+        description: "Optional parameter. If specified, these UTXOs will be used in the transaction. If not specified, the default UTXO selection logic will be used."
     ErrorMessage:
         type: object
         properties:

--- a/docs/api/wallet-rpc.yaml
+++ b/docs/api/wallet-rpc.yaml
@@ -1121,14 +1121,9 @@ components:
           example: 6
           description: Bitcoin miner fee to use for transaction. A number higher than 1000 is used as satoshi per kvB tx fee. The number lower than that uses the dynamic fee estimation of blockchain provider as confirmation target.
         utxos:
-          type: array
-          items:
-            type: string
-            example:
-              - 96a1195792bfc851fbbd8ff51d07294cf9daa81af720bd020e6397311fc3b220:0
-          description: |
-            Optional parameter. If specified, these UTXOs will be used in the transaction.
-            If not specified, the default UTXO selection logic will be used.
+          type: string
+          example: 96a1195792bfc851fbbd8ff51d07294cf9daa81af720bd020e6397311fc3b220:0
+          description: Optional parameter. If specified, these UTXOs will be used in the transaction.If not specified, the default UTXO selection logic will be used.
     ErrorMessage:
         type: object
         properties:

--- a/docs/api/wallet-rpc.yaml
+++ b/docs/api/wallet-rpc.yaml
@@ -1120,10 +1120,6 @@ components:
           type: integer
           example: 6
           description: Bitcoin miner fee to use for transaction. A number higher than 1000 is used as satoshi per kvB tx fee. The number lower than that uses the dynamic fee estimation of blockchain provider as confirmation target.
-        utxos:
-          type: string
-          example: 96a1195792bfc851fbbd8ff51d07294cf9daa81af720bd020e6397311fc3b220:0
-          description: Optional parameter. If specified, these UTXOs will be used in the transaction.If not specified, the default UTXO selection logic will be used.
     ErrorMessage:
         type: object
         properties:

--- a/docs/api/wallet-rpc.yaml
+++ b/docs/api/wallet-rpc.yaml
@@ -1124,8 +1124,11 @@ components:
           type: array
           items:
             type: string
-            example: "96a1195792bfc851fbbd8ff51d07294cf9daa81af720bd020e6397311fc3b220:0"
-          description: Optional parameter. If specified, these UTXOs will be used in the transaction. If not specified, the default UTXO selection logic will be used.
+            example:
+              - 96a1195792bfc851fbbd8ff51d07294cf9daa81af720bd020e6397311fc3b220:0
+          description: |
+            Optional parameter. If specified, these UTXOs will be used in the transaction.
+            If not specified, the default UTXO selection logic will be used.
     ErrorMessage:
         type: object
         properties:

--- a/src/jmclient/taker_utils.py
+++ b/src/jmclient/taker_utils.py
@@ -173,7 +173,14 @@ def direct_send(wallet_service: WalletService,
                 utxo_str = f"{txid}:{index}"
                 if utxo_str in selected_utxos:
                     utxos[(u[0], u[1])] = va
-            
+                    
+            # Check if all selected_utxos are present in utxos
+            for utxo_str in selected_utxos:
+                txid, index = utxo_str.split(':')
+                if not any(u[0].hex() == txid and str(u[1]) == index for u in utxos.keys()):
+                    log.error(f"Selected UTXO {utxo_str} is not available in the specified mixdepth.")
+                    return False
+
             if not utxos:
                 log.error("None of the selected UTXOs are available in the specified mixdepth.")
                 return False

--- a/src/jmclient/taker_utils.py
+++ b/src/jmclient/taker_utils.py
@@ -4,6 +4,7 @@ import os
 import sys
 import time
 import numbers
+import ast
 from typing import Callable, List, Optional, Tuple, Union
 
 from jmbase import get_log, jmprint, bintohex, hextobin, \
@@ -37,7 +38,6 @@ def get_utxo_scripts(wallet: BaseWallet, utxos: dict) -> list:
 def direct_send(wallet_service: WalletService,
                 mixdepth: int,
                 dest_and_amounts: List[Tuple[str, int]],
-                selected_utxos: Optional[List[str]] = None,
                 answeryes: bool = False,
                 accept_callback: Optional[Callable[[str, str, int, int, Optional[str]], bool]] = None,
                 info_callback: Optional[Callable[[str], None]] = None,
@@ -161,7 +161,9 @@ def direct_send(wallet_service: WalletService,
 
         outs = []
         utxos = {}
-        if selected_utxos:
+        selected_utxos = jm_single().config.get("POLICY","utxos")
+        selected_utxos = ast.literal_eval(selected_utxos)
+        if selected_utxos is not None:
             # Filter UTXOs based on selected_utxos
             all_utxos = wallet_service.get_utxos_by_mixdepth().get(mixdepth, {})
             if not all_utxos:

--- a/src/jmclient/taker_utils.py
+++ b/src/jmclient/taker_utils.py
@@ -57,7 +57,7 @@ def direct_send(wallet_service: WalletService,
     ====
     args:
     deserialized tx, destination address, amount in satoshis,
-    fee in satoshis, custom change address
+    fee in satoshis, custom change address, selected utxos
 
     returns:
     True if accepted, False if not

--- a/src/jmclient/taker_utils.py
+++ b/src/jmclient/taker_utils.py
@@ -4,7 +4,6 @@ import os
 import sys
 import time
 import numbers
-import ast
 from typing import Callable, List, Optional, Tuple, Union
 
 from jmbase import get_log, jmprint, bintohex, hextobin, \
@@ -38,6 +37,7 @@ def get_utxo_scripts(wallet: BaseWallet, utxos: dict) -> list:
 def direct_send(wallet_service: WalletService,
                 mixdepth: int,
                 dest_and_amounts: List[Tuple[str, int]],
+                selected_utxos: Optional[List[str]] = None,
                 answeryes: bool = False,
                 accept_callback: Optional[Callable[[str, str, int, int, Optional[str]], bool]] = None,
                 info_callback: Optional[Callable[[str], None]] = None,
@@ -161,9 +161,7 @@ def direct_send(wallet_service: WalletService,
 
         outs = []
         utxos = {}
-        selected_utxos = jm_single().config.get("POLICY","utxos")
-        selected_utxos = ast.literal_eval(selected_utxos)
-        if selected_utxos is not None:
+        if selected_utxos:
             # Filter UTXOs based on selected_utxos
             all_utxos = wallet_service.get_utxos_by_mixdepth().get(mixdepth, {})
             if not all_utxos:

--- a/src/jmclient/taker_utils.py
+++ b/src/jmclient/taker_utils.py
@@ -47,7 +47,7 @@ def direct_send(wallet_service: WalletService,
                 optin_rbf: bool = True,
                 custom_change_addr: Optional[str] = None,
                 change_label: Optional[str] = None) -> Union[bool, str]:
-    """Send coins directly from one mixdepth to one or more destination addresses either using specific UTXOs or by mixdepth;
+    """Send coins directly either by mixdepth or selected UTXOs from a certain mixdepth to one or more destination addresses;
     does not need IRC. Sweep as for normal sendpayment (set amount=0).
     If answeryes is True, callback/command line query is not performed.
     If optin_rbf is True, the nSequence values are changed as appropriate.
@@ -173,7 +173,7 @@ def direct_send(wallet_service: WalletService,
                 utxo_str = f"{txid}:{index}"
                 if utxo_str in selected_utxos:
                     utxos[(u[0], u[1])] = va
-                    
+
             # Check if all selected_utxos are present in utxos
             for utxo_str in selected_utxos:
                 txid, index = utxo_str.split(':')

--- a/src/jmclient/taker_utils.py
+++ b/src/jmclient/taker_utils.py
@@ -57,13 +57,13 @@ def direct_send(wallet_service: WalletService,
     ====
     args:
     deserialized tx, destination address, amount in satoshis,
-    fee in satoshis, custom change address, selected UTXOs
+    fee in satoshis, custom change address
 
     returns:
     True if accepted, False if not
     ====
-    info_callback and error_callback take one parameter, the information
-    message (when tx is pushed or error occurred), and return nothing.
+    info_callback and error_callback takes one parameter, the information
+    message (when tx is pushed or error occured), and returns nothing.
 
     This function returns:
     1. False if there is any failure.
@@ -78,7 +78,7 @@ def direct_send(wallet_service: WalletService,
     outtypes = []
     total_outputs_val = 0
 
-    # Sanity checks
+    #Sanity checks
     assert isinstance(dest_and_amounts, list)
     assert len(dest_and_amounts) > 0
     assert custom_change_addr is None or validate_address(custom_change_addr)[0]

--- a/src/jmclient/taker_utils.py
+++ b/src/jmclient/taker_utils.py
@@ -47,7 +47,7 @@ def direct_send(wallet_service: WalletService,
                 optin_rbf: bool = True,
                 custom_change_addr: Optional[str] = None,
                 change_label: Optional[str] = None) -> Union[bool, str]:
-    """Send coins directly from one mixdepth to one or more destination addresses using specific UTXOs;
+    """Send coins directly from one mixdepth to one or more destination addresses either using specific UTXOs or by mixdepth;
     does not need IRC. Sweep as for normal sendpayment (set amount=0).
     If answeryes is True, callback/command line query is not performed.
     If optin_rbf is True, the nSequence values are changed as appropriate.
@@ -131,69 +131,96 @@ def direct_send(wallet_service: WalletService,
         amount = dest_and_amounts[0][1]
         utxos = wallet_service.get_utxos_by_mixdepth()[mixdepth]
         if utxos == {}:
-            log.error(f"There are no available utxos in mixdepth {mixdepth}, quitting.")
-            return False
+            log.error(
+                f"There are no available utxos in mixdepth {mixdepth}, "
+                 "quitting.")
+            return
         total_inputs_val = sum([va['value'] for u, va in utxos.items()])
         script_types = get_utxo_scripts(wallet_service.wallet, utxos)
-        fee_est = estimate_tx_fee(len(utxos), 1, txtype=script_types, outtype=outtypes[0])
-        outs = [{"address": destination, "value": total_inputs_val - fee_est}]
+        fee_est = estimate_tx_fee(len(utxos), 1, txtype=script_types,
+            outtype=outtypes[0])
+        outs = [{"address": destination,
+                 "value": total_inputs_val - fee_est}]
     else:
-        utxos = wallet_service.get_utxos_by_mixdepth().get(mixdepth, {})
-        if not utxos:
-            log.error(f"There are no available utxos in mixdepth {mixdepth}.")
-            return False
-        
+        if custom_change_addr:
+            change_type = wallet_service.get_outtype(custom_change_addr)
+            if change_type is None:
+                # we don't recognize this type; best we can do is revert to
+                # default, even though it may be inaccurate:
+                change_type = txtype
+        else:
+            change_type = txtype
+        if outtypes[0] is None:
+            # we don't recognize the destination script type,
+            # so set it as the same as the change (which will usually
+            # be the same as the spending wallet, but see above for custom)
+            # Notice that this is handled differently to the sweep case above,
+            # because we must use a list - there is more than one output
+            outtypes[0] = change_type
+        outtypes.append(change_type)
+
+        outs = []
+        utxos = {}
         if selected_utxos:
             # Filter UTXOs based on selected_utxos
-            selected_utxo_dict = {}
-            for u, va in utxos.items():
+            all_utxos = wallet_service.get_utxos_by_mixdepth().get(mixdepth, {})
+            if not all_utxos:
+                log.error(f"There are no available utxos in mixdepth {mixdepth}.")
+                return False
+            for u, va in all_utxos.items():
                 txid = u[0].hex()
                 index = u[1]
                 utxo_str = f"{txid}:{index}"
                 if utxo_str in selected_utxos:
-                    selected_utxo_dict[(u[0], u[1])] = va
+                    utxos[(u[0], u[1])] = va
             
-            if not selected_utxo_dict:
+            if not utxos:
                 log.error("None of the selected UTXOs are available in the specified mixdepth.")
                 return False
+            script_types = get_utxo_scripts(wallet_service.wallet, utxos)
+            fee_est = estimate_tx_fee(len(utxos), len(dest_and_amounts) + 1, txtype=script_types, outtype=outtypes)
+            total_inputs_val = sum([va['value'] for u, va in utxos.items()])
+            changeval = total_inputs_val - fee_est - total_outputs_val
+            
+            for out in dest_and_amounts:
+                outs.append({"value": out[1], "address": out[0]})
+            
+            change_addr = wallet_service.get_internal_addr(mixdepth) if custom_change_addr is None else custom_change_addr
+            outs.append({"value": changeval, "address": change_addr})
+        
         else:
-            selected_utxo_dict = utxos
+            # not doing a sweep; we will have change.
+            # 8 inputs to be conservative; note we cannot account for the possibility
+            # of non-standard input types at this point.
+            initial_fee_est = estimate_tx_fee(8, len(dest_and_amounts) + 1,
+                                            txtype=txtype, outtype=outtypes)
+            utxos = wallet_service.select_utxos(mixdepth, amount + initial_fee_est,
+                                                includeaddr=True)
+            script_types = get_utxo_scripts(wallet_service.wallet, utxos)
+            if len(utxos) < 8:
+                fee_est = estimate_tx_fee(len(utxos), len(dest_and_amounts) + 1,
+                                        txtype=script_types, outtype=outtypes)
+            else:
+                fee_est = initial_fee_est
+            total_inputs_val = sum([va['value'] for u, va in utxos.items()])
+            changeval = total_inputs_val - fee_est - total_outputs_val
+            
+            for out in dest_and_amounts:
+                outs.append({"value": out[1], "address": out[0]})
+            change_addr = wallet_service.get_internal_addr(mixdepth) \
+                if custom_change_addr is None else custom_change_addr
+            outs.append({"value": changeval, "address": change_addr})
 
-        total_inputs_val = sum([va['value'] for u, va in selected_utxo_dict.items()])
-        if total_inputs_val < total_outputs_val:
-            log.error("Selected UTXOs do not cover the total output value.")
-            return False
-        
-        if custom_change_addr:
-            change_type = wallet_service.get_outtype(custom_change_addr)
-            if change_type is None:
-                change_type = txtype
-        else:
-            change_type = txtype
-        
-        if outtypes[0] is None:
-            outtypes[0] = change_type
-        outtypes.append(change_type)
-        
-        fee_est = estimate_tx_fee(len(selected_utxo_dict), len(dest_and_amounts) + 1, txtype=txtype, outtype=outtypes)
-        changeval = total_inputs_val - fee_est - total_outputs_val
-        
-        outs = []
-        for out in dest_and_amounts:
-            outs.append({"value": out[1], "address": out[0]})
-        
-        change_addr = wallet_service.get_internal_addr(mixdepth) if custom_change_addr is None else custom_change_addr
-        outs.append({"value": changeval, "address": change_addr})
-    
     #compute transaction locktime, has special case for spending timelocked coins
     tx_locktime = compute_tx_locktime()
-    if mixdepth == FidelityBondMixin.FIDELITY_BOND_MIXDEPTH and isinstance(wallet_service.wallet, FidelityBondMixin):
-        for outpoint, utxo in selected_utxo_dict.items():
+    if mixdepth == FidelityBondMixin.FIDELITY_BOND_MIXDEPTH and \
+            isinstance(wallet_service.wallet, FidelityBondMixin):
+        for outpoint, utxo in utxos.items():
             path = wallet_service.script_to_path(utxo["script"])
             if not FidelityBondMixin.is_timelocked_path(path):
                 continue
             path_locktime = path[-1]
-            tx_locktime = max(tx_locktime, path_locktime + 1)
+            tx_locktime = max(tx_locktime, path_locktime+1)
             #compute_tx_locktime() gives a locktime in terms of block height
             #timelocked addresses use unix time instead
             #OP_CHECKLOCKTIMEVERIFY can only compare like with like, so we
@@ -203,8 +230,8 @@ def direct_send(wallet_service: WalletService,
     log.info("Using a fee of: " + amount_to_str(fee_est) + ".")
     if not is_sweep:
         log.info("Using a change value of: " + amount_to_str(changeval) + ".")
-    
-    tx = make_shuffled_tx(list(selected_utxo_dict.keys()), outs, version=2, locktime=tx_locktime)
+    tx = make_shuffled_tx(list(utxos.keys()), outs,
+                          version=2, locktime=tx_locktime)
 
     if optin_rbf:
         for inp in tx.vin:
@@ -214,9 +241,9 @@ def direct_send(wallet_service: WalletService,
     spent_outs = []
     for i, txinp in enumerate(tx.vin):
         u = (txinp.prevout.hash[::-1], txinp.prevout.n)
-        inscripts[i] = (selected_utxo_dict[u]["script"], selected_utxo_dict[u]["value"])
-        spent_outs.append(CMutableTxOut(selected_utxo_dict[u]["value"], selected_utxo_dict[u]["script"]))
-    
+        inscripts[i] = (utxos[u]["script"], utxos[u]["value"])
+        spent_outs.append(CMutableTxOut(utxos[u]["value"],
+                                        utxos[u]["script"]))
     if with_final_psbt:
         # here we have the PSBTWalletMixin do the signing stage
         # for us:
@@ -233,11 +260,12 @@ def direct_send(wallet_service: WalletService,
         success, msg = wallet_service.sign_tx(tx, inscripts)
         if not success:
             log.error("Failed to sign transaction, quitting. Error msg: " + msg)
-            return False
+            return
         log.info("Got signed transaction:\n")
         log.info(human_readable_transaction(tx))
-        actual_amount = sum([out[1] for out in dest_and_amounts])
-        sending_info = "Sends: " + amount_to_str(actual_amount) + " to destination: " + ", ".join([out[0] for out in dest_and_amounts])
+        actual_amount = amount if amount != 0 else total_inputs_val - fee_est
+        sending_info = "Sends: " + amount_to_str(actual_amount) + \
+            " to destination: " + destination
         if custom_change_addr:
             sending_info += ", custom change to: " + custom_change_addr
         log.info(sending_info)
@@ -247,13 +275,16 @@ def direct_send(wallet_service: WalletService,
                     log.info("You chose not to broadcast the transaction, quitting.")
                     return False
             else:
-                accepted = accept_callback(human_readable_transaction(tx), dest_and_amounts[0][0], actual_amount, fee_est, custom_change_addr)
+                accepted = accept_callback(human_readable_transaction(tx),
+                                           destination, actual_amount, fee_est,
+                                           custom_change_addr)
                 if not accepted:
                     return False
         if change_label:
             try:
                 wallet_service.set_address_label(change_addr, change_label)
             except UnknownAddressForLabel:
+                # ignore, will happen with custom change not part of a wallet
                 pass
         if jm_single().bc_interface.pushtx(tx.serialize()):
             txid = bintohex(tx.GetTxid()[::-1])

--- a/src/jmclient/taker_utils.py
+++ b/src/jmclient/taker_utils.py
@@ -36,6 +36,7 @@ def get_utxo_scripts(wallet: BaseWallet, utxos: dict) -> list:
 
 def direct_send(wallet_service: WalletService,
                 mixdepth: int,
+                selected_utxos: List[str],
                 dest_and_amounts: List[Tuple[str, int]],
                 answeryes: bool = False,
                 accept_callback: Optional[Callable[[str, str, int, int, Optional[str]], bool]] = None,
@@ -46,7 +47,7 @@ def direct_send(wallet_service: WalletService,
                 optin_rbf: bool = True,
                 custom_change_addr: Optional[str] = None,
                 change_label: Optional[str] = None) -> Union[bool, str]:
-    """Send coins directly from one mixdepth to one destination address;
+    """Send coins directly from one mixdepth to one or more destination addresses using specific UTXOs;
     does not need IRC. Sweep as for normal sendpayment (set amount=0).
     If answeryes is True, callback/command line query is not performed.
     If optin_rbf is True, the nSequence values are changed as appropriate.
@@ -56,13 +57,13 @@ def direct_send(wallet_service: WalletService,
     ====
     args:
     deserialized tx, destination address, amount in satoshis,
-    fee in satoshis, custom change address
+    fee in satoshis, custom change address, selected UTXOs
 
     returns:
     True if accepted, False if not
     ====
-    info_callback and error_callback takes one parameter, the information
-    message (when tx is pushed or error occured), and returns nothing.
+    info_callback and error_callback take one parameter, the information
+    message (when tx is pushed or error occurred), and return nothing.
 
     This function returns:
     1. False if there is any failure.
@@ -77,7 +78,7 @@ def direct_send(wallet_service: WalletService,
     outtypes = []
     total_outputs_val = 0
 
-    #Sanity checks
+    # Sanity checks
     assert isinstance(dest_and_amounts, list)
     assert len(dest_and_amounts) > 0
     assert custom_change_addr is None or validate_address(custom_change_addr)[0]
@@ -128,67 +129,72 @@ def direct_send(wallet_service: WalletService,
         #doing a sweep
         destination = dest_and_amounts[0][0]
         amount = dest_and_amounts[0][1]
-        utxos = wallet_service.get_utxos_by_mixdepth()[mixdepth]
-        if utxos == {}:
+        selected_utxo_dict = wallet_service.get_utxos_by_mixdepth()[mixdepth]
+        if selected_utxo_dict == {}:
             log.error(
                 f"There are no available utxos in mixdepth {mixdepth}, "
                  "quitting.")
             return
-        total_inputs_val = sum([va['value'] for u, va in utxos.items()])
-        script_types = get_utxo_scripts(wallet_service.wallet, utxos)
-        fee_est = estimate_tx_fee(len(utxos), 1, txtype=script_types,
+        total_inputs_val = sum([va['value'] for u, va in selected_utxo_dict.items()])
+        script_types = get_utxo_scripts(wallet_service.wallet, selected_utxo_dict)
+        fee_est = estimate_tx_fee(len(selected_utxo_dict), 1, txtype=script_types,
             outtype=outtypes[0])
         outs = [{"address": destination,
                  "value": total_inputs_val - fee_est}]
     else:
+        utxos = wallet_service.get_utxos_by_mixdepth().get(mixdepth, {})
+        if not utxos:
+            log.error(f"There are no available utxos in mixdepth {mixdepth}.")
+            return False
+        
+        # Filter UTXOs based on selected_utxos
+        selected_utxo_dict = {}
+        for u, va in utxos.items():
+            txid = u[0].hex()
+            index = u[1]
+            utxo_str = f"{txid}:{index}"
+            if utxo_str in selected_utxos:
+                selected_utxo_dict[(u[0], u[1])] = va
+        
+        if not selected_utxo_dict:
+            log.error("None of the selected UTXOs are available in the specified mixdepth.")
+            return False
+        
+        total_inputs_val = sum([va['value'] for u, va in selected_utxo_dict.items()])
+        if total_inputs_val < total_outputs_val:
+            log.error("Selected UTXOs do not cover the total output value.")
+            return False
+        
         if custom_change_addr:
             change_type = wallet_service.get_outtype(custom_change_addr)
             if change_type is None:
-                # we don't recognize this type; best we can do is revert to
-                # default, even though it may be inaccurate:
                 change_type = txtype
         else:
             change_type = txtype
+        
         if outtypes[0] is None:
-            # we don't recognize the destination script type,
-            # so set it as the same as the change (which will usually
-            # be the same as the spending wallet, but see above for custom)
-            # Notice that this is handled differently to the sweep case above,
-            # because we must use a list - there is more than one output
             outtypes[0] = change_type
         outtypes.append(change_type)
-        # not doing a sweep; we will have change.
-        # 8 inputs to be conservative; note we cannot account for the possibility
-        # of non-standard input types at this point.
-        initial_fee_est = estimate_tx_fee(8, len(dest_and_amounts) + 1,
-                                          txtype=txtype, outtype=outtypes)
-        utxos = wallet_service.select_utxos(mixdepth, amount + initial_fee_est,
-                                            includeaddr=True)
-        script_types = get_utxo_scripts(wallet_service.wallet, utxos)
-        if len(utxos) < 8:
-            fee_est = estimate_tx_fee(len(utxos), len(dest_and_amounts) + 1,
-                                      txtype=script_types, outtype=outtypes)
-        else:
-            fee_est = initial_fee_est
-        total_inputs_val = sum([va['value'] for u, va in utxos.items()])
+        
+        fee_est = estimate_tx_fee(len(selected_utxo_dict), len(dest_and_amounts) + 1, txtype=txtype, outtype=outtypes)
         changeval = total_inputs_val - fee_est - total_outputs_val
+        
         outs = []
         for out in dest_and_amounts:
             outs.append({"value": out[1], "address": out[0]})
-        change_addr = wallet_service.get_internal_addr(mixdepth) \
-            if custom_change_addr is None else custom_change_addr
+        
+        change_addr = wallet_service.get_internal_addr(mixdepth) if custom_change_addr is None else custom_change_addr
         outs.append({"value": changeval, "address": change_addr})
-
+    
     #compute transaction locktime, has special case for spending timelocked coins
     tx_locktime = compute_tx_locktime()
-    if mixdepth == FidelityBondMixin.FIDELITY_BOND_MIXDEPTH and \
-            isinstance(wallet_service.wallet, FidelityBondMixin):
-        for outpoint, utxo in utxos.items():
+    if mixdepth == FidelityBondMixin.FIDELITY_BOND_MIXDEPTH and isinstance(wallet_service.wallet, FidelityBondMixin):
+        for outpoint, utxo in selected_utxo_dict.items():
             path = wallet_service.script_to_path(utxo["script"])
             if not FidelityBondMixin.is_timelocked_path(path):
                 continue
             path_locktime = path[-1]
-            tx_locktime = max(tx_locktime, path_locktime+1)
+            tx_locktime = max(tx_locktime, path_locktime + 1)
             #compute_tx_locktime() gives a locktime in terms of block height
             #timelocked addresses use unix time instead
             #OP_CHECKLOCKTIMEVERIFY can only compare like with like, so we
@@ -198,8 +204,8 @@ def direct_send(wallet_service: WalletService,
     log.info("Using a fee of: " + amount_to_str(fee_est) + ".")
     if not is_sweep:
         log.info("Using a change value of: " + amount_to_str(changeval) + ".")
-    tx = make_shuffled_tx(list(utxos.keys()), outs,
-                          version=2, locktime=tx_locktime)
+    
+    tx = make_shuffled_tx(list(selected_utxo_dict.keys()), outs, version=2, locktime=tx_locktime)
 
     if optin_rbf:
         for inp in tx.vin:
@@ -209,9 +215,9 @@ def direct_send(wallet_service: WalletService,
     spent_outs = []
     for i, txinp in enumerate(tx.vin):
         u = (txinp.prevout.hash[::-1], txinp.prevout.n)
-        inscripts[i] = (utxos[u]["script"], utxos[u]["value"])
-        spent_outs.append(CMutableTxOut(utxos[u]["value"],
-                                        utxos[u]["script"]))
+        inscripts[i] = (selected_utxo_dict[u]["script"], selected_utxo_dict[u]["value"])
+        spent_outs.append(CMutableTxOut(selected_utxo_dict[u]["value"], selected_utxo_dict[u]["script"]))
+    
     if with_final_psbt:
         # here we have the PSBTWalletMixin do the signing stage
         # for us:
@@ -228,12 +234,11 @@ def direct_send(wallet_service: WalletService,
         success, msg = wallet_service.sign_tx(tx, inscripts)
         if not success:
             log.error("Failed to sign transaction, quitting. Error msg: " + msg)
-            return
+            return False
         log.info("Got signed transaction:\n")
         log.info(human_readable_transaction(tx))
-        actual_amount = amount if amount != 0 else total_inputs_val - fee_est
-        sending_info = "Sends: " + amount_to_str(actual_amount) + \
-            " to destination: " + destination
+        actual_amount = sum([out[1] for out in dest_and_amounts])
+        sending_info = "Sends: " + amount_to_str(actual_amount) + " to destination: " + ", ".join([out[0] for out in dest_and_amounts])
         if custom_change_addr:
             sending_info += ", custom change to: " + custom_change_addr
         log.info(sending_info)
@@ -243,16 +248,13 @@ def direct_send(wallet_service: WalletService,
                     log.info("You chose not to broadcast the transaction, quitting.")
                     return False
             else:
-                accepted = accept_callback(human_readable_transaction(tx),
-                                           destination, actual_amount, fee_est,
-                                           custom_change_addr)
+                accepted = accept_callback(human_readable_transaction(tx), dest_and_amounts[0][0], actual_amount, fee_est, custom_change_addr)
                 if not accepted:
                     return False
         if change_label:
             try:
                 wallet_service.set_address_label(change_addr, change_label)
             except UnknownAddressForLabel:
-                # ignore, will happen with custom change not part of a wallet
                 pass
         if jm_single().bc_interface.pushtx(tx.serialize()):
             txid = bintohex(tx.GetTxid()[::-1])

--- a/src/jmclient/wallet_rpc.py
+++ b/src/jmclient/wallet_rpc.py
@@ -792,43 +792,36 @@ class JMWalletDaemon(Service):
                                            str(payment_info_json["txfee"]))
                 else:
                     raise InvalidRequestFormat()
-                    
-            if "utxos" in payment_info_json:
-                jm_single().config.set("POLICY", "utxos", str(payment_info_json["utxos"]))
-            else:
-                jm_single().config.set("POLICY", "utxos", str(None))
 
             try:
                 mixdepth = int(payment_info_json["mixdepth"])
                 destination = payment_info_json["destination"]
                 amount_sats = int(payment_info_json["amount_sats"])
                 dest_and_amounts = [(destination, amount_sats)]
+                utxos = payment_info_json.get("utxos", None)
 
                 tx = direct_send(
                     self.services["wallet"],
                     mixdepth,
                     dest_and_amounts,
+                    utxos,
                     return_transaction=True,
                     answeryes=True
                     )
 
                 jm_single().config.set("POLICY", "tx_fees",
                                        self.default_policy_tx_fees)
-                jm_single().config.set("POLICY", "utxos", str(None))
             except AssertionError:
                 jm_single().config.set("POLICY", "tx_fees",
                                        self.default_policy_tx_fees)
-                jm_single().config.set("POLICY", "utxos", str(None))
                 raise InvalidRequestFormat()
             except NotEnoughFundsException as e:
                 jm_single().config.set("POLICY", "tx_fees",
                                        self.default_policy_tx_fees)
-                jm_single().config.set("POLICY", "utxos", str(None))
                 raise TransactionFailed(repr(e))
             except Exception:
                 jm_single().config.set("POLICY", "tx_fees",
                                        self.default_policy_tx_fees)
-                jm_single().config.set("POLICY", "utxos", str(None))
                 raise
             if not tx:
                 # this should not really happen; not a coinjoin

--- a/src/jmclient/wallet_rpc.py
+++ b/src/jmclient/wallet_rpc.py
@@ -770,9 +770,8 @@ class JMWalletDaemon(Service):
             """
             self.check_cookie(request)
             assert isinstance(request.content, BytesIO)
-            payment_info_json = self.get_POST_body(request, ["mixdepth","utxos","amount_sats",
-                                                             "destination"],
-                                                            ["txfee"])
+            payment_info_json = self.get_POST_body(request, ["mixdepth", "amount_sats", "destination"], ["txfee", "utxos"])
+
             if not payment_info_json:
                 raise InvalidRequestFormat()
             if not self.services["wallet"]:
@@ -799,7 +798,7 @@ class JMWalletDaemon(Service):
                 destination = payment_info_json["destination"]
                 amount_sats = int(payment_info_json["amount_sats"])
                 dest_and_amounts = [(destination, amount_sats)]
-                utxos = payment_info_json.get("utxos")
+                utxos = payment_info_json.get("utxos", None)
 
                 tx = direct_send(
                     self.services["wallet"],

--- a/src/jmclient/wallet_rpc.py
+++ b/src/jmclient/wallet_rpc.py
@@ -803,11 +803,12 @@ class JMWalletDaemon(Service):
                 tx = direct_send(
                     self.services["wallet"],
                     mixdepth,
-                    utxos,
                     dest_and_amounts,
+                    utxos,
                     return_transaction=True,
                     answeryes=True
                     )
+
                 jm_single().config.set("POLICY", "tx_fees",
                                        self.default_policy_tx_fees)
             except AssertionError:

--- a/src/jmclient/wallet_rpc.py
+++ b/src/jmclient/wallet_rpc.py
@@ -792,36 +792,43 @@ class JMWalletDaemon(Service):
                                            str(payment_info_json["txfee"]))
                 else:
                     raise InvalidRequestFormat()
+                    
+            if "utxos" in payment_info_json:
+                jm_single().config.set("POLICY", "utxos", str(payment_info_json["utxos"]))
+            else:
+                jm_single().config.set("POLICY", "utxos", str(None))
 
             try:
                 mixdepth = int(payment_info_json["mixdepth"])
                 destination = payment_info_json["destination"]
                 amount_sats = int(payment_info_json["amount_sats"])
                 dest_and_amounts = [(destination, amount_sats)]
-                utxos = payment_info_json.get("utxos", None)
 
                 tx = direct_send(
                     self.services["wallet"],
                     mixdepth,
                     dest_and_amounts,
-                    utxos,
                     return_transaction=True,
                     answeryes=True
                     )
 
                 jm_single().config.set("POLICY", "tx_fees",
                                        self.default_policy_tx_fees)
+                jm_single().config.set("POLICY", "utxos", str(None))
             except AssertionError:
                 jm_single().config.set("POLICY", "tx_fees",
                                        self.default_policy_tx_fees)
+                jm_single().config.set("POLICY", "utxos", str(None))
                 raise InvalidRequestFormat()
             except NotEnoughFundsException as e:
                 jm_single().config.set("POLICY", "tx_fees",
                                        self.default_policy_tx_fees)
+                jm_single().config.set("POLICY", "utxos", str(None))
                 raise TransactionFailed(repr(e))
             except Exception:
                 jm_single().config.set("POLICY", "tx_fees",
                                        self.default_policy_tx_fees)
+                jm_single().config.set("POLICY", "utxos", str(None))
                 raise
             if not tx:
                 # this should not really happen; not a coinjoin


### PR DESCRIPTION
This PR fixes #1712 and addresses https://github.com/joinmarket-webui/jam/issues/772
Changes Made:

1. Updated the `direct-send` API to accept a list of `UTXOs` specified by the user.
2. Implemented backend logic to handle the selection of these `UTXOs` for the transaction.
3. Added necessary `validation checks` to ensure the specified UTXOs are part of the `user's wallet` and are `unfrozen`.