### PR TITLE
feat: tor managed services support

### DIFF
--- a/docs/onion-message-channels.md
+++ b/docs/onion-message-channels.md
@@ -59,6 +59,7 @@ onion_serving_port = 8080
 # but NOT TO BE USED by non-directory nodes (which is you, unless
 # you know otherwise!), as it will greatly degrade your privacy.
 # (note the default is no value, don't replace it with "").
+# Use tor-managed: prefix to use Tor-managed hidden services.
 hidden_service_dir =
 #
 # This is a comma separated list (comma can be omitted if only one item).
@@ -155,9 +156,11 @@ Add a non-empty `hidden_service_dir` entry to your `[MESSAGING:onion]` with a di
 
 The hostname for your onion service will not change and will be stored permanently in that directory.
 
-The point to understand is: Joinmarket's `jmbase.JMHiddenService` will, if configured with a non-empty `hidden_service_dir`
-field, actually start an *independent* instance of Tor specifically for serving this, under the current user.
-(our Tor interface library `txtorcon` needs read access to the Tor HS dir, so it's troublesome to do this another way).
+There are two ways to configure a persistent hidden service:
+
+1. **txtorcon-managed** (default when `hidden_service_dir` is set to a path): Joinmarket's `jmbase.JMHiddenService` will manage the hidden service via the Tor control port. This requires control port access and will start an *independent* instance of Tor specifically for serving this, under the current user. (our Tor interface library `txtorcon` needs read access to the Tor HS dir, so it's troublesome to do this another way).
+
+2. **Tor-managed** (when `hidden_service_dir` is prefixed with `tor-managed:`): Tor manages the hidden service via its `torrc` configuration file. JoinMarket reads the hostname from the `hostname` file in the specified directory. This mode does not require Tor control port access. See [Tor configuration documentation](./tor.md) for setup instructions.
 
 #### Question: How to configure the `directory-nodes` list in our `joinmarket.cfg` for this directory node bot?
 

