### PR TITLE
build(docker): update to debian bookworm

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -1,0 +1,33 @@
+name: Build Docker image
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+env:
+  DOCKER_IMAGE_NAME: joinmarket-clientserver
+  DOCKER_IMAGE_TAG: test
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build
+        uses: docker/build-push-action@v6
+        env:
+          SOURCE_DATE_EPOCH: 0
+        with:
+          load: true
+          push: false
+          tags: ${{ env.DOCKER_IMAGE_NAME }}:${{ env.DOCKER_IMAGE_TAG }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bullseye-slim
+FROM debian:bookworm-slim
 
 RUN mkdir -p /jm/clientserver
 WORKDIR /jm/clientserver
@@ -7,8 +7,10 @@ COPY . .
 
 RUN apt-get update && apt-get install -y --no-install-recommends gnupg ca-certificates=* curl=* \
   python3-pip=* python3=* \
+  && pip3 config set global.break-system-packages true \
   && pip3 install 'wheel>=0.35.1' \
   && ./install.sh --docker-install \
   && apt-get purge -y --autoremove python3-pip \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
+


### PR DESCRIPTION
Updates `Dockerfile` base image from `debian:bullseye-slim` to `debian:bookworm-slim`.

Bullseye default version of [`autoconf`](https://github.com/JoinMarket-Org/joinmarket-clientserver/pull/1703) is incompatible with [`libffi` v3.4.6](https://github.com/JoinMarket-Org/joinmarket-clientserver/commit/cbd88681f96d29c47a2512b3051c58f774064012) (needed 2.71, installed v1.69):

```
534.3 v3.4.6.tar.gz: OK
534.3 /jm/clientserver/deps/libffi-3.4.6 /jm/clientserver/deps /jm/clientserver
[...]
536.0 configure.ac:3: error: Autoconf version 2.71 or higher is required
536.0 configure.ac:3: the top level
536.0 autom4te: /usr/bin/m4 failed with exit status: 63
536.0 aclocal: error: /usr/bin/autom4te failed with exit status: 63
536.0 autoreconf: aclocal failed with exit status: 63
536.0 ./install.sh: line 247: ./configure: No such file or directory
536.0 make: *** No rule to make target 'uninstall'.  Stop.
536.0 make: *** No targets specified and no makefile found.  Stop.
536.0 make: *** No rule to make target 'check'.  Stop.
536.0 Libffi was not built. Exiting.
```

## How to test
Run `docker build -t joinmarket-clientserver-pr-1771 .` and check if image is built successfully.

