### PR TITLE
Updated Direct-Send RPC-Api to accept list of UTXOs

### DIFF
--- a/docs/api/wallet-rpc.yaml
+++ b/docs/api/wallet-rpc.yaml
@@ -1120,6 +1120,12 @@ components:
           type: integer
           example: 6
           description: Bitcoin miner fee to use for transaction. A number higher than 1000 is used as satoshi per kvB tx fee. The number lower than that uses the dynamic fee estimation of blockchain provider as confirmation target.
+        selected_utxos:
+          type: array
+          items:
+            type: string
+            example: 85cf4c880876eead0a6674cbc341b21b86058530c2eacf18a16007f8f9cb1b1a:0
+          nullable: true
     ErrorMessage:
         type: object
         properties:


### PR DESCRIPTION
This PR fixes https://github.com/JoinMarket-Org/joinmarket-clientserver/issues/1712 and addresses https://github.com/joinmarket-webui/jam/issues/772
Changes Made:

- Updated the direct-send API to accept a list of UTXOs specified by the user.
- Implemented backend logic to handle the selection of these UTXOs for the transaction.
- Added necessary validation checks to ensure the specified UTXOs are part of the user's wallet.
- Ensured backward compatibility by making selected_utxos an optional property."