--- a/docs/tor.md
+++ b/docs/tor.md
@@ -83,3 +83,37 @@ sudo service tor start
 ```
 
 Once this is done, you should be able to start the yieldgenerator successfully.
+
+#### Tor-managed hidden services
+
+As an alternative to using the Tor control port, you can configure Tor to manage the hidden service directly via its configuration file (`torrc`). This approach is useful when:
+
+- You want Tor to fully manage the hidden service lifecycle
+- You don't want to grant control port access to JoinMarket
+- You're running Tor as a system service and prefer centralized configuration
+
+To use this mode:
+
+1. Configure the hidden service in Tor's `torrc` file (typically `/etc/tor/torrc`):
+
+   ```ini
+   HiddenServiceDir /var/lib/tor/joinmarket_hidden_service
+   HiddenServicePort 5222 127.0.0.1:8080
+   ```
+
+2. Set appropriate permissions
+3. Restart To
+4. Configure JoinMarket to use the Tor-managed service by setting `hidden_service_dir` in your `joinmarket.cfg`:
+
+   ```ini
+   hidden_service_dir = tor-managed:/var/lib/tor/joinmarket_hidden_service
+   ```
+
+   Note the `tor-managed:` prefix, which tells JoinMarket to read the hostname from the `hostname` file in that directory rather than managing the service via the control port.
+
+##### Important notes
+
+- The directory path in `hidden_service_dir` must match exactly what's configured in `torrc`
+- JoinMarket will read the hostname from the `hostname` file; make sure Tor has created it
+- No control port configuration is needed for this mode (though you may still need it for other features)
+- The hidden service directory must be readable by the user running JoinMarket (or the `hostname` file at minimum)

--- a/src/jmclient/configure.py
+++ b/src/jmclient/configure.py
@@ -172,6 +172,7 @@ onion_serving_port = 8080
 # but NOT TO BE USED by non-directory nodes (which is you, unless
 # you know otherwise!), as it will greatly degrade your privacy.
 # (note the default is no value, don't replace it with "").
+# Use tor-managed: prefix to use Tor-managed hidden services.
 hidden_service_dir =
 #
 # This is a comma separated list (comma can be omitted if only one item).

--- a/test/jmbase/test_twisted_utils.py
+++ b/test/jmbase/test_twisted_utils.py
@@ -1,0 +1,65 @@
+from unittest.mock import Mock, patch
+
+import pytest
+
+from jmbase.twisted_utils import JMHiddenService
+
+
+def mock_hs(hidden_service_dir: str = "") -> JMHiddenService:
+    return JMHiddenService(
+        Mock(),
+        Mock(),
+        Mock(),
+        Mock(),
+        "127.0.0.1",
+        9051,
+        "127.0.0.1",
+        8080,
+        80,
+        None,
+        hidden_service_dir,
+    )
+
+
+class TestTorManagedHiddenService:
+    @pytest.mark.parametrize(
+        "hidden_service_dir,expect_managed,expect_connect",
+        [
+            ("tor-managed:/path/to/dir", True, False),
+            ("/normal/path", False, True),
+        ],
+    )
+    def test_hidden_service_dir_detection(
+        self, hidden_service_dir, expect_managed, expect_connect
+    ):
+        with (
+            patch.object(JMHiddenService, "start_tor_managed_onion") as mock_managed,
+            patch("jmbase.twisted_utils.txtorcon.connect") as mock_connect,
+        ):
+            hs = mock_hs(hidden_service_dir)
+
+            hs.start_tor()
+
+            if expect_managed:
+                mock_managed.assert_called_once()
+                mock_connect.assert_not_called()
+            else:
+                mock_managed.assert_not_called()
+                mock_connect.assert_called_once()
+
+    def test_ephemeral_service_creation(self):
+        with patch("jmbase.twisted_utils.txtorcon") as mock_txtorcon:
+            mock_t = Mock()
+            mock_t.create_onion_service.return_value = Mock()
+
+            hs = mock_hs()
+            hs.tor_connection = mock_t
+            hs.virtual_port = 80
+            hs.serving_host = "127.0.0.1"
+            hs.serving_port = 8080
+
+            hs.create_onion_ep(mock_t)
+
+            mock_t.create_onion_service.assert_called_once_with(
+                ports=["80 127.0.0.1:8080"], private_key=mock_txtorcon.DISCARD
+            )

--- a/test/jmdaemon/test_onionmc.py
+++ b/test/jmdaemon/test_onionmc.py
@@ -1,0 +1,90 @@
+from unittest.mock import Mock, patch
+
+import pytest
+
+from jmdaemon.onionmc import OnionMessageChannel
+
+
+@pytest.fixture
+def configdata():
+    return {
+        "btcnet": "mainnet",
+        "tor_control_host": "127.0.0.1",
+        "tor_control_port": 9051,
+        "onion_serving_host": "127.0.0.1",
+        "serving": False,
+        "socks5_host": "127.0.0.1",
+        "socks5_port": 9050,
+        "directory_nodes": "",
+        "passive": False,
+    }
+
+
+class TestOnionMessageChannelListener:
+    def test_start_listener_creates_tcp_endpoint(self, configdata):
+        with (
+            patch("jmdaemon.onionmc.reactor") as mock_reactor,
+            patch("jmdaemon.onionmc.serverFromString") as mock_server_from_string,
+        ):
+            mock_deferred = Mock()
+            mock_endpoint = Mock()
+            mock_endpoint.listen.return_value = mock_deferred
+            mock_server_from_string.return_value = mock_endpoint
+
+            mc = OnionMessageChannel(configdata)
+            mc.onion_serving_host = "127.0.0.1"
+            mc.onion_serving_port = 8080
+            mc.proto_factory = Mock()
+            mc.on_welcome = Mock()
+            mc.setup_error_callback = Mock()
+
+            mc._start_listener()
+
+            expected_serverstring = "tcp:8080:interface=127.0.0.1"
+            mock_server_from_string.assert_called_once_with(
+                mock_reactor, expected_serverstring
+            )
+
+            mock_endpoint.listen.assert_called_once_with(mc.proto_factory)
+
+            mock_deferred.addCallback.assert_called_once_with(mc.on_welcome)
+            mock_deferred.addErrback.assert_called_once()
+
+            errback_callback = mock_deferred.addErrback.call_args[0][0]
+            test_failure = Exception("Test error")
+            errback_callback(test_failure)
+
+            mc.setup_error_callback.assert_called_once_with("Listen failed: Test error")
+
+    @pytest.mark.parametrize(
+        "host,port",
+        [
+            ("192.168.1.1", 9000),
+            ("localhost", 1234),
+            ("0.0.0.0", 80),
+        ],
+    )
+    def test_start_listener_different_ports_and_hosts(self, configdata, host, port):
+        with (
+            patch("jmdaemon.onionmc.reactor") as mock_reactor,
+            patch("jmdaemon.onionmc.serverFromString") as mock_server_from_string,
+        ):
+            mock_endpoint = Mock()
+            mock_server_from_string.return_value = mock_endpoint
+
+            configdata["onion_serving_host"] = host
+            configdata["onion_serving_port"] = port
+
+            mc = OnionMessageChannel(configdata)
+            mc.onion_serving_host = host
+            mc.onion_serving_port = port
+            mc.proto_factory = Mock()
+            mc.on_welcome = Mock()
+            mc.setup_error_callback = Mock()
+
+            mc._start_listener()
+
+            expected_serverstring = f"tcp:{port}:interface={host}"
+            mock_server_from_string.assert_called_once_with(
+                mock_reactor, expected_serverstring
+            )


### PR DESCRIPTION
This PR introduces support for Tor-managed hidden services, providing a more secure and simplified way to run persistent onion services without requiring Tor control port access.

## Changes
### Core Implementation

Modified `JMHiddenService` class in `src/jmbase/twisted_utils.py`:

- Added detection for `tor-managed:` prefixed hidden service directories
- Implemented `start_tor_managed_onion()` method that polls for hostname file creation
- Added `create_filesystem_onion_ep()` for better code organization
- No Tor control port connection needed in managed mode

### Daemon Integration

Updated `OnionMessageChannel` in `src/jmdaemon/onionmc.py`:

- Added `_start_listener()` method for cleaner listener setup
- Modified genesis node handling to work with managed services
- Improved error handling and callback management

### Testing

Added comprehensive test coverage:

- `test/jmbase/test_twisted_utils.py`: Tests for hidden service mode detection and ephemeral service creation
- `test/jmdaemon/test_onionmc.py`: Tests for listener setup and different host/port configurations

## Benefits

- Optionally eliminates the need for Tor control port access, reducing attack surface
- Hidden services ca be configured entirely in torrc, no JoinMarket-specific setup required
- Existing ephemeral and persistent modes continue to work unchanged
- HiddenServicePOWDefense ready 🚀 

## Usage

To use Tor-managed hidden services, configure your `joinmarket.cfg`:

```ini
[MESSAGING:onion]
hidden_service_dir = tor-managed:/path/to/tor/hidden/service/dir
```

The corresponding torrc entry would be:

```
HiddenServiceDir /path/to/tor/hidden/service/dir
HiddenServicePort 80 127.0.0.1:8080
```

The code automatically detects the `tor-managed:` prefix and switches to managed mode, polling for the hostname file that Tor creates.