### PR TITLE
doc: Tor control auth cookie file must be group readable

### DIFF
--- a/docs/tor.md
+++ b/docs/tor.md
@@ -54,11 +54,12 @@ Don't start the tor daemon yet though, since we need to do some setup. Edit Tor'
 sudo vim /etc/tor/torrc
 ```
 
-and uncomment these two lines to enable onion service startup:
+and uncomment these three lines to enable onion service startup:
 
 ```
 ControlPort 9051
 CookieAuthentication 1
+CookieAuthFileGroupReadable 1
 ```
 
 However if you proceed at this point to try to start your yieldgenerator with `python yg-privacyenhanced.py wallet.jmdat` or similar, you will almost certainly get an error like this:


### PR DESCRIPTION
It is off by default, but must be enabled, unless Tor is running under the same user as JoinMarket, which is not the case except for built-in Tor (but then user does not need to configure `/etc/tor/torrc`).

```
       CookieAuthFileGroupReadable 0|1
           If this option is set to 0, don’t allow the filesystem group to read the cookie file. If the option is set to 1, make the cookie file readable
           by the default GID. [Making the file readable by other groups is not yet implemented; let us know if you need this for some reason.] (Default:
           0)
```