### PR TITLE
fixed color=false disables coloured output for log messages, not rest of the output - Issue #911

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ scripts/snicker/candidates.txt
 .qt_for_python/
 cmtdata/
 **/build/
+test_venv/

--- a/src/jmbase/support.py
+++ b/src/jmbase/support.py
@@ -73,6 +73,8 @@ log.setLevel(logging.DEBUG)
 joinmarket_alert = ['']
 core_alert = ['']
 debug_silence = [False]
+# Global variable to track whether colored output is enabled
+colored_output = [True]
 
 class JoinMarketStreamHandler(ColorizingStreamHandler):
 
@@ -182,7 +184,7 @@ def jmprint(msg, level="info"):
 
     fmtfn = eval(level)
     fmtd_msg = fmtfn(msg)
-    if sys.stdout.isatty():
+    if sys.stdout.isatty() and colored_output[0]:
         print(jm_colorizer.colorize_message(fmtd_msg))
     else:
         print(fmtd_msg)
@@ -198,6 +200,8 @@ def set_logging_level(level):
     handler.setLevel(level)
 
 def set_logging_color(colored=False):
+    # Update the global colored_output setting
+    colored_output[0] = colored
     if colored and sys.stdout.isatty():
         handler.colorizer = jm_colorizer
     else:


### PR DESCRIPTION
I've fixed the issue where setting color = false in joinmarket.cfg only disabled colored output for log messages but not for other console output.

The fix involved three changes to src/jmbase/support.py:

Added a global variable to track the color setting:

- Global variable to track whether colored output is enabled
colored_output = [True]



- Modified the jmprint() function to respect this setting:

if sys.stdout.isatty() and colored_output[0]:
    print(jm_colorizer.colorize_message(fmtd_msg))
else:
    print(fmtd_msg)


- Updated the set_logging_color() function to set this global variable:

def set_logging_color(colored=False):
    # Update the global colored_output setting
    colored_output[0] = colored
    if colored and sys.stdout.isatty():
        handler.colorizer = jm_colorizer
    else:
        handler.colorizer = MonochromaticColorizer()



Now when a user sets color = false in joinmarket.cfg, it will disable colored output for both log messages and direct console output via jmprint().