### PR TITLE
Fix: GetAddressResponse schema to return an object with address property

### DIFF
--- a/docs/api/wallet-rpc.yaml
+++ b/docs/api/wallet-rpc.yaml
@@ -795,8 +795,13 @@ components:
           type: string
           example: "8000000"
     GetAddressResponse:
-      type: string
-      example: "bcrt1qujp2x2fv437493sm25gfjycns7d39exjnpptzw"
+      type: object
+      required:
+        - address
+      properties:
+        address:
+          type: string
+          example: "bcrt1qujp2x2fv437493sm25gfjycns7d39exjnpptzw"
     ListWalletsResponse:
       type: object
       properties:


### PR DESCRIPTION
Corrected the `GetAddressResponse` schema definition in `wallet-rpc.yaml` to properly represent the actual API response structure.