### PR TITLE
fix(daemon): mitigate onion message flooding DoS attack

### DIFF
--- a/src/jmdaemon/onionmc.py
+++ b/src/jmdaemon/onionmc.py
@@ -4,6 +4,7 @@ from jmbase import get_log,  JM_APP_NAME, JMHiddenService, stop_reactor
 import json
 import copy
 import random
+import time
 from typing import Callable, Union, Tuple, List
 from twisted.internet import reactor, task, protocol
 from twisted.protocols import basic
@@ -24,6 +25,13 @@ ONION_VIRTUAL_PORT = 5222
 # How many seconds to wait before treating an onion
 # as unreachable
 CONNECT_TO_ONION_TIMEOUT = 60
+
+# Rate limiting for inbound messages per connection.
+# If a peer sends more than ONION_MSG_RATE_LIMIT messages
+# within ONION_MSG_RATE_INTERVAL seconds, the connection
+# is dropped to protect against message flooding DoS attacks.
+ONION_MSG_RATE_LIMIT = 45
+ONION_MSG_RATE_INTERVAL = 15
 
 def location_tuple_to_str(t: Tuple[str, int]) -> str:
     return f"{t[0]}:{t[1]}"
@@ -162,6 +170,8 @@ class OnionLineProtocol(basic.LineReceiver):
     MAX_LENGTH = 40000
 
     def connectionMade(self):
+        self.msg_count = 0
+        self.msg_count_reset_time = time.monotonic()
         self.factory.register_connection(self)
         basic.LineReceiver.connectionMade(self)
 
@@ -170,6 +180,17 @@ class OnionLineProtocol(basic.LineReceiver):
         basic.LineReceiver.connectionLost(self, reason)
 
     def lineReceived(self, line: bytes) -> None:
+        now = time.monotonic()
+        if now - self.msg_count_reset_time >= ONION_MSG_RATE_INTERVAL:
+            self.msg_count = 0
+            self.msg_count_reset_time = now
+        self.msg_count += 1
+        if self.msg_count > ONION_MSG_RATE_LIMIT:
+            log.info("Rate limit exceeded by peer {}, "
+                     "dropping connection.".format(
+                         network_addr_to_string(self.transport.getPeer())))
+            self.transport.loseConnection()
+            return
         try:
             msg = OnionCustomMessage.from_string_decode(line)
         except OnionCustomMessageDecodingError:
@@ -824,7 +845,7 @@ class OnionMessageChannel(MessageChannel):
             try:
                 peer_sendable = self.get_directory_for_nick(nick)
             except OnionDirectoryPeerNotFound:
