### PR TITLE
Bump minimum required Bitcoin Core version from 0.18 to 22.0

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -10,7 +10,7 @@ jobs:
       matrix:
         os: [macos-13, ubuntu-latest]
         python-version: ["3.8", "3.12"]
-        bitcoind-version: ["0.18.0", "27.1"]
+        bitcoind-version: ["22.0", "27.1"]
 
     steps:
       - uses: actions/checkout@v3

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -137,7 +137,7 @@ If (a), then note the following two points:
 
 ##### Installing Bitcoin Core
 
-If you haven't done so yet, install Bitcoin Core, version 0.18 or newer, as described [here](https://bitcoin.org/en/full-node#windows-10). After starting it for the first time, it will start the Initial Block Download. JoinMarket cannot be used until this is finished. More information on that can be found [here](https://bitcoin.org/en/full-node#initial-block-downloadibd).
+If you haven't done so yet, install Bitcoin Core, version 22.0 or newer, as described [here](https://bitcoin.org/en/full-node#windows-10). After starting it for the first time, it will start the Initial Block Download. JoinMarket cannot be used until this is finished. More information on that can be found [here](https://bitcoin.org/en/full-node#initial-block-downloadibd).
 
 ##### Configuring Bitcoin Core
 

--- a/docs/PAYJOIN.md
+++ b/docs/PAYJOIN.md
@@ -39,7 +39,7 @@ So just skip those sections if you already know it.
 
 ### Preparatory step: configuring for Bitcoin Core.
 
-Joinmarket currently requires a Bitcoin Core full node, version 0.18 or newer, although it can be pruned.
+Joinmarket currently requires a Bitcoin Core full node, version 22.0 or newer, although it can be pruned.
 
 First thing to do: in `scripts/`, run:
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -1,6 +1,6 @@
 ### Test instructions (for developers):
 
-Work in your `jmvenv` virtual environment as for all Joinmarket work. Make sure to have [bitcoind](https://bitcoin.org/en/full-node) 0.18 or newer installed. Also need miniircd installed to the root (i.e. in your `joinmarket-clientserver` directory):
+Work in your `jmvenv` virtual environment as for all Joinmarket work. Make sure to have [bitcoind](https://bitcoin.org/en/full-node) 22.0 or newer installed. Also need miniircd installed to the root (i.e. in your `joinmarket-clientserver` directory):
 
     (jmvenv)$ cd /path/to/joinmarket-clientserver
     (jmvenv)$ git clone https://github.com/Joinmarket-Org/miniircd

--- a/test/Dockerfiles/build_docker.sh
+++ b/test/Dockerfiles/build_docker.sh
@@ -15,7 +15,7 @@ build_docker ()
         return 0
     fi
 
-    core_version='0.18.0'
+    core_version='22.0'
     core_dist="bitcoin-${core_version}-x86_64-linux-gnu.tar.gz"
     core_url="https://bitcoincore.org/bin/bitcoin-core-${core_version}/${core_dist}"
     declare -A deps=( [${core_dist}]="${core_url}" )


### PR DESCRIPTION
There have been multiple vulnerabilities disclosed for older versions, we should not recommend people using them.

* Disclosure of memory DoS due to malicious P2P message - https://bitcoincore.org/en/2024/07/03/disclose-inv-buffer-blowup/
* Disclosure of CPU DoS due to malicious P2P message - https://bitcoincore.org/en/2024/07/03/disclose-getdata-cpu/
* Disclosure of crash due to malicious BIP72 URI - https://bitcoincore.org/en/2024/07/03/disclose-bip70-crash/
* Disclosure of netsplit due to malicious P2P messages by first 200 peers - https://bitcoincore.org/en/2024/07/03/disclose-timestamp-overflow/
* Disclosure of CPU/memory DoS due to many malicious peers - https://bitcoincore.org/en/2024/07/03/disclose-unbounded-banlist/
* Disclosure of censoring unconfirmed transactions to a specific victim - https://bitcoincore.org/en/2024/07/03/disclose_already_asked_for/
* https://github.com/bitcoin-core/bitcoincore.org/pull/1049