### PR TITLE
chore(deps): bump txtorcon to 24.8.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
     "cryptography==42.0.4",
     "service-identity==21.1.0",
     "twisted==24.7.0",
-    "txtorcon==23.11.0",
+    "txtorcon==24.8.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
a version bump that cannot harm

> I'm gruntled to announce txtorcon 24.8.0 with the following changes:
> 
>  * Fix (test) issues with Twisted 24.7.0 (https://github.com/meejah/txtorcon/pull/400)
>  * Remove usage of "six" (https://github.com/meejah/txtorcon/issues/395)
>    from https://github.com/a-detiste


https://github.com/meejah/txtorcon/releases/tag/v24.8.0