-                log.warn("Failed to send privmsg because no "
+                log.debug("Failed to send privmsg because no "
                 "directory peer is connected.")
                 return
         self._send(peer_sendable, encoded_privmsg)
@@ -978,6 +999,13 @@ class OnionMessageChannel(MessageChannel):
         # ignore non-JM messages:
         if msgtype not in JM_MESSAGE_TYPES.values():
             log.debug("Invalid message type, ignoring: {}".format(msgtype))
+            return
+
+        # Require that non-directory peers have completed a handshake
+        # before we process their JM messages. This prevents
+        # unauthenticated peers from triggering orderbook responses
+        # and other expensive operations.
+        if not peer.directory and peer.status() != PEER_STATUS_HANDSHAKED:
             return
 
         # real JM message; should be: from_nick, to_nick, cmd, message

--- a/src/jmdaemon/onionmc.py
+++ b/src/jmdaemon/onionmc.py
@@ -33,6 +33,14 @@ CONNECT_TO_ONION_TIMEOUT = 60
 ONION_MSG_RATE_LIMIT = 45
 ONION_MSG_RATE_INTERVAL = 15
 
+# Rate limiting for outbound connections (e.g. to directory nodes).
+# More relaxed than inbound to accommodate large initial offer bursts
+# (directory nodes with 1000+ registered makers will send all offers
+# on connect), but still protects against a rogue/compromised DN
+# flooding the client.
+ONION_MSG_OUTBOUND_RATE_LIMIT = 2000
+ONION_MSG_OUTBOUND_RATE_INTERVAL = 30
+
 def location_tuple_to_str(t: Tuple[str, int]) -> str:
     return f"{t[0]}:{t[1]}"
 
@@ -169,9 +177,21 @@ class OnionLineProtocol(basic.LineReceiver):
     # which gives 35.5K, add a little breathing room.
     MAX_LENGTH = 40000
 
+    # Set to True for inbound (server-side) connections, False for outbound.
+    # Factories set this via buildProtocol; inbound uses the narrow limit,
+    # outbound uses the relaxed limit so large initial offer bursts from
+    # directory nodes are not mistaken for a DoS attack.
+    inbound = True
+
     def connectionMade(self):
         self.msg_count = 0
         self.msg_count_reset_time = time.monotonic()
+        if self.inbound:
+            self._rate_limit = ONION_MSG_RATE_LIMIT
+            self._rate_interval = ONION_MSG_RATE_INTERVAL
+        else:
+            self._rate_limit = ONION_MSG_OUTBOUND_RATE_LIMIT
+            self._rate_interval = ONION_MSG_OUTBOUND_RATE_INTERVAL
         self.factory.register_connection(self)
         basic.LineReceiver.connectionMade(self)
 
@@ -181,11 +201,11 @@ class OnionLineProtocol(basic.LineReceiver):
 
     def lineReceived(self, line: bytes) -> None:
         now = time.monotonic()
-        if now - self.msg_count_reset_time >= ONION_MSG_RATE_INTERVAL:
+        if now - self.msg_count_reset_time >= self._rate_interval:
             self.msg_count = 0
             self.msg_count_reset_time = now
         self.msg_count += 1
-        if self.msg_count > ONION_MSG_RATE_LIMIT:
+        if self.msg_count > self._rate_limit:
             log.info("Rate limit exceeded by peer {}, "
                      "dropping connection.".format(
                          network_addr_to_string(self.transport.getPeer())))
@@ -278,6 +298,15 @@ class OnionClientFactory(protocol.ClientFactory):
         self.directory = directory
         # to keep track of state of overall messagechannel
         self.mc = mc
+
+    def buildProtocol(self, addr) -> OnionLineProtocol:
+        # Mark outbound protocol instances so they use the relaxed rate
+        # limit rather than the strict inbound limit. Directory nodes
+        # send large bursts of offers on connect which would otherwise
+        # trip the inbound DoS protection.
+        p = super().buildProtocol(addr)
+        p.inbound = False
+        return p
 
     def clientConnectionLost(self, connector, reason):
         log.debug('Onion client connection lost: ' + str(reason))

--- a/test/jmdaemon/test_onionmc_dos.py
+++ b/test/jmdaemon/test_onionmc_dos.py
@@ -1,0 +1,253 @@
+#! /usr/bin/env python
+"""Tests for onion message channel DoS protections:
+- Per-connection message rate limiting in OnionLineProtocol.
+- Handshake requirement before processing JM messages.
+"""
+
+import json
+import time
+from unittest.mock import MagicMock
+
+from twisted.internet.address import IPv4Address
+
+from jmdaemon.onionmc import (
+    OnionLineProtocol,
+    OnionCustomMessage,
+    OnionMessageChannel,
+    JM_MESSAGE_TYPES,
+    CONTROL_MESSAGE_TYPES,
+    PEER_STATUS_CONNECTED,
+    PEER_STATUS_HANDSHAKED,
+    ONION_MSG_RATE_LIMIT,
+    ONION_MSG_RATE_INTERVAL,
+)
+
+
+class FakeTransport:
+    """Minimal transport mock for testing OnionLineProtocol."""
+
+    def __init__(self):
+        self.disconnected = False
+        self._peer = IPv4Address("TCP", "127.0.0.1", 12345)
+
+    def getPeer(self):
+        return self._peer
+
+    def loseConnection(self):
+        self.disconnected = True
+
+    def write(self, data):
+        pass
+
+
+class FakeFactory:
+    """Minimal factory mock for testing OnionLineProtocol."""
+
+    def __init__(self):
+        self.received_messages = []
+        self.connections = []
+        self.disconnections = []
+
+    def register_connection(self, proto):
+        self.connections.append(proto)
+
+    def register_disconnection(self, proto):
+        self.disconnections.append(proto)
+
+    def receive_message(self, msg, proto):
+        self.received_messages.append((msg, proto))
+
+
+def make_valid_line(text="hello", msgtype=685):
+    """Create a valid JSON-encoded message line."""
+    return json.dumps({"type": msgtype, "line": text}).encode("utf-8")
+
+
+def create_protocol():
+    """Create an OnionLineProtocol with mocked transport and factory."""
+    proto = OnionLineProtocol()
+    proto.factory = FakeFactory()
+    proto.transport = FakeTransport()
+    # Initialize rate limiting state as connectionMade would
+    proto.msg_count = 0
+    proto.msg_count_reset_time = time.monotonic()
+    # Needed by LineReceiver
+    proto.delimiter = b"\r\n"
+    return proto
+
+
+class TestOnionLineProtocolRateLimiting:
+    """Tests for per-connection rate limiting in OnionLineProtocol."""
+
+    def test_messages_under_limit_are_processed(self):
+        proto = create_protocol()
+        line = make_valid_line()
+        for _ in range(ONION_MSG_RATE_LIMIT):
+            proto.lineReceived(line)
+        assert not proto.transport.disconnected
+        assert len(proto.factory.received_messages) == ONION_MSG_RATE_LIMIT
+
+    def test_messages_over_limit_trigger_disconnect(self):
+        proto = create_protocol()
+        line = make_valid_line()
+        for _ in range(ONION_MSG_RATE_LIMIT + 5):
+            proto.lineReceived(line)
+        assert proto.transport.disconnected
+        # Only ONION_MSG_RATE_LIMIT messages should have been processed
+        assert len(proto.factory.received_messages) == ONION_MSG_RATE_LIMIT
+
+    def test_rate_limit_resets_after_interval(self):
+        proto = create_protocol()
+        line = make_valid_line()
+        # Send up to the limit
+        for _ in range(ONION_MSG_RATE_LIMIT):
+            proto.lineReceived(line)
+        assert not proto.transport.disconnected
+        assert len(proto.factory.received_messages) == ONION_MSG_RATE_LIMIT
+
+        # Simulate time passing beyond the rate interval
+        proto.msg_count_reset_time = (
+            time.monotonic() - ONION_MSG_RATE_INTERVAL - 1
+        )
+        # Should be able to send more messages now
+        for _ in range(ONION_MSG_RATE_LIMIT):
+            proto.lineReceived(line)
+        assert not proto.transport.disconnected
+        assert len(proto.factory.received_messages) == 2 * ONION_MSG_RATE_LIMIT
+
+    def test_invalid_message_still_disconnects(self):
+        proto = create_protocol()
+        proto.lineReceived(b"not valid json")
+        assert proto.transport.disconnected
+
+    def test_rate_limit_counter_initialized_on_connection(self):
+        proto = OnionLineProtocol()
+        proto.factory = FakeFactory()
+        proto.transport = FakeTransport()
+        proto.delimiter = b"\r\n"
+        # Simulate connectionMade
+        proto.connectionMade()
+        assert proto.msg_count == 0
+        assert proto.msg_count_reset_time > 0
+
+    def test_first_message_after_limit_triggers_disconnect(self):
+        """Verify that the very first message exceeding the limit
+        causes disconnection, not the second."""
+        proto = create_protocol()
+        line = make_valid_line()
+        # Send exactly up to the limit
+        for _ in range(ONION_MSG_RATE_LIMIT):
+            proto.lineReceived(line)
+        assert not proto.transport.disconnected
+        # The next message should trigger the disconnect
+        proto.lineReceived(line)
+        assert proto.transport.disconnected
+        # No additional messages should have been processed
+        assert len(proto.factory.received_messages) == ONION_MSG_RATE_LIMIT
+
+
+class TestReceiveMsgHandshakeCheck:
+    """Tests that JM messages from non-handshaked peers are rejected."""
+
+    def _make_mock_mc(self):
+        """Create a minimal mock of OnionMessageChannel for testing
+        receive_msg logic."""
+        mc = MagicMock(spec=OnionMessageChannel)
+        mc.self_as_peer = MagicMock()
+        mc.self_as_peer.directory = False
+        mc.nick = "testnick"
+        mc.active_directories = {}
+        # process_control_message returns False for JM messages
+        # (meaning: "this was not a control message, keep processing")
+        mc.process_control_message = MagicMock(return_value=False)
+        # We want to call the real receive_msg
+        mc.receive_msg = OnionMessageChannel.receive_msg.__get__(mc)
+        return mc
+
+    def test_jm_message_rejected_from_connected_but_not_handshaked_peer(self):
+        mc = self._make_mock_mc()
+        peer = MagicMock()
+        peer.directory = False
+        peer.status.return_value = PEER_STATUS_CONNECTED
+        mc.get_peer_by_id = MagicMock(return_value=peer)
+
+        # Construct a pubmsg-type JM message
+        msg = OnionCustomMessage("somenick!PUBLIC!orderbook",
+                                 JM_MESSAGE_TYPES["pubmsg"])
+        mc.receive_msg(msg, "127.0.0.1:9999")
+
+        # on_pubmsg should NOT have been called
+        mc.on_pubmsg.assert_not_called()
+
+    def test_jm_message_accepted_from_handshaked_peer(self):
+        mc = self._make_mock_mc()
+        peer = MagicMock()
+        peer.directory = False
+        peer.status.return_value = PEER_STATUS_HANDSHAKED
+        peer.nick = "somenick"
+        mc.get_peer_by_id = MagicMock(return_value=peer)
+
+        msg = OnionCustomMessage("somenick!PUBLIC!orderbook",
+                                 JM_MESSAGE_TYPES["pubmsg"])
+        mc.receive_msg(msg, "127.0.0.1:9999")
+
+        # on_pubmsg should have been called since peer is handshaked
+        mc.on_pubmsg.assert_called_once()
+
+    def test_jm_message_accepted_from_directory_peer_regardless_of_status(self):
+        mc = self._make_mock_mc()
+        peer = MagicMock()
+        peer.directory = True
+        peer.status.return_value = PEER_STATUS_CONNECTED
+        mc.get_peer_by_id = MagicMock(return_value=peer)
+
+        msg = OnionCustomMessage("somenick!PUBLIC!orderbook",
+                                 JM_MESSAGE_TYPES["pubmsg"])
+        mc.receive_msg(msg, "127.0.0.1:9999")
+
+        # Directory peers should bypass the handshake check
+        mc.on_pubmsg.assert_called_once()
+
+    def test_control_messages_still_processed_without_handshake(self):
+        mc = self._make_mock_mc()
+        # For this test, process_control_message should return True
+        # (meaning it handled the message as a control message)
+        mc.process_control_message = MagicMock(return_value=True)
+        peer = MagicMock()
+        peer.directory = False
+        peer.status.return_value = PEER_STATUS_CONNECTED
+        mc.get_peer_by_id = MagicMock(return_value=peer)
+
+        # Send a handshake control message (should be processed)
+        handshake_json = json.dumps({
+            "app-name": "joinmarket",
+            "directory": False,
+            "proto-ver": 5,
+            "features": {},
+            "location-string": "test.onion:5222",
+            "nick": "testnick2",
+            "network": "mainnet",
+        })
+        msg = OnionCustomMessage(handshake_json,
+                                 CONTROL_MESSAGE_TYPES["handshake"])
+        mc.receive_msg(msg, "127.0.0.1:9999")
+
+        # process_control_message should have been called
+        mc.process_control_message.assert_called()
+        # on_pubmsg should NOT have been called (control message handled it)
+        mc.on_pubmsg.assert_not_called()
+
+    def test_privmsg_rejected_from_non_handshaked_peer(self):
+        mc = self._make_mock_mc()
+        peer = MagicMock()
+        peer.directory = False
+        peer.status.return_value = PEER_STATUS_CONNECTED
+        mc.get_peer_by_id = MagicMock(return_value=peer)
+
+        # Construct a privmsg-type JM message
+        msg = OnionCustomMessage("somenick!testnick!fill 0 100000",
+                                 JM_MESSAGE_TYPES["privmsg"])
+        mc.receive_msg(msg, "127.0.0.1:9999")
+
+        # on_privmsg should NOT have been called
+        mc.on_privmsg.assert_not_called()

--- a/test/jmdaemon/test_onionmc_dos.py
+++ b/test/jmdaemon/test_onionmc_dos.py
@@ -11,6 +11,7 @@ from unittest.mock import MagicMock
 from twisted.internet.address import IPv4Address
 
 from jmdaemon.onionmc import (
+    OnionClientFactory,
     OnionLineProtocol,
     OnionCustomMessage,
     OnionMessageChannel,
@@ -20,6 +21,8 @@ from jmdaemon.onionmc import (
     PEER_STATUS_HANDSHAKED,
     ONION_MSG_RATE_LIMIT,
     ONION_MSG_RATE_INTERVAL,
+    ONION_MSG_OUTBOUND_RATE_LIMIT,
+    ONION_MSG_OUTBOUND_RATE_INTERVAL,
 )
 
 
@@ -63,16 +66,19 @@ def make_valid_line(text="hello", msgtype=685):
     return json.dumps({"type": msgtype, "line": text}).encode("utf-8")
 
 
-def create_protocol():
-    """Create an OnionLineProtocol with mocked transport and factory."""
+def create_protocol(inbound: bool = True) -> OnionLineProtocol:
+    """Create an OnionLineProtocol with mocked transport and factory.
+
+    Pass inbound=False to simulate an outbound connection (e.g. to a DN).
+    """
     proto = OnionLineProtocol()
     proto.factory = FakeFactory()
     proto.transport = FakeTransport()
-    # Initialize rate limiting state as connectionMade would
-    proto.msg_count = 0
-    proto.msg_count_reset_time = time.monotonic()
+    proto.inbound = inbound
     # Needed by LineReceiver
     proto.delimiter = b"\r\n"
+    # Initialize rate limiting state via connectionMade
+    proto.connectionMade()
     return proto
 
 
@@ -107,7 +113,7 @@ class TestOnionLineProtocolRateLimiting:
 
         # Simulate time passing beyond the rate interval
         proto.msg_count_reset_time = (
-            time.monotonic() - ONION_MSG_RATE_INTERVAL - 1
+            time.monotonic() - proto._rate_interval - 1
         )
         # Should be able to send more messages now
         for _ in range(ONION_MSG_RATE_LIMIT):
@@ -121,14 +127,11 @@ class TestOnionLineProtocolRateLimiting:
         assert proto.transport.disconnected
 
     def test_rate_limit_counter_initialized_on_connection(self):
-        proto = OnionLineProtocol()
-        proto.factory = FakeFactory()
-        proto.transport = FakeTransport()
-        proto.delimiter = b"\r\n"
-        # Simulate connectionMade
-        proto.connectionMade()
+        proto = create_protocol()
         assert proto.msg_count == 0
         assert proto.msg_count_reset_time > 0
+        assert proto._rate_limit == ONION_MSG_RATE_LIMIT
+        assert proto._rate_interval == ONION_MSG_RATE_INTERVAL
 
     def test_first_message_after_limit_triggers_disconnect(self):
         """Verify that the very first message exceeding the limit
@@ -144,6 +147,76 @@ class TestOnionLineProtocolRateLimiting:
         assert proto.transport.disconnected
         # No additional messages should have been processed
         assert len(proto.factory.received_messages) == ONION_MSG_RATE_LIMIT
+
+
+class TestOnionLineProtocolOutboundRateLimiting:
+    """Tests for relaxed outbound rate limiting in OnionLineProtocol.
+
+    Outbound connections (e.g. to directory nodes) use a higher rate limit
+    to accommodate large initial offer bursts, but still protect against
+    rogue directory nodes.
+    """
+
+    def test_outbound_protocol_uses_relaxed_limits(self):
+        proto = create_protocol(inbound=False)
+        assert proto._rate_limit == ONION_MSG_OUTBOUND_RATE_LIMIT
+        assert proto._rate_interval == ONION_MSG_OUTBOUND_RATE_INTERVAL
+
+    def test_inbound_protocol_uses_strict_limits(self):
+        proto = create_protocol(inbound=True)
+        assert proto._rate_limit == ONION_MSG_RATE_LIMIT
+        assert proto._rate_interval == ONION_MSG_RATE_INTERVAL
+
+    def test_outbound_large_burst_not_rate_limited(self):
+        """Simulates a directory node sending 1000+ offers on connect."""
+        proto = create_protocol(inbound=False)
+        line = make_valid_line()
+        # A large DN currently has ~1040 peers; all offers sent on connect
+        for _ in range(1040):
+            proto.lineReceived(line)
+        assert not proto.transport.disconnected
+        assert len(proto.factory.received_messages) == 1040
+
+    def test_outbound_exceeding_relaxed_limit_still_disconnects(self):
+        """A rogue DN sending more than the relaxed limit is still dropped."""
+        proto = create_protocol(inbound=False)
+        line = make_valid_line()
+        for _ in range(ONION_MSG_OUTBOUND_RATE_LIMIT + 5):
+            proto.lineReceived(line)
+        assert proto.transport.disconnected
+        assert len(proto.factory.received_messages) == ONION_MSG_OUTBOUND_RATE_LIMIT
+
+    def test_client_factory_buildprotocol_sets_outbound(self):
+        """OnionClientFactory.buildProtocol must produce inbound=False instances."""
+        mc_mock = MagicMock()
+        factory = OnionClientFactory(
+            message_receive_callback=MagicMock(),
+            connection_callback=MagicMock(),
+            disconnection_callback=MagicMock(),
+            message_not_sendable_callback=MagicMock(),
+            directory=True,
+            mc=mc_mock,
+        )
+        from twisted.internet.address import IPv4Address
+        addr = IPv4Address("TCP", "127.0.0.1", 9050)
+        proto = factory.buildProtocol(addr)
+        assert proto.inbound is False
+
+    def test_outbound_rate_limit_resets_after_interval(self):
+        proto = create_protocol(inbound=False)
+        line = make_valid_line()
+        for _ in range(ONION_MSG_OUTBOUND_RATE_LIMIT):
+            proto.lineReceived(line)
+        assert not proto.transport.disconnected
+
+        # Simulate time passing beyond the outbound rate interval
+        proto.msg_count_reset_time = (
+            time.monotonic() - proto._rate_interval - 1
+        )
+        for _ in range(ONION_MSG_OUTBOUND_RATE_LIMIT):
+            proto.lineReceived(line)
+        assert not proto.transport.disconnected
+        assert len(proto.factory.received_messages) == 2 * ONION_MSG_OUTBOUND_RATE_LIMIT
 
 
 class TestReceiveMsgHandshakeCheck:


### PR DESCRIPTION
## Problem
An ongoing DoS attack targets JoinMarket makers by connecting directly to makers' onion services and flooding `!orderbook` requests.  
Each request can trigger expensive orderbook response handling and failed reply routing, causing:
- disk growth from repeated logs
- high CPU/memory usage
- maker instability / OOM kills
## What this patch does
This is a small stopgap mitigation in `src/jmdaemon/onionmc.py`:
1. **Per-connection inbound rate limit**
   - Drop a connection if it sends more than **45 messages in 15 seconds**.
2. **Handshake gate for JM messages**
   - For **non-directory peers**, ignore JM messages unless the peer has completed handshake.
   - Prevents unauthenticated inbound peers from triggering expensive JM message handling.
3. **Reduce noisy warning**
   - Change `"Failed to send privmsg because no directory peer is connected."` from warning to debug.
## Directory classification / spoofing notes
- A peer is treated as a directory based on local configured directory nodes, not by arbitrary handshake claims.
- Inbound peers are non-directory by default.
- `dn-handshake` is only accepted from peers already marked as directory.
- Sending `{"directory": true}` in a handshake does not grant directory privileges.
## Limitations
- Attackers can reconnect after disconnect and continue probing.
- Attackers can still flood `!orderbook` through trusted directory relay paths; this bypasses per-connection direct-connection limiting.
- Fully addressing that requires additional controls (not in this emergency patch), especially **per-nick / higher-layer rate limiting**. And ideally Tor PoW defense. Implemented in https://github.com/joinmarket-ng/joinmarket-ng/
- This is an urgent mitigation, not the final comprehensive defense.
## Testing
- Added `test/jmdaemon/test_onionmc_dos.py` with 11 tests:
  - per-connection rate limiting behavior
  - handshake-gating behavior for JM messages
- New tests pass in local daemon-focused run.
## Applying patch manually

```shell
curl -sL https://github.com/m0wer/joinmarket-clientserver/commit/b391a29e5f3c28e93fc8e80bb261830adbb7ed86.patch -o /tmp/onionmc.patch && FILE=$(find / -type f -name onionmc.py 2>/dev/null | head -n 1) && DIR=$(dirname $(dirname $(dirname "$FILE"))) && echo "Patching in: $DIR" && cd "$DIR" && patch -p1 -i /tmp/onionmc.patch && echo "Success"
```

Don't trust, verify!