### PR TITLE
fix(deps): bencode library

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-13, ubuntu-latest]
-        python-version: ["3.8", "3.12"]
+        python-version: ["3.9", "3.12"]
         bitcoind-version: ["29.2"]
 
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "joinmarket"
 version = "0.9.12dev"
 description = "Joinmarket client library for Bitcoin coinjoins"
 readme = "README.md"
-requires-python = ">=3.8,<3.13"
+requires-python = ">=3.9,<3.13"
 license = {file = "LICENSE"}
 dependencies = [
     "chromalog==1.0.5",
@@ -24,7 +24,7 @@ jmbitcoin = [
 jmclient = [
     "argon2_cffi==21.3.0",
     "autobahn==20.12.3",
-    "bencoder.pyx==3.0.1",
+    "fastbencode==0.3.6",
     "klein==20.6.0",
     "mnemonic==0.20",
     "pyjwt==2.4.0",

--- a/src/jmclient/storage.py
+++ b/src/jmclient/storage.py
@@ -1,10 +1,14 @@
+import atexit
 import os
 import shutil
-import atexit
-import bencoder
 from hashlib import sha256
+from typing import Any
+
 from argon2 import low_level
-from jmbase import aes_cbc_encrypt, aes_cbc_decrypt
+from fastbencode import bdecode, bencode_utf8
+
+from jmbase import aes_cbc_decrypt, aes_cbc_encrypt
+
 from .support import get_random_bytes
 
 
@@ -223,12 +227,12 @@ class Storage(object):
         return self.path
 
     @staticmethod
-    def _serialize(data):
-        return bencoder.bencode(data)
+    def _serialize(data: Any) -> bytes:
+        return bencode_utf8(data)
 
     @staticmethod
-    def _deserialize(data):
-        return bencoder.bdecode(data)
+    def _deserialize(data: bytes) -> Any:
+        return bdecode(data)
 
     def _encrypt_file(self, data):
         if not self.is_encrypted():


### PR DESCRIPTION
Migrate from abandoned `bencoder.pyx` to `fastbencode`.  
Update minimum Python version requirement to 3.9 (with 3.8 effectively eol since a year)  

Python 3.13 compatibility will require other dependencies bumping such as `twisted` in https://github.com/JoinMarket-Org/joinmarket-clientserver/pull/1732

Closes: https://github.com/JoinMarket-Org/joinmarket-clientserver/issues/1805