### PR TITLE
feat(config): override config with environment variables

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -67,6 +67,10 @@ You should see the following files and folders for an initial setup:
 
 `joinmarket.cfg` is the main configuration file for Joinmarket and has a lot of settings, several of which you'll want to edit or at least examine.
 This will be discussed in several of the sections below.
+
+> **Environment variable overrides**  
+> Configuration values can be overridden using environment variables prefixed with `JM_`. Format: `JM_SECTION_KEY` (e.g., `JM_POLICY_TX_FEES`) or `JM_SECTION_SUBSECTION_KEY` for sections with subsections like `MESSAGING` (e.g., `JM_MESSAGING_ONION_TYPE`). When environment variables are present, they take precedence over the config file.
+
 The `wallets/` directory is where wallet files, extension (by default) of `.jmdat` are stored after you create them. They are encrypted and store important information; without them, it is possible to recover your coins with the seedphrase, but can be a hassle, so keep the file safe.
 The `logs/` directory contains a log file for each bot you run (Maker or Taker), with debug information. You'll rarely need to read these files unless you encounter a problem; deleting them regularly is recommended (and never dangerous). However there are other log files kept here, in particular one called `yigen-statement.csv` which records all transactions your Maker bot does over time. This can be useful for keeping track. Additionally, tumbles have a `TUMBLE.schedule` and `TUMBLE.log` file here which can be very useful; don't delete these.
 The `cmtdata/` directory stores technical information that you will not need to read.

--- a/test/jmclient/test_configure.py
+++ b/test/jmclient/test_configure.py
@@ -1,8 +1,12 @@
 '''test configure module.'''
 
+import copy
+from configparser import ConfigParser
+
 import pytest
-from jmclient import load_test_config, jm_single
-from jmclient.configure import get_blockchain_interface_instance
+
+from jmclient import jm_single, load_test_config
+from jmclient.configure import get_blockchain_interface_instance, override
 
 pytestmark = pytest.mark.usefixtures("setup_regtest_bitcoind")
 
@@ -23,6 +27,8 @@ def test_load_config(tmpdir):
         load_test_config(config_path=str(tmpdir), bs="regtest")
     jm_single().config_location = "joinmarket.cfg"
     load_test_config()
+    ref = copy.deepcopy(jm_single().config)
+    assert override(jm_single().config) == ref
 
 
 def test_blockchain_sources():
@@ -35,3 +41,32 @@ def test_blockchain_sources():
         else:
             get_blockchain_interface_instance(jm_single().config)
     load_test_config()
+
+
+@pytest.fixture
+def overrides(monkeypatch):
+    overrides = {
+        "JM_BLOCKCHAIN_BLOCKCHAIN_SOURCE": "no-blockchain",
+        "JM_POLICY_TX_FEES": "12345678",
+        "JM_MESSAGING_ONION_TYPE": "lorem-ipsum",
+    }
+    for key, value in overrides.items():
+        monkeypatch.setenv(key, value)
+    return overrides
+
+
+def test_override(overrides):
+    config = ConfigParser()
+    override(config)
+    assert (
+        config.get("BLOCKCHAIN", "blockchain_source")
+        == overrides["JM_BLOCKCHAIN_BLOCKCHAIN_SOURCE"]
+    )
+    assert config.get("POLICY", "tx_fees") == overrides["JM_POLICY_TX_FEES"]
+    assert config.get("MESSAGING:onion", "type") == overrides["JM_MESSAGING_ONION_TYPE"]
+
+
+def test_load_program_config_overrides(overrides):
+    load_test_config()
+    assert jm_single().config.get("POLICY", "tx_fees") == overrides["JM_POLICY_TX_FEES"]
+    assert jm_single().config.get("MESSAGING:onion", "socks5_port") == "9050"


### PR DESCRIPTION
This PR adds support for overriding JoinMarket configuration settings via environment variables, enabling easier deployment in containerized environments and CI/CD pipelines.

## Changes

### Core Functionality

- Added `override()` function that reads environment variables prefixed with `JM_` and applies them to the configuration
- Environment variables are automatically converted to lowercase config keys and mapped to appropriate sections
- Support for sections with subsections (e.g., `JM_MESSAGING_ONION_TYPE=onion` maps to `[MESSAGING:onion] type=onion`)

### Refactoring

- Split `load_program_config()` into smaller, focused functions:
  - `set_paths()` - handles data directory and config file path setup
  - `read_config_file()` - reads existing config file with error handling
  - `write_config_file()` - creates new default config file\

## Usage Examples

```bash
# Override blockchain network
export JM_BLOCKCHAIN_NETWORK=testnet

# Override policy settings
export JM_POLICY_TX_FEES=1000

# Override messaging subsection
export JM_MESSAGING_ONION_TYPE=onion

# Override daemon port
export JM_DAEMON_DAEMON_PORT=27184
```

## Benefits

- **Container-friendly**: No need to modify config files in Docker containers
- **CI/CD integration**: Easy configuration overrides in deployment pipelines  
- **Security**: Sensitive settings can be injected via environment variables
- **Flexibility**: Maintains backward compatibility with existing config files

This feature follows the common pattern of using prefixed environment variables for configuration overrides, making JoinMarket more suitable for modern deployment workflows.