### PR TITLE
Bump built-in Tor from 0.4.8.10 to 0.4.8.13

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -414,9 +414,9 @@ tor_build ()
 
 tor_install ()
 {
-    tor_version='tor-0.4.8.10'
+    tor_version='tor-0.4.8.13'
     tor_tar="${tor_version}.tar.gz"
-    tor_sha='e628b4fab70edb4727715b23cf2931375a9f7685ac08f2c59ea498a178463a86'
+    tor_sha='9baf26c387a2820b3942da572146e6eb77c2bc66862af6297cd02a074e6fba28'
     tor_url='https://dist.torproject.org'
     tor_pubkeys='Tor.asc'
 


### PR DESCRIPTION
There have been some bugfixes in between.

[Full changes](https://gitlab.torproject.org/tpo/core/tor/-/raw/tor-0.4.8.13/ChangeLog):

```
Changes in version 0.4.8.13 - 2024-10-24
  This is minor release fixing an important client circuit building (Conflux
  related) bug which lead to performance degradation and extra load on the
  network. Some minor memory leaks fixes as well as an important minor feature
  for pluggable transports. We strongly recommend to update as soon as possible
  for clients in order to neutralize this conflux bug.

  o Major bugfixes (circuit building):
    - Conflux circuit building was ignoring the "predicted ports" feature, which aims to make Tor stop building circuits if there have been no user requests lately. This bug led to every idle Tor on the network building and discarding circuits every 30 seconds, which added overall load to the network, used bandwidth and battery from clients that weren't actively using their Tor, and kept sockets open on guards which added connection padding essentially forever. Fixes bug 40981; bugfix on 0.4.8.1-alpha;

  o Minor feature (bridges, pluggable transport):
    - Add STATUS TYPE=version handler for Pluggable Transport. This allows us to gather version statistics on Pluggable Transport usage from bridge servers on our metrics portal. Closes ticket 11101.

  o Minor features (fallbackdir):
    - Regenerate fallback directories generated on October 24, 2024.

  o Minor features (geoip data):
    - Update the geoip files to match the IPFire Location Database, as retrieved on 2024/10/24.

  o Minor bugfixes (memleak, authority):
    - Fix a small memleak when computing a new consensus. This only affects directory authorities. Fixes bug 40966; bugfix on 0.3.5.1-alpha.

  o Minor bugfixes (memory):
    - Fix memory leaks of the CPU worker code during shutdown. Fixes bug 833; bugfix on 0.3.5.1-alpha.

Changes in version 0.4.8.12 - 2024-06-06
  This is a minor release with couple bugfixes affecting conflux and logging.
  We also have the return of faravahar directory authority with new keys and
  address.

  o Minor feature (dirauth):
    - Add back faravahar with a new address and new keys. Closes 40689.

  o Minor features (fallbackdir):
    - Regenerate fallback directories generated on June 06, 2024.

  o Minor features (geoip data):
    - Update the geoip files to match the IPFire Location Database, as retrieved on 2024/06/06.

  o Minor bugfix (circuit):
    - Remove a log_warn being triggered by a protocol violation that already emits a protocol warning log. Fixes bug 40932; bugfix on 0.4.8.1-alpha.

  o Minor bugfixes (conflux):
    - Avoid a potential hard assert (crash) when sending a cell on a Conflux set. Fixes bug 40921; bugfix on 0.4.8.1-alpha.
    - Make sure we don't process a closed circuit when packaging data. This lead to a non fatal BUG() spamming logs. Fixes bug 40908; bugfix on 0.4.8.1-alpha.

Changes in version 0.4.8.11 - 2024-04-10
  This is a minor release mostly to upgrade the fallbackdir list. Worth noting
  also that directory authority running this version will now automatically
  reject relays running the end of life 0.4.7.x version.

  o Minor feature (authority):
    - Reject 0.4.7.x series at the authority level. Closes ticket 40896.

  o Minor feature (dirauth, tor26):
    - New IP address and keys.

  o Minor feature (directory authority):
    - Allow BandwidthFiles "node_id" KeyValue without the dollar sign at the start of the hexdigit, in order to easier database queries combining Tor documents in which the relays fingerprint does not include it. Fixes bug 40891; bugfix on 0.4.7 (all supported versions of Tor).

  o Minor features (fallbackdir):
    - Regenerate fallback directories generated on April 10, 2024.

  o Minor features (geoip data):
    - Update the geoip files to match the IPFire Location Database, as retrieved on 2024/04/10.

  o Minor bugfixes (directory authorities):
    - Add a warning when publishing a vote or signatures to another directory authority fails. Fixes bug 40910; bugfix on 0.2.0.3-alpha.
 ```