### PR TITLE
Remove DarkScience IRC network from default config

### DIFF
--- a/src/jmclient/configure.py
+++ b/src/jmclient/configure.py
@@ -187,27 +187,7 @@ directory_nodes = g3hv4uynnmynqqq2mchf3fcm3yd46kfzmcdogejuckgwknwyq5ya6iad.onion
 # running multiple bots at once. Don't alter it otherwise
 regtest_count = 0,0
 
-## IRC SERVER 1: Darkscience IRC (Tor, IP)
-################################################################################
-[MESSAGING:darkscience]
-# by default the legacy format without a `type` field is
-# understood to be IRC, but you can, optionally, add it:
-# type = irc
-channel = joinmarket-pit
-port = 6697
-usessl = true
-
-# For traditional IP:
-#host = irc.darkscience.net
-#socks5 = false
-
-# For Tor (recommended as clearnet alternative):
-host = darkirc6tqgpnwd3blln3yfv5ckl47eg7llfxkmtovrv7c7iwohhb6ad.onion
-socks5 = true
-socks5_host = localhost
-socks5_port = 9050
-
-# IRC SERVER 2: (backup) hackint IRC (Tor, IP)
+# IRC SERVER: hackint IRC (Tor, IP)
 ###############################################################################
 [MESSAGING:hackint]
 channel = joinmarket-pit


### PR DESCRIPTION
As requested by DarkScience Operations Team.

Resolves #1760.