### PR TITLE
Adding a parameter and model that limits a very large maker to be systematically included in every transaction.

### DIFF
--- a/scripts/tumbler.py
+++ b/scripts/tumbler.py
@@ -65,6 +65,18 @@ def main():
     log.info("Using maximum coinjoin fee limits per maker of {:.4%}, {} sat"
              .format(*maxcjfee))
 
+    tx_max_expected_probability = jm_single().config.getfloat("POLICY", "tx_max_expected_probability")
+
+    if tx_max_expected_probability <= 0:
+        jmprint('Error: tx_max_expected_probability must be greater than 0', "error")
+        sys.exit(EXIT_FAILURE)
+
+    elif tx_max_expected_probability > 1:
+        tx_max_expected_probability = 1
+
+    log.info("Using maximum expected probability of selecting a maker of {:.2%}"
+             .format(tx_max_expected_probability))
+
     #Parse options and generate schedule
     #Output information to log files
     jm_single().mincjamount = options['mincjamount']
@@ -185,6 +197,7 @@ def main():
     taker = Taker(wallet_service,
                   schedule,
                   maxcjfee,
+                  tx_max_expected_probability,
                   order_chooser=options['order_choose_fn'],
                   callbacks=(filter_orders_callback, None, taker_finished),
                   tdestaddrs=destaddrs)

--- a/src/jmclient/configure.py
+++ b/src/jmclient/configure.py
@@ -400,6 +400,8 @@ bondless_makers_allowance = """ + _DEFAULT_BONDLESS_MAKERS_ALLOWANCE + """
 # where x > 1. It is a real number (so written as a decimal).
 bond_value_exponent = 1.3
 
+tx_max_expected_probability = 1.0
+
 ##############################
 # THE FOLLOWING SETTINGS ARE REQUIRED TO DEFEND AGAINST SNOOPERS.
 # DON'T ALTER THEM UNLESS YOU UNDERSTAND THE IMPLICATIONS.

--- a/src/jmclient/taker.py
+++ b/src/jmclient/taker.py
@@ -48,6 +48,7 @@ class Taker(object):
                  wallet_service,
                  schedule,
                  max_cj_fee,
+                 tx_max_expected_probability,
                  order_chooser=fidelity_bond_weighted_order_choose,
                  callbacks=None,
                  tdestaddrs=None,
@@ -104,6 +105,7 @@ class Taker(object):
         self.schedule = schedule
         self.order_chooser = order_chooser
         self.max_cj_fee = max_cj_fee
+        self.tx_max_expected_probability = tx_max_expected_probability
         self.custom_change_address = custom_change_address
         self.change_label = change_label
 
@@ -290,7 +292,7 @@ class Taker(object):
             self.orderbook, self.total_cj_fee = choose_orders(
                 orderbook, self.cjamount, self.n_counterparties, self.order_chooser,
                 self.ignored_makers, allowed_types=allowed_types,
-                max_cj_fee=self.max_cj_fee)
+                max_cj_fee=self.max_cj_fee, tx_max_expected_probability=self.tx_max_expected_probability)
             if self.orderbook is None:
                 #Failure to get an orderbook means order selection failed
                 #for some reason; no action is taken, we let the stallMonitor
@@ -381,7 +383,7 @@ class Taker(object):
                 self.orderbook, total_value, self.total_txfee,
                 self.n_counterparties, self.order_chooser,
                 self.ignored_makers, allowed_types=allowed_types,
-                max_cj_fee=self.max_cj_fee)
+                max_cj_fee=self.max_cj_fee, tx_max_expected_probability=self.tx_max_expected_probability)
             if not self.orderbook:
                 self.taker_info_callback("ABORT",
                                 "Could not find orders to complete transaction")

--- a/test/jmclient/test_support.py
+++ b/test/jmclient/test_support.py
@@ -76,7 +76,7 @@ def test_choose_orders():
     #test the fidelity bond one
     for i, o in enumerate(orderbook):
         o["fidelity_bond_value"] = i+1
-    orders_fees = choose_orders(orderbook, 100000000, 3, fidelity_bond_weighted_order_choose)
+    orders_fees = choose_orders(orderbook, 100000000, 3, fidelity_bond_weighted_order_choose, tx_max_expected_probability=0.75)
     assert len(orders_fees[0]) == 3
     #test sweep
     result, cjamount, total_fee = choose_sweep_orders(orderbook, 50000000,


### PR DESCRIPTION
Adding support for tx_max_expected_probability, a parameter that defines the maximum expected probability for a single maker to be included in a collaborative transaction. A value of 1 (100%) for this probability corresponds to the previous behavior. A value smaller than 1 allows to prevent a large maker from always being included in a transaction. For a given total amount of fidelity bonds, this mechanism allows to reduce the ability of an attacker to be systematically included in a transaction, and also to be the only entity included as makers in the transaction.

The maximum probability of a maker to be included in each maker draw is calculated based on the number of remaining draws and the probability for such a maker to have not been included so far in the previous single maker draws for the current transaction. This maximum probability per draw is used to effectively cap the fidelity bond values of bond makers that would be otherwise included in every single transaction. It makes it more expensive for an attacker to either prevent transactions or to be the only entity used as counter-party