### PR TITLE
install.sh: use debian dist libffi

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -74,6 +74,8 @@ deps_install ()
         'python3-pip' \
         'python3-setuptools' \
         'python3-venv' \
+        'libffi-dev' \
+        'libffi8' \
         'libltdl-dev' )
 
     if [ "$with_sudo" == 1 ]; then debian_deps+=("sudo"); fi
@@ -617,9 +619,11 @@ main ()
         echo "libsecp256k1 was not built. Exiting."
         return 1
     fi
-    if ! libffi_install; then
-        echo "Libffi was not built. Exiting."
-        return 1
+    if [[ "${install_os}" != 'debian' ]]; then
+        if ! libffi_install; then
+            echo "Libffi was not built. Exiting."
+            return 1
+        fi
     fi
     if ! libsodium_install; then
         echo "Libsodium was not built. Exiting."


### PR DESCRIPTION
We can use `libffi-dev` and `libffi8` debian packages instead of downloading and building from source. Significantly reduces build time.

- bookworm/oldstable: `3.4.4` (https://packages.debian.org/bookworm/libffi-dev)
- trixie/stable: `3.4.8` (https://packages.debian.org/trixie/libffi-dev)

fall back to installing libffi from source like before on non-debian targets