### PR TITLE
Remove incentive for makers to cheat by creating multiple bots

### DIFF
--- a/src/jmclient/configure.py
+++ b/src/jmclient/configure.py
@@ -93,7 +93,7 @@ required_options = {'BLOCKCHAIN': ['blockchain_source', 'network'],
 
 _DEFAULT_INTEREST_RATE = "0.015"
 
-_DEFAULT_BONDLESS_MAKERS_ALLOWANCE = "0.125"
+_DEFAULT_BONDLESS_MAKERS_ALLOWANCE = "0.0"
 
 defaultconfig = \
     """
@@ -366,7 +366,7 @@ bondless_makers_allowance = """ + _DEFAULT_BONDLESS_MAKERS_ALLOWANCE + """
 # To (strongly) disincentivize Sybil behaviour, the value assessment of the bond
 # is based on the (time value of the bond)^x where x is the bond_value_exponent here,
 # where x > 1. It is a real number (so written as a decimal).
-bond_value_exponent = 1.3
+bond_value_exponent = 2.0
 
 ##############################
 # THE FOLLOWING SETTINGS ARE REQUIRED TO DEFEND AGAINST SNOOPERS.


### PR DESCRIPTION
This was discussed in Issue #1790.

This change removes the incentive of makers to cheat through creating multiple makers/bots. This is done by restoring JM creator Chris Belcher's [original bond value exponent of 2.0 in his fidelity bond paper](https://gist.github.com/chris-belcher/87ebbcbb639686057a389acb9ab3e25b). This also reduces the sybil attack surface. The exponent had been set to 1.3 to address a perception that too many offers were going to a handful of makers. This was in an environment where only a handful of makers had fidelity bonds. With the maturity of the marketplace and fidelity bonds being around for years now, the default setting should be restored to help reduce maker cheating and sybil attacks. It seems pretty obvious that cheating is occurring through multiple makers being created/controlled by the same entity.

This pull request also incorporates seamo1's necessary pull request #1792 to remove spam bots from JM by setting default bondless makers to 0. Fidelity bonds have been around long enough where makers can easily set one up.

**For current users, I strongly urge you to update your joinmarket.cfg file as such:
bondless_makers_allowance = 0.0
bond_value_exponent = 2.0**