### PR TITLE
chore: add bug report and feature request templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,46 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: 'bug'
+assignees: ''
+
+---
+
+Hey there! Thank you for reporting an issue – your feedback is invaluable to open-source software development, and all contributions are greatly appreciated.
+
+🚨 Important warning: Be cautious of scammers in the comments. 🚨
+
+Red flags to watch out for:
+- Requests to email "official support" or links to external websites
+- Responses from recently created accounts, often lacking profile pictures
+- Inquiries for personal information that is not relevant to resolving your issue
+
+As long as you avoid sharing sensitive information (such as your seed phrase), you should be safe. 
+However, it's best to avoid engaging with any suspicious comments.
+
+
+**Expected behavior**
+
+A clear and concise description of what you expected to happen.
+
+**Actual behavior**
+
+A clear and concise description of what the bug is and what actually happens.
+
+**Steps to reproduce the problem**
+  1.
+  2.
+  3.
+
+**Specifications**
+  - Version:
+  - Platform:
+  - Python version:
+  - Tor version:
+
+**Additional context**
+
+Add any other context about the problem here to help explain your problem, e.g. error logs or screenshots if applicable. 
+
+⚠️ Make sure to remove any sensitive information before sharing screenshots or logs. ⚠️

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,37 @@
+---
+name: Feature request
+about: Suggest an idea
+title: ''
+labels: 'enhancement'
+assignees: ''
+
+---
+
+Hey there! Thank you for proposing a new feature – your feedback is invaluable to open-source software development, and all contributions are greatly appreciated.
+
+🚨 Important warning: Be cautious of scammers in the comments. 🚨
+
+Red flags to watch out for:
+- Requests to email "official support" or links to external websites
+- Responses from recently created accounts, often lacking profile pictures
+- Inquiries for personal information that is not relevant to resolving your issue
+
+As long as you avoid sharing sensitive information (such as your seed phrase), you should be safe. 
+However, it's best to avoid engaging with any suspicious comments.
+
+
+**Is your feature request related to a problem? Please describe.**
+
+A clear and concise description of what the problem is. Example: I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+
+Add any other context or screenshots about the feature request here.


### PR DESCRIPTION
Adds bug report and feature requests templates, basically copied from the Jam repository.
Noticing more and more bots in the comments. If it helps a single person not engaging with these individuals, it was already worth it.

<img src="https://github.com/user-attachments/assets/8eeb585a-94f5-4ee3-918c-3b962f87d73f" width=250 />
<br />
<img src="https://github.com/user-attachments/assets/4d04a1eb-5d16-4e73-8c2e-3242714a7cf8" width=250 />
