### PR TITLE
Bump minimum required Bitcoin Core version from 24.0.1 to 25.1

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -10,7 +10,7 @@ jobs:
       matrix:
         os: [macos-13, ubuntu-latest]
         python-version: ["3.8", "3.12"]
-        bitcoind-version: ["24.0.1", "28.0"]
+        bitcoind-version: ["25.1", "28.0"]
 
     steps:
       - uses: actions/checkout@v3

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -137,7 +137,7 @@ If (a), then note the following two points:
 
 ##### Installing Bitcoin Core
 
-If you haven't done so yet, install Bitcoin Core, version 24.0.1 or newer, as described [here](https://bitcoin.org/en/full-node#windows-10). After starting it for the first time, it will start the Initial Block Download. JoinMarket cannot be used until this is finished. More information on that can be found [here](https://bitcoin.org/en/full-node#initial-block-downloadibd).
+If you haven't done so yet, install Bitcoin Core, version 25.1 or newer, as described [here](https://bitcoin.org/en/full-node#windows-10). After starting it for the first time, it will start the Initial Block Download. JoinMarket cannot be used until this is finished. More information on that can be found [here](https://bitcoin.org/en/full-node#initial-block-downloadibd).
 
 ##### Configuring Bitcoin Core
 

--- a/docs/PAYJOIN.md
+++ b/docs/PAYJOIN.md
@@ -39,7 +39,7 @@ So just skip those sections if you already know it.
 
 ### Preparatory step: configuring for Bitcoin Core.
 
-Joinmarket currently requires a Bitcoin Core full node, version 24.0.1 or newer, although it can be pruned.
+Joinmarket currently requires a Bitcoin Core full node, version 25.1 or newer, although it can be pruned.
 
 First thing to do: in `scripts/`, run:
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -1,6 +1,6 @@
 ### Test instructions (for developers):
 
-Work in your `jmvenv` virtual environment as for all Joinmarket work. Make sure to have [bitcoind](https://bitcoin.org/en/full-node) 24.0.1 or newer installed. Also need miniircd installed to the root (i.e. in your `joinmarket-clientserver` directory):
+Work in your `jmvenv` virtual environment as for all Joinmarket work. Make sure to have [bitcoind](https://bitcoin.org/en/full-node) 25.1 or newer installed. Also need miniircd installed to the root (i.e. in your `joinmarket-clientserver` directory):
 
     (jmvenv)$ cd /path/to/joinmarket-clientserver
     (jmvenv)$ git clone https://github.com/Joinmarket-Org/miniircd

--- a/test/Dockerfiles/build_docker.sh
+++ b/test/Dockerfiles/build_docker.sh
@@ -15,7 +15,7 @@ build_docker ()
         return 0
     fi
 
-    core_version='24.0.1'
+    core_version='25.1'
     core_dist="bitcoin-${core_version}-x86_64-linux-gnu.tar.gz"
     core_url="https://bitcoincore.org/bin/bitcoin-core-${core_version}/${core_dist}"
     declare -A deps=( [${core_dist}]="${core_url}" )


### PR DESCRIPTION
Security vulnerability has been disclosed for versions older than 25.1, which are also currently EOL. https://bitcoincore.org/en/2024/11/05/cb-stall-hindering-propagation/