### PR TITLE
Update INSTALL.md to Reflect Changes for Native Windows libsecp256k1 Dependency Setup

### DIFF
--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -166,9 +166,13 @@ Using the command prompt in Administrator mode, go to that directory and run the
 
 (replace `services` with `gui` for Joinmarket-Qt).
 
-The final step is to manually add the libsodium dependency, as mentioned. Do the following:
+The final step is to manually add the libsecp256k1 dependency, as mentioned. Do the following:
 
-Download the file at `https://www.nuget.org/api/v2/package/libsodium` and rename it to `.zip` so that you can unzip it. Once unzipped, find the `libsodium.dll` file at `runtimes\win-x64\native\libsodium.dll` and copy it into `C:\Windows\System` (note this will require Admin rights).
+Install the libsecp256k1-0 package with
+
+`pip install libsecp256k1-0`
+
+Find the `libsecp256k1-0.dll` within the `/Lib/site-packages/libsecp256k1_0/compiled/` directory of your Python environment and copy it into the `Scripts` folder of your Python environment. Rename the file to `secp256k1.dll`.
 
 At this point Joinmarket should be ready to run both in command line and Joinmarket-Qt form (using `python joinmarket-qt.py` from the `\scripts` subdirectory of `joinmarket-clientserver`).
 


### PR DESCRIPTION
This PR updates the installation instructions in `INSTALL.md` to replace the outdated steps for configuring `libsodium.dll` with steps to configure `libsecp256k1.dll`.

### Summary of Changes:
- The original instructions described downloading `libsodium.dll` from nuget.org and placing it in `C:\Windows\System`. However, the `libsodium.dll` library is no longer compatible with `bitcointx`.
- The updated instructions guide users to:
  1. Install the `libsecp256k1-0` Python package.
  2. Locate the compiled `libsecp256k1-0.dll` within the Python environment.
  3. Copy and rename it to `secp256k1.dll` in the `Scripts` folder of the Python environment.

### Why This Change is Necessary:
The previous method for handling dependencies is no longer compatible with the current requirements of `bitcointx`, which is a critical component of Joinmarket. This change ensures that users can correctly configure the required library and continue using the software without encountering compatibility issues.

### Additional Notes:
- The new instructions provide a simpler and more Python-environment-focused approach, avoiding the need for admin privileges to place the DLL in system directories.
- Tested on Windows with the latest version of the project dependencies.

Let me know if additional clarifications or adjustments are needed!