### PR TITLE
ci: no fail-fast for unittests

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -7,6 +7,7 @@ jobs:
     name: python ${{ matrix.python-version }}, bitcoind ${{ matrix.bitcoind-version }} on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [macos-13, ubuntu-latest]
         python-version: ["3.9", "3.12"]


### PR DESCRIPTION
Let all unittest jobs finish to completion even if one in the matrix fails.

This should make it easier and quicker to distinguish between:
- Legitimate new regressions affecting all runtimes
- Flaky tests
- Differences between runtimes
- Whether errors are consistent or intermittent

without manually restarting or retrying.

https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idstrategyfail-fast

Also ensures results for `master` have complete coverage (for example one was skipped for 5246c1ccb5fcc9eae383e8addcca3677bb9e76c8: https://github.com/JoinMarket-Org/joinmarket-clientserver/actions/runs/18861473464/job/53820509485 )