### PR TITLE
fix(api-docs):  fix YieldGenReportResponse format

### DIFF
--- a/docs/api/wallet-rpc.yaml
+++ b/docs/api/wallet-rpc.yaml
@@ -833,10 +833,13 @@ components:
             type: string
             example: wallet.jmdat
     YieldGenReportResponse:
-      type: array
-      items:
-        type: string
-        example: "2021/10/26 16:40:21,133986791,1,200000000,2680,2680,0.08,"
+      type: object
+      properties:
+        yigen_data:
+          type: array
+          items:
+            type: string
+            example: "2021/10/26 16:40:21,133986791,1,200000000,2680,2680,0.08,"
     GetinfoResponse:
       type: object
       required:


### PR DESCRIPTION
API docs state wrong return type for `/wallet/yieldgen/report`.

Instead of an array, the response contains an object with property `yigen_data`:

https://github.com/JoinMarket-Org/joinmarket-clientserver/blob/ce32bafbb5d716bde61830f71266410249d43dbc/src/jmclient/wallet_rpc.py#L974C53-L974